### PR TITLE
Add minimal Discord bot message sender

### DIFF
--- a/src/discord_bot.zig
+++ b/src/discord_bot.zig
@@ -1,0 +1,43 @@
+const std = @import("std");
+
+pub fn postMessage(allocator: std.mem.Allocator, token: []const u8, channel_id: []const u8, content: []const u8) !void {
+    var client = std.http.Client{ .allocator = allocator };
+    defer client.deinit();
+
+    // Prepare JSON payload
+    var body_buf = std.ArrayList(u8).init(allocator);
+    defer body_buf.deinit();
+    try std.json.stringify(.{ .content = content }, .{}, body_buf.writer());
+
+    const url = try std.fmt.allocPrint(
+        allocator,
+        "https://discord.com/api/v10/channels/{s}/messages",
+        .{channel_id},
+    );
+    defer allocator.free(url);
+
+    const auth_value = try std.fmt.allocPrint(allocator, "Bot {s}", .{token});
+    defer allocator.free(auth_value);
+
+    const headers = [_]std.http.Header{
+        .{ .name = "Authorization", .value = auth_value },
+        .{ .name = "Content-Type", .value = "application/json" },
+    };
+
+    var response = std.ArrayList(u8).init(allocator);
+    defer response.deinit();
+
+    const result = try client.fetch(.{
+        .location = .{ .url = url },
+        .method = .POST,
+        .headers = .{ .authorization = .omit },
+        .extra_headers = &headers,
+        .payload = body_buf.items,
+        .response_storage = .dynamic(&response),
+    });
+
+    std.debug.print("Discord API response status: {d}\n", .{@intFromEnum(result.status)});
+    if (response.items.len > 0) {
+        std.debug.print("Response body: {s}\n", .{response.items});
+    }
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -96,6 +96,25 @@ pub fn main() !void {
             const tui = @import("tui.zig");
             try tui.run();
             return;
+        } else if (std.mem.eql(u8, arg, "discord")) {
+            const bot = @import("discord_bot.zig");
+            var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+            defer _ = gpa.deinit();
+            const allocator = gpa.allocator();
+
+            const token = std.process.getEnvVarOwned(allocator, "DISCORD_TOKEN") catch {
+                std.log.err("DISCORD_TOKEN environment variable not set", .{});
+                return;
+            };
+            defer allocator.free(token);
+
+            const channel = args.next() orelse {
+                std.log.err("channel id required", .{});
+                return;
+            };
+
+            try bot.postMessage(allocator, token, channel, "Hello from Zig!");
+            return;
         }
     }
 


### PR DESCRIPTION
## Summary
- add `discord_bot.zig` to send a simple message to a Discord channel
- wire new `discord` subcommand in `main.zig`

## Testing
- `zig build test` *(fails: unable to find system library `uring`)*
- `zig build` *(fails: unable to find system library `uring`)*

------
https://chatgpt.com/codex/tasks/task_e_6843cc7530148331851f3acccf39a46a