### PR TITLE
Fix README path to localml.zig

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,18 @@ zig build run -- tui
 ```
 
 ### Local ML Example
-`local_ml.zig` demonstrates cross-platform logistic regression training and
+`localml.zig` demonstrates cross-platform logistic regression training and
 prediction without any external dependencies. To train a model using a CSV file
 containing `x1,x2,label` rows and save it to `model.txt`:
 
 ```bash
-zig run local_ml.zig -- train data.csv model.txt
+zig run localml.zig -- train data.csv model.txt
 ```
 
 To predict a probability with the trained model:
 
 ```bash
-zig run local_ml.zig -- predict model.txt 1.2 3.4
+zig run localml.zig -- predict model.txt 1.2 3.4
 ```
 
 


### PR DESCRIPTION
## Summary
- update README to reference `localml.zig`

## Testing
- `zig build test` *(fails: `zig` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862fc35568883318087e0f651ae3a5f