### PR TITLE
Fix Cell framework CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 **/*.DS_Store
 **/*.zig-cache
+# Ignore build directories
+*/build/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+Please write clear commit messages that briefly describe the changes.
+For example:
+
+```
+Add Cell framework example using C++23 modules
+```
+
+Commit messages like "Applying previous commit" should be avoided.

--- a/README.md
+++ b/README.md
@@ -30,3 +30,6 @@ To predict a probability with the trained model:
 zig run local_ml.zig -- predict model.txt 1.2 3.4
 ```
 
+
+### Cell Framework Example
+This repository now includes a demonstration of the Cell framework using modern C++23 modules. See `cell_framework/README.md` for build instructions.

--- a/cell_framework/CMakeLists.txt
+++ b/cell_framework/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.26)
+project(CellFramework LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_EXPERIMENTAL_CXX_MODULE_CMAKE_API 1)
+
+# Directory for generated headers
+set(GENERATED_INCLUDE_DIR ${CMAKE_BINARY_DIR}/include)
+file(MAKE_DIRECTORY ${GENERATED_INCLUDE_DIR})
+
+add_custom_target(generate_headers
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/generate_headers.cmake
+    BYPRODUCTS ${GENERATED_INCLUDE_DIR}/Cell/Core.hpp
+    VERBATIM
+)
+
+add_library(CellCore)
+
+target_sources(CellCore
+    PUBLIC
+        FILE_SET cxx_modules TYPE CXX_MODULES FILES
+            ${CMAKE_CURRENT_SOURCE_DIR}/Cell/Core.ixx
+        FILE_SET cxx_modules TYPE CXX_MODULES FILES
+            ${CMAKE_CURRENT_SOURCE_DIR}/Cell/Core.cpp
+)
+
+target_include_directories(CellCore PUBLIC ${GENERATED_INCLUDE_DIR})
+
+add_dependencies(CellCore generate_headers)
+
+add_executable(cell_app main.cpp)
+
+target_link_libraries(cell_app PRIVATE CellCore)
+
+add_dependencies(cell_app generate_headers)

--- a/cell_framework/Cell/Core.cpp
+++ b/cell_framework/Cell/Core.cpp
@@ -1,0 +1,11 @@
+module;
+#include <iostream>
+
+module Cell.Core;
+
+namespace Cell {
+    void Engine::run() {
+        std::cout << "Cell Engine running!" << std::endl;
+        std::cout << "2 + 2 = " << add(2, 2) << std::endl;
+    }
+}

--- a/cell_framework/Cell/Core.ixx
+++ b/cell_framework/Cell/Core.ixx
@@ -1,0 +1,14 @@
+export module Cell.Core;
+
+export import <vector>;
+
+export namespace Cell {
+    inline int add(int a, int b) {
+        return a + b;
+    }
+
+    class Engine {
+    public:
+        void run();
+    };
+}

--- a/cell_framework/README.md
+++ b/cell_framework/README.md
@@ -1,0 +1,27 @@
+# Cell Framework Example with C++23 Modules
+
+This example demonstrates the Cell framework using a modules-first design.
+The build system uses CMake 3.26+ with the experimental C++ module API and
+automatically generates traditional headers from module interface files.
+
+## Prerequisites
+
+- CMake 3.26 or newer
+- A C++23 compiler with module support (Clang 18+ or equivalent)
+
+## Building
+
+```bash
+mkdir build && cd build
+cmake ..
+cmake --build .
+./cell_app
+```
+
+CMake should be invoked from a separate `build` directory to keep
+generated files isolated from the source tree.
+
+During configuration, module interfaces located in the `Cell/` directory are
+converted into headers under `build/include/Cell`. These generated headers
+allow interoperability with code that still relies on the traditional `#include`
+mechanism.

--- a/cell_framework/main.cpp
+++ b/cell_framework/main.cpp
@@ -1,0 +1,7 @@
+import Cell.Core;
+
+int main() {
+    Cell::Engine engine;
+    engine.run();
+    return 0;
+}

--- a/scripts/generate_headers.cmake
+++ b/scripts/generate_headers.cmake
@@ -1,0 +1,10 @@
+# Simple header generation from module interface files
+file(GLOB MODULE_FILES "${CMAKE_CURRENT_LIST_DIR}/../cell_framework/Cell/*.ixx")
+foreach(MFILE ${MODULE_FILES})
+    get_filename_component(MNAME ${MFILE} NAME_WE)
+    set(HEADER "${GENERATED_INCLUDE_DIR}/Cell/${MNAME}.hpp")
+    file(MAKE_DIRECTORY "${GENERATED_INCLUDE_DIR}/Cell")
+    file(READ ${MFILE} CONTENTS)
+    string(REGEX REPLACE "export module ([A-Za-z0-9_.]+);" "#pragma once\n// Generated from module \1" CONTENTS "${CONTENTS}")
+    file(WRITE ${HEADER} "${CONTENTS}")
+endforeach()


### PR DESCRIPTION
## Summary
- fix invalid file set names
- use `CMAKE_CURRENT_SOURCE_DIR` and `CMAKE_CURRENT_LIST_DIR` for portability
- document prerequisites for building the modules example
- add commit message guidelines
- ignore typical build directories

## Testing
- `cmake ..` *(fails: modules not supported by generator)*
- `cmake -G Ninja -DCMAKE_CXX_SCAN_FOR_MODULES=ON ..` *(fails: compiler missing module support)*
- `zig build test` *(fails: `zig` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6862eb947c948331b0e2d31a7980840e