### PR TITLE
benchmarks: fix logging format for zig 0.16

### DIFF
--- a/benchmarks/benchmark_framework.zig
+++ b/benchmarks/benchmark_framework.zig
@@ -11,6 +11,9 @@ const std = @import("std");
 const builtin = @import("builtin");
 const utils = @import("abi").utils;
 
+const separator_line = "================================================================================";
+const subsection_line = "------------------------------------------------------------";
+
 /// Benchmark configuration with standardized settings
 pub const BenchmarkConfig = struct {
     /// Number of warmup iterations to perform before measurement
@@ -292,13 +295,13 @@ pub const BenchmarkSuite = struct {
     }
 
     fn printConsoleReport(self: *BenchmarkSuite) !void {
-        std.log.info("\n{'='**80}", .{});
+        std.log.info("\n{s}", .{separator_line});
         std.log.info("🚀 BENCHMARK RESULTS REPORT", .{});
-        std.log.info("{'='**80}", .{});
+        std.log.info("{s}", .{separator_line});
         std.log.info("Platform: {s} {s} (Zig {s})", .{ self.platform_info.os, self.platform_info.arch, self.platform_info.zig_version });
         std.log.info("CPU Cores: {}", .{self.platform_info.cpu_count});
         std.log.info("Total Benchmarks: {}", .{self.results.items.len});
-        std.log.info("{'='**80}", .{});
+        std.log.info("{s}", .{separator_line});
 
         // Group by category
         var categories = std.StringHashMap(std.ArrayList(*BenchmarkResult)).init(self.allocator);
@@ -321,7 +324,7 @@ pub const BenchmarkSuite = struct {
         var it = categories.iterator();
         while (it.next()) |entry| {
             std.log.info("\n📊 Category: {s}", .{entry.key_ptr.*});
-            std.log.info("{'-'**60}", .{});
+            std.log.info("{s}", .{subsection_line});
 
             for (entry.value_ptr.items) |result| {
                 std.log.info("  {s:<30} {d:>8.0} ops/sec  {d:>8.2}ns avg", .{ result.name, result.stats.throughput_ops_per_sec, result.stats.mean_ns });
@@ -362,7 +365,7 @@ pub const BenchmarkSuite = struct {
         }
 
         std.log.info("\n🏆 PERFORMANCE SUMMARY", .{});
-        std.log.info("{'-'**60}", .{});
+        std.log.info("{s}", .{subsection_line});
         std.log.info("Average Throughput: {d:.0} ops/sec", .{total_throughput / @as(f64, @floatFromInt(self.results.items.len))});
 
         if (fastest_benchmark) |fastest| {

--- a/benchmarks/main.zig
+++ b/benchmarks/main.zig
@@ -9,6 +9,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const framework = @import("benchmark_framework.zig");
+const separator_line = "============================================================";
 
 /// Unified benchmark entry point for ABI
 /// Consolidates all benchmark suites with enhanced reporting
@@ -65,27 +66,27 @@ pub fn main() !void {
     } else if (std.mem.eql(u8, bench, "all")) {
         std.log.info("🎯 Running All Available Benchmarks", .{});
 
-        std.log.info("\n{'='**60}", .{});
+        std.log.info("\n{s}", .{separator_line});
         std.log.info("🧠 AI/NEURAL NETWORK BENCHMARKS", .{});
-        std.log.info("{'='**60}", .{});
+        std.log.info("{s}", .{separator_line});
         const benchmark_suite = @import("benchmark_suite.zig");
         try benchmark_suite.main();
 
-        std.log.info("\n{'='**60}", .{});
+        std.log.info("\n{s}", .{separator_line});
         std.log.info("🗄️ DATABASE BENCHMARKS", .{});
-        std.log.info("{'='**60}", .{});
+        std.log.info("{s}", .{separator_line});
         const db_bench = @import("database_benchmark.zig");
         try db_bench.main();
 
-        std.log.info("\n{'='**60}", .{});
+        std.log.info("\n{s}", .{separator_line});
         std.log.info("⚡ PERFORMANCE BENCHMARKS", .{});
-        std.log.info("{'='**60}", .{});
+        std.log.info("{s}", .{separator_line});
         const perf_bench = @import("performance_suite.zig");
         try perf_bench.main();
 
-        std.log.info("\n{'='**60}", .{});
+        std.log.info("\n{s}", .{separator_line});
         std.log.info("📐 SIMD MICRO-BENCHMARKS", .{});
-        std.log.info("{'='**60}", .{});
+        std.log.info("{s}", .{separator_line});
         const simd_bench = @import("simd_micro.zig");
         try simd_bench.main();
 


### PR DESCRIPTION
## Summary
- add reusable separator constants for the benchmark console output
- replace invalid logging format expressions so Zig 0.16 accepts the benchmark sources

## Testing
- zig build --summary all
- zig build test --summary all
- zig run --dep abi -Mroot=benchmarks/main.zig -Mabi=src/mod.zig -O ReleaseFast -- neural

------
https://chatgpt.com/codex/tasks/task_e_68ce492816f08331b0c9b0e91e7c6d70