### PR TITLE
Fix Windows network test report header spacing

### DIFF
--- a/src/tools/windows_network_test.zig
+++ b/src/tools/windows_network_test.zig
@@ -688,7 +688,7 @@ pub const WindowsNetworkTester = struct {
 
     fn generateNetworkTestReport(self: *Self) !void {
         std.debug.print("📊 Comprehensive Network Test Report\n", .{});
-        std.debug.print("{s}\n\n", .{"=" ** 50 ++ "\n\n"});
+        std.debug.print("{s}", .{"=" ** 50 ++ "\n\n"});
 
         const test_duration = self.test_end_time - self.test_start_time;
 


### PR DESCRIPTION
## Summary
- ensure the report header prints the separator with the intended double blank line spacing

## Testing
- `zig fmt src/tools/windows_network_test.zig` *(fails: zig executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce504bf4d483318bc59c1734556ff7