### PR TITLE
Sort code index inputs for deterministic docs

### DIFF
--- a/src/tools/docs_generator.zig
+++ b/src/tools/docs_generator.zig
@@ -625,6 +625,11 @@ fn generateCodeApiIndex(allocator: std.mem.Allocator) !void {
     defer files.deinit(a);
 
     try collectZigFiles(a, "src", &files);
+    std.mem.sort([]u8, files.items, {}, struct {
+        fn lessThan(_: void, lhs: []u8, rhs: []u8) bool {
+            return std.mem.lessThan(u8, lhs, rhs);
+        }
+    }.lessThan);
 
     var out = try std.fs.cwd().createFile("docs/generated/CODE_API_INDEX.md", .{ .truncate = true });
     defer out.close();


### PR DESCRIPTION
## Summary
- sort the collected source file list before generating the code API index
- iterate over the sorted paths to ensure headings are emitted in lexicographic order

## Testing
- `zig run src/tools/docs_generator.zig` *(fails: zig executable not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce547c12688331bce8b881e6a2c39d