### PR TITLE
docs: sort search index inputs

### DIFF
--- a/src/tools/docs_generator.zig
+++ b/src/tools/docs_generator.zig
@@ -615,6 +615,10 @@ const Declaration = struct {
     doc: []u8,
 };
 
+fn docPathLessThan(_: void, lhs: []const u8, rhs: []const u8) bool {
+    return std.mem.order(u8, lhs, rhs) == .lt;
+}
+
 fn generateCodeApiIndex(allocator: std.mem.Allocator) !void {
     // Use an arena for all temporary allocations in scanning to avoid leaks and simplify ownership
     var arena = std.heap.ArenaAllocator.init(allocator);
@@ -625,6 +629,8 @@ fn generateCodeApiIndex(allocator: std.mem.Allocator) !void {
     defer files.deinit(a);
 
     try collectZigFiles(a, "src", &files);
+
+    std.sort.block([]u8, files.items, {}, docPathLessThan);
 
     var out = try std.fs.cwd().createFile("docs/generated/CODE_API_INDEX.md", .{ .truncate = true });
     defer out.close();
@@ -818,6 +824,8 @@ fn generateSearchIndex(allocator: std.mem.Allocator) !void {
             try files.append(a, rel);
         }
     }
+
+    std.sort.block([]const u8, files.items, {}, docPathLessThan);
 
     var out = try std.fs.cwd().createFile("docs/generated/search_index.json", .{ .truncate = true });
     defer out.close();


### PR DESCRIPTION
## Summary
- add a shared comparator helper for documentation paths in the docs generator
- sort the collected file lists for both the code API index and the search index generation so output order is deterministic

## Testing
- `zig fmt src/tools/docs_generator.zig`
- `zig run src/tools/docs_generator.zig` *(fails: upstream generator currently targets older std.fs API; see error about File.reader signature / std.array_list availability)*

------
https://chatgpt.com/codex/tasks/task_e_68ce547d43908331a27cf692247841cb