### PR TITLE
docs: sort search index inputs

### DIFF
--- a/src/tools/docs_generator.zig
+++ b/src/tools/docs_generator.zig
@@ -615,16 +615,22 @@ const Declaration = struct {
     doc: []u8,
 };
 
+fn docPathLessThan(_: void, lhs: []const u8, rhs: []const u8) bool {
+    return std.mem.order(u8, lhs, rhs) == .lt;
+}
+
 fn generateCodeApiIndex(allocator: std.mem.Allocator) !void {
     // Use an arena for all temporary allocations in scanning to avoid leaks and simplify ownership
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
     const a = arena.allocator();
 
-    var files = std.ArrayListUnmanaged([]u8){};
+    var files = std.ArrayListUnmanaged([]const u8){};
     defer files.deinit(a);
 
     try collectZigFiles(a, "src", &files);
+
+    std.sort.block([]const u8, files.items, {}, docPathLessThan);
 
     var out = try std.fs.cwd().createFile("docs/generated/CODE_API_INDEX.md", .{ .truncate = true });
     defer out.close();
@@ -661,7 +667,7 @@ fn generateCodeApiIndex(allocator: std.mem.Allocator) !void {
     }
 }
 
-fn collectZigFiles(allocator: std.mem.Allocator, dir_path: []const u8, out_files: *std.ArrayListUnmanaged([]u8)) !void {
+fn collectZigFiles(allocator: std.mem.Allocator, dir_path: []const u8, out_files: *std.ArrayListUnmanaged([]const u8)) !void {
     var stack = std.ArrayListUnmanaged([]u8){};
     defer {
         for (stack.items) |p| allocator.free(p);
@@ -818,6 +824,8 @@ fn generateSearchIndex(allocator: std.mem.Allocator) !void {
             try files.append(a, rel);
         }
     }
+
+    std.sort.block([]const u8, files.items, {}, docPathLessThan);
 
     var out = try std.fs.cwd().createFile("docs/generated/search_index.json", .{ .truncate = true });
     defer out.close();


### PR DESCRIPTION
## Summary
- add a shared comparator helper for documentation paths in the docs generator
- sort the collected file lists for both the code API index and the search index generation so output order is deterministic
- const-qualify the stored doc paths so both sort call sites reuse the shared comparator without mutability mismatches

## Testing
- `zig fmt src/tools/docs_generator.zig` *(fails: `zig` binary is unavailable in the current container)*
- `zig run src/tools/docs_generator.zig` *(fails: `zig` binary is unavailable in the current container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce547d43908331a27cf692247841cb