### PR TITLE
Fix GitHub Pages routing for generated docs

### DIFF
--- a/docs/_layouts/documentation.html
+++ b/docs/_layouts/documentation.html
@@ -20,7 +20,7 @@ layout: default
   <!-- Search functionality -->
   <script src="{{ '/assets/js/search.js' | relative_url }}" defer></script>
 </head>
-<body>
+<body data-baseurl="{{ site.baseurl | default: '' }}">
   <div class="wrapper">
     <header>
       <h1><a href="{{ '/' | relative_url }}">{{ site.title | default: site.github.repository_name }}</a></h1>

--- a/docs/assets/js/documentation.js
+++ b/docs/assets/js/documentation.js
@@ -2,6 +2,45 @@
 (function() {
   'use strict';
 
+  function buildUrl(path) {
+    const baseUrl = document.body ? (document.body.dataset.baseurl || '') : '';
+
+    if (!path) {
+      return baseUrl || '/';
+    }
+
+    if (/^https?:\/\//i.test(path)) {
+      return path;
+    }
+
+    const normalizedBase = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+    const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+
+    return `${normalizedBase}${normalizedPath}` || normalizedPath;
+  }
+
+  function normalizeDocPath(file) {
+    if (!file) {
+      return buildUrl('/');
+    }
+
+    let normalized = file.trim();
+
+    if (normalized.endsWith('.md')) {
+      normalized = normalized.slice(0, -3);
+    }
+
+    if (!normalized.startsWith('/')) {
+      normalized = `/${normalized}`;
+    }
+
+    if (!normalized.endsWith('/') && !normalized.endsWith('.html')) {
+      normalized = `${normalized}/`;
+    }
+
+    return buildUrl(normalized);
+  }
+
   // Generate table of contents
   function generateTOC() {
     const content = document.querySelector('.documentation-content .content');
@@ -40,7 +79,7 @@
     let searchData = [];
     
     // Load search index
-    fetch('/generated/search_index.json')
+    fetch(buildUrl('/generated/search_index.json'))
       .then(response => response.json())
       .then(data => {
         searchData = data;
@@ -102,7 +141,7 @@
   }
 
   function navigateToPage(file) {
-    window.location.href = `/${file}`;
+    window.location.href = normalizeDocPath(file);
   }
 
   // Smooth scrolling for anchor links
@@ -204,5 +243,7 @@
   } else {
     initialize();
   }
+
+  window.navigateToPage = navigateToPage;
 
 })();

--- a/docs/assets/js/search.js
+++ b/docs/assets/js/search.js
@@ -2,13 +2,30 @@
 (function() {
   'use strict';
 
+  function buildUrl(path) {
+    const baseUrl = document.body ? (document.body.dataset.baseurl || '') : '';
+
+    if (!path) {
+      return baseUrl || '/';
+    }
+
+    if (/^https?:\/\//i.test(path)) {
+      return path;
+    }
+
+    const normalizedBase = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+    const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+
+    return `${normalizedBase}${normalizedPath}` || normalizedPath;
+  }
+
   let searchIndex = [];
   let searchWorker;
 
   // Initialize search with web worker for better performance
   function initializeAdvancedSearch() {
     // Load search index
-    fetch('/generated/search_index.json')
+    fetch(buildUrl('/generated/search_index.json'))
       .then(response => response.json())
       .then(data => {
         searchIndex = data;
@@ -104,5 +121,7 @@
   } else {
     initializeAdvancedSearch();
   }
+
+  window.searchFor = searchFor;
 
 })();


### PR DESCRIPTION
## Summary
- expose the GitHub Pages base URL to documentation layouts so scripts can build correct links
- update documentation search scripts to respect the base URL and link to the generated HTML pages
- export helper functions used by inline handlers so suggestions and results work on GitHub Pages

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce70fa95008331902a0d5cc82842da