### PR TITLE
wdbx: wire up http server and update cli docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ const embedding = [_]f32{0.1, 0.2, 0.3};
 const results = try db.search(&embedding, 10, allocator);
 ```
 
+### WDBX CLI
+
+```bash
+# Inspect available subcommands
+wdbx help
+
+# Launch the lightweight HTTP API (Ctrl+C to stop)
+wdbx http --host 0.0.0.0 --port 8080
+```
+
 ## Modules
 
 - **`core/`**: Core utilities and framework foundation

--- a/docs/api/wdbx.md
+++ b/docs/api/wdbx.md
@@ -20,5 +20,23 @@ WDBX utilities for database management and operations.
 - `wdbx add <vector>`: Add vector to database
 - `wdbx query <vector>`: Find nearest neighbor
 - `wdbx knn <vector> <k>`: Find k-nearest neighbors
-- `wdbx http <port>`: Start HTTP server
+- `wdbx http [--host <ip>] [--port <port>]`: Start the built-in HTTP server
+
+### Running the HTTP server
+
+```bash
+# Start the HTTP server on the default loopback interface and port 8080
+wdbx http
+
+# Expose the server on all interfaces on port 9090
+wdbx http --host 0.0.0.0 --port 9090
+```
+
+The CLI binds directly to the lightweight in-memory WDBX service. The server
+responds to REST-style requests such as:
+
+- `GET /health` – service health probe returning host and port metadata.
+- `GET /stats` – database/vector statistics.
+- `GET /query?vec=1,2,3&k=5` – nearest-neighbour search for a CSV vector.
+- `POST /add` – add a vector by sending a JSON body `{ "vector": [...] }`.
 


### PR DESCRIPTION
## Summary
- enable the WDBX CLI to launch the built-in HTTP server and drop the unused websocket command
- add a minimal TCP listener and request handling loop to the WDBX HTTP server module
- document the HTTP command usage in the README and API guide

## Testing
- zig fmt src/features/database/cli.zig src/features/web/wdbx_http.zig *(fails: command not found)*
- zig build test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ce80c926588331b13f28c92975ea80