### PR TITLE
build: pin zig 0.16.0-dev.254+6dd0270a1

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -37,9 +37,9 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Zig
-        uses: goto-bus-stop/setup-zig@v2
+        uses: mlugg/setup-zig@v2
         with:
-          version: 0.12.0
+          version: 0.16.0-dev.254+6dd0270a1
 
       - name: Cache Zig dependencies
         uses: actions/cache@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,7 +173,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Restructured AI Components**: Dedicated AI module with enhanced capabilities
 
 #### **⚡ Performance Improvements**
-- **Updated to Zig 0.15.x Compatibility**: Requires 0.15.0 or later (tested on 0.15.1)
+- **Updated to Zig 0.15.x Compatibility**: Historical note; current releases require Zig 0.16.0-dev.254+6dd0270a1
 - **Modern Error Handling**: Proper resource cleanup and error propagation
 - **Zero-copy Operations**: Where applicable for maximum efficiency
 - **Enhanced SIMD Alignment**: Memory alignment optimizations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ By participating in this project, you agree to abide by our Code of Conduct:
    ```
 
 2. **Set Up Development Environment**
-   - Install Zig 0.14.1 or later
+   - Install Zig 0.16.0-dev.254+6dd0270a1 (see `.zigversion`; confirm with `zig version`)
    - Install Bun (recommended): `curl -fsSL https://bun.sh/install | bash`
    - Set up your editor with Zig language support
 
@@ -285,7 +285,7 @@ Violations will be addressed by the project maintainers. We reserve the right to
 
 ### **Prerequisites**
 
-- **Zig 0.15.1 or later** (required for latest features)
+- **Zig 0.16.0-dev.254+6dd0270a1** (required and enforced in CI)
 - **Git** for version control
 - **Basic understanding** of systems programming concepts
 - **Enthusiasm** for AI/ML and high-performance computing

--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -17,8 +17,7 @@ The ABI Framework is a high-performance, cross-platform Zig application that sup
 - ✅ **ARM64** (AArch64)
 
 ### Zig Versions
-- ✅ **0.15.1** (Latest Stable - Recommended)
-- ⚠️ **0.16.0-dev** (Development - Use with caution)
+- ✅ **0.16.0-dev.254+6dd0270a1** (Required; matches `.zigversion`)
 
 ## 🏗️ Build Requirements
 
@@ -61,25 +60,27 @@ winget install LLVM.LLVM
 
 ### Zig Installation
 
-#### Option 1: Official Installer (Recommended)
+#### Option 1: Official Build (Recommended)
 ```bash
-# Download and install Zig 0.15.1
-wget https://ziglang.org/download/0.15.1/zig-linux-x86_64-0.15.1.tar.xz
-tar -xf zig-linux-x86_64-0.15.1.tar.xz
-sudo mv zig-linux-x86_64-0.15.1 /usr/local/zig
+# Download and install Zig 0.16.0-dev.254+6dd0270a1
+wget https://ziglang.org/builds/zig-linux-x86_64-0.16.0-dev.254+6dd0270a1.tar.xz
+tar -xf zig-linux-x86_64-0.16.0-dev.254+6dd0270a1.tar.xz
+sudo mv zig-linux-x86_64-0.16.0-dev.254+6dd0270a1 /usr/local/zig
 export PATH="/usr/local/zig:$PATH"
+zig version  # should report 0.16.0-dev.254+6dd0270a1
 ```
 
 #### Option 2: From Source
 ```bash
 git clone https://github.com/ziglang/zig
 cd zig
-git checkout 0.15.1
+git checkout 6dd0270a1
 mkdir build
 cd build
 cmake ..
 make -j$(nproc)
 sudo make install
+zig version  # verify the installed compiler matches 0.16.0-dev.254+6dd0270a1
 ```
 
 ## 🔨 Build Instructions
@@ -218,8 +219,8 @@ RUN apt update && apt install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Zig
-RUN curl -L https://ziglang.org/download/0.15.1/zig-linux-x86_64-0.15.1.tar.xz | tar -xJ && \
-    mv zig-linux-x86_64-0.15.1 /usr/local/zig && \
+RUN curl -L https://ziglang.org/builds/zig-linux-x86_64-0.16.0-dev.254+6dd0270a1.tar.xz | tar -xJ && \
+    mv zig-linux-x86_64-0.16.0-dev.254+6dd0270a1 /usr/local/zig && \
     ln -s /usr/local/zig/zig /usr/local/bin/zig
 
 # Set working directory

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Abi AI Framework
 > Ultra-high-performance AI framework with GPU acceleration, lock-free concurrency, and platform-optimized implementations.
 
-[![Zig Version](https://img.shields.io/badge/Zig-0.16.0--dev-orange.svg)](https://ziglang.org/)
+[![Zig Version](https://img.shields.io/badge/Zig-0.16.0--dev.254%2B6dd0270a1-orange.svg)](https://ziglang.org/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/Platform-Cross--platform-green.svg)]()
 
@@ -24,7 +24,7 @@
 ## Installation
 
 ### Prerequisites
-- **Zig 0.16.0-dev** or later
+- **Zig 0.16.0-dev.254+6dd0270a1** (see `.zigversion` and verify with `zig version`)
 - GPU drivers (optional, for acceleration)
 - OpenAI API key (for AI features)
 
@@ -176,7 +176,7 @@ MIT License - see [LICENSE](LICENSE)
 
 > **Ultra-high-performance AI framework with GPU acceleration, lock-free concurrency, advanced monitoring, and platform-optimized implementations for Zig development.**
 
-[![Zig Version](https://img.shields.io/badge/Zig-0.15.1%2B-orange.svg)](https://ziglang.org/) • [Docs](https://donaldfilimon.github.io/abi/) • [CI: Pages](.github/workflows/deploy_docs.yml)
+[![Zig Version](https://img.shields.io/badge/Zig-0.16.0--dev.254%2B6dd0270a1-orange.svg)](https://ziglang.org/) • [Docs](https://donaldfilimon.github.io/abi/) • [CI: Pages](.github/workflows/deploy_docs.yml)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/Platform-Cross--platform-green.svg)](https://github.com/yourusername/abi)
 [![Build Status](https://img.shields.io/badge/Build-Passing-brightgreen.svg)]()
@@ -232,7 +232,7 @@ MIT License - see [LICENSE](LICENSE)
 ## 🚀 **Quick Start**
 
 ### **Prerequisites**
-- **Zig 0.15.1 or later** (GitHub Actions uses `mlugg/setup-zig@v2` with Zig 0.15.0)
+- **Zig 0.16.0-dev.254+6dd0270a1** (GitHub Actions uses `mlugg/setup-zig@v2` pinned to this version)
 - GPU drivers (optional, for acceleration)
 - OpenAI API key (for AI agent features)
 
@@ -552,7 +552,7 @@ The framework includes production-ready deployment configurations:
 
 See [Production Deployment Guide](docs/PRODUCTION_DEPLOYMENT.md) for complete deployment instructions.
 
-## 🌍 **Cross-Platform Guide (Zig 0.16-dev)**
+## 🌍 **Cross-Platform Guide (Zig 0.16.0-dev.254+6dd0270a1)**
 
 ### **Targets**
 ```bash

--- a/deploy/scripts/deploy-staging.ps1
+++ b/deploy/scripts/deploy-staging.ps1
@@ -89,8 +89,8 @@ FROM alpine:3.19 AS builder
 
 # Install Zig
 RUN apk add --no-cache curl xz
-RUN curl -L https://ziglang.org/download/0.14.1/zig-linux-x86_64-0.14.1.tar.xz | tar -xJ -C /opt
-ENV PATH="/opt/zig-linux-x86_64-0.14.1:$PATH"
+RUN curl -L https://ziglang.org/builds/zig-linux-x86_64-0.16.0-dev.254+6dd0270a1.tar.xz | tar -xJ -C /opt
+ENV PATH="/opt/zig-linux-x86_64-0.16.0-dev.254+6dd0270a1:$PATH"
 
 WORKDIR /build
 COPY . .

--- a/src/tools/docs_generator.zig
+++ b/src/tools/docs_generator.zig
@@ -3794,9 +3794,9 @@ fn generateGitHubActionsWorkflow(allocator: std.mem.Allocator) !void {
         \\          fetch-depth: 0
         \\
         \\      - name: Setup Zig
-        \\        uses: goto-bus-stop/setup-zig@v2
+        \\        uses: mlugg/setup-zig@v2
         \\        with:
-        \\          version: 0.12.0
+        \\          version: 0.16.0-dev.254+6dd0270a1
         \\
         \\      - name: Cache Zig dependencies
         \\        uses: actions/cache@v3


### PR DESCRIPTION
## Summary
- align README, contributing docs, and deployment guide on the required Zig 0.16.0-dev.254+6dd0270a1 toolchain
- update GitHub Actions and the docs generator workflow template to use mlugg/setup-zig@v2 pinned to the same version
- refresh deployment scripts and historical notes to remove claims of Zig 0.15.x support and add verification steps

## Testing
- not run (zig not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68ce80c8e47883318bcc7bce742fc692