### PR TITLE
docs: align docs with feature-based layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,21 +41,33 @@ zig build test
 
 ```
 abi/
-├── src/                          # Source code
-│   ├── core/                     # Core utilities
-│   ├── framework/                # Runtime orchestration and lifecycle
-│   ├── ai/                       # AI/ML components
-│   ├── database/                 # Vector database
-│   ├── net/                      # Networking
-│   ├── perf/                     # Performance monitoring
-│   ├── gpu/                      # GPU acceleration
-│   ├── ml/                       # ML algorithms
-│   ├── simd/                     # SIMD operations
-│   └── wdbx/                     # CLI interface
-├── tests/                        # Test suite
-├── docs/                         # Documentation
-├── examples/                     # Usage examples
-└── tools/                        # Development tools
+├── src/                              # Framework implementation and public entrypoints
+│   ├── mod.zig                       # Library surface re-exported by dependents
+│   ├── main.zig                      # CLI/bootstrap wiring
+│   ├── framework/                    # Runtime orchestration (feature toggles, lifecycle, state)
+│   ├── features/                     # Feature families managed by the framework
+│   │   ├── ai/                       # Agents, training loops, and ML utilities
+│   │   ├── database/                 # Vector database storage and indexing
+│   │   ├── web/                      # HTTP servers, gateways, and protocol adapters
+│   │   ├── monitoring/               # Telemetry, metrics, and health probes
+│   │   ├── gpu/                      # GPU compute backends and kernels
+│   │   └── connectors/               # Third-party integrations and adapters
+│   ├── shared/                       # Cross-cutting subsystems reused by every feature
+│   │   ├── core/                     # Configuration, lifecycle, and error handling
+│   │   ├── logging/                  # Structured logging and sinks
+│   │   ├── platform/                 # Platform detection and host capabilities
+│   │   ├── utils/                    # Common helpers (fs/http/json/crypto/math)
+│   │   ├── simd.zig                  # SIMD primitives exposed to features
+│   │   └── enhanced_plugin_system.zig  # Dynamic plugin loader/runtime
+│   ├── tests/                        # In-tree unit/integration harnesses (mirrors features)
+│   ├── examples/                     # Feature-focused runnable samples
+│   └── tools/                        # Developer tooling compiled into the framework build
+├── tests/                            # Standalone integration and regression suites
+├── docs/                             # Documentation site, guides, and generated references
+├── benchmarks/                       # Performance harnesses and reports
+├── deploy/                           # Deployment scripts and staging manifests
+├── scripts/                          # CI and automation helpers
+└── tools/                            # Repository-level utilities (lint, coverage, etc.)
 ```
 
 ## Quick Start

--- a/docs/GPU_AI_ACCELERATION.md
+++ b/docs/GPU_AI_ACCELERATION.md
@@ -32,7 +32,7 @@ The Abi AI Framework now includes comprehensive GPU acceleration for AI/ML opera
 ### **Core Components**
 
 ```
-src/gpu/compute/gpu_ai_acceleration.zig
+src/features/gpu/compute/gpu_ai_acceleration.zig
 ├── AIMLAcceleration          # Main acceleration manager with backend verification
 ├── Tensor                     # GPU-accelerated tensor operations
 ├── MatrixOps                  # Matrix operations with GPU kernel dispatch
@@ -102,8 +102,8 @@ The GPU acceleration integrates seamlessly with existing AI components:
 
 ```zig
 const std = @import("std");
-const gpu_accel = @import("../src/gpu/compute/gpu_ai_acceleration.zig");
-const gpu_renderer = @import("../src/gpu/core/gpu_renderer.zig");
+const gpu_accel = @import("../src/features/gpu/compute/gpu_ai_acceleration.zig");
+const gpu_renderer = @import("../src/features/gpu/core/gpu_renderer.zig");
 
 pub fn main() !void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
@@ -229,7 +229,7 @@ try dispatchMatmulKernel(a_buffer, b_buffer, c_buffer, m, n, p);
 
 ```zig
 // Using the GPU kernel system for custom operations
-const kernels = @import("../src/gpu/compute/kernels.zig");
+const kernels = @import("../src/features/gpu/compute/kernels.zig");
 
 // Create custom kernel configuration
 const config = kernels.KernelConfig{

--- a/docs/MODULE_ORGANIZATION.md
+++ b/docs/MODULE_ORGANIZATION.md
@@ -1,126 +1,120 @@
 # Abi Framework Module Organization
 
-Organized module structure with clear separation of concerns for the Abi AI Framework.
+Structured overview of the feature-oriented layout that powers the Abi AI Framework.
 
 ## 📁 Module Architecture
 
 ```
 src/
-├── root.zig          # Main module interface
-├── core/             # Foundation utilities
-├── ai/               # AI/ML functionality
-├── database/         # Vector database
-├── net/              # Networking
-├── perf/             # Performance monitoring
-├── gpu/              # GPU computing
-├── ml/               # ML algorithms
-├── api/              # C API bindings
-├── simd/             # SIMD operations
-├── plugins/          # Plugin system
-└── wdbx/             # CLI interface
+├── mod.zig              # Primary library surface
+├── main.zig             # CLI/bootstrap entrypoint
+├── framework/           # Runtime orchestration and feature management
+│   ├── config.zig       # Feature toggles and public options
+│   ├── runtime.zig      # Framework bootstrap and lifecycle
+│   ├── feature_manager.zig  # Feature discovery and activation helpers
+│   ├── catalog.zig      # Metadata exposed to tooling and docs
+│   └── state.zig        # Long-lived runtime state container
+├── features/            # Domain feature families surfaced to users
+│   ├── ai/              # Agents, ML pipelines, training/inference helpers
+│   ├── database/        # Vector storage, indexing, and query APIs
+│   ├── web/             # HTTP servers, gateways, protocol adapters
+│   ├── monitoring/      # Metrics, telemetry, and health probes
+│   ├── gpu/             # GPU backends, kernels, and device orchestration
+│   └── connectors/      # Third-party integrations and adapters
+├── shared/              # Cross-cutting subsystems reused everywhere
+│   ├── core/            # Configuration, lifecycle, and error types
+│   ├── logging/         # Structured logging sinks and formatters
+│   ├── platform/        # Host detection and capability probing
+│   ├── utils/           # Common helpers (fs/http/json/crypto/math)
+│   ├── simd.zig         # SIMD primitives exported to features
+│   ├── types.zig        # Shared type aliases and option sets
+│   ├── registry.zig     # Service registry used by the framework
+│   └── enhanced_plugin_system.zig # Plugin runtime and hot-reload orchestration
+├── examples/            # Runnable samples demonstrating the API
+├── tests/               # In-tree unit and integration harnesses
+└── tools/               # Developer tooling compiled as part of the build
 ```
 
 ## 🔧 Module Details
 
-### Core Module (`core/`)
-- **Purpose**: Framework foundation
-- **Components**: Memory management, error handling, cross-platform utilities
-- **Dependencies**: None
+### Framework Layer (`framework/`)
+- **Purpose**: Central orchestration layer that interprets `FrameworkOptions`, derives feature toggles, and coordinates lifecycle hooks.
+- **Components**: `config.zig`, `runtime.zig`, `catalog.zig`, `feature_manager.zig`, `state.zig`.
+- **Dependencies**: Relies on `shared/core`, `shared/utils`, logging, and the plugin system to manage feature wiring.
 
-### AI Module (`ai/`)
-- **Purpose**: AI capabilities
-- **Components**: Neural networks, agents, embeddings
-- **Dependencies**: `core/`, `simd/`
+### Shared Layer (`shared/`)
+- **Purpose**: Provides foundational services that every feature builds upon.
+- **Components**:
+  - `core/` for configuration management, lifecycle primitives, and error types.
+  - `logging/` for structured logging and sinks.
+  - `platform/` for OS/runtime detection.
+  - `utils/` for reusable helpers (filesystem, HTTP, JSON, crypto, math, encoding, networking).
+  - `simd.zig`, `types.zig`, and `registry.zig` for cross-feature data structures.
+  - `enhanced_plugin_system.zig` for dynamic plugin discovery, hot reload, and lifecycle management.
+- **Dependencies**: Minimal external dependencies; consumed by the framework and every feature module.
 
-### Database Module (`database/`)
-- **Purpose**: Vector database operations
-- **Components**: HNSW indexing, vector storage, query optimization
-- **Dependencies**: `core/`, `simd/`
+### Feature Families (`features/*`)
+Each feature family is independent, exporting a `mod.zig` with public APIs and relying on shared utilities for cross-cutting concerns.
 
-### Networking Module (`net/`)
-- **Purpose**: HTTP client and communication
-- **Components**: HTTP client, curl wrapper
-- **Dependencies**: `core/`
+- **`features/ai/`**: Agents, neural network layers, reinforcement learning, model registries, and serialization.
+- **`features/database/`**: Vector database kernels, sharding, persistence, and query planning.
+- **`features/web/`**: HTTP servers, gateway orchestration, WebSocket support, and client adapters.
+- **`features/monitoring/`**: Metrics pipelines, telemetry exporters, health checks, and diagnostics.
+- **`features/gpu/`**: GPU backend detection, compute kernels, optimization passes, and testing utilities.
+- **`features/connectors/`**: Integrations with third-party services, protocol bridges, and connector registries.
 
-### Performance Module (`perf/`)
-- **Purpose**: Performance monitoring
-- **Components**: Metrics, profiling, memory tracking
-- **Dependencies**: `core/`
+### Entry Points (`mod.zig` & `main.zig`)
+- **Purpose**: Provide the public ABI surface (`src/mod.zig`) and the CLI runtime (`src/main.zig`) that consumers interact with.
+- **Dependencies**: Delegate orchestration to `framework/runtime.zig` and consume shared utilities for bootstrapping.
 
-### GPU Module (`gpu/`)
-- **Purpose**: GPU acceleration
-- **Components**: Buffer management, shaders, matrix ops
-- **Dependencies**: `core/`, `simd/`
-
-### ML Module (`ml/`)
-- **Purpose**: Machine learning algorithms
-- **Components**: Training, inference, optimization
-- **Dependencies**: `core/`, `simd/`, `perf/`
-
-### API Module (`api/`)
-- **Purpose**: C bindings
-- **Components**: C API, foreign interfaces
-- **Dependencies**: `core/`, `database/`
-
-### SIMD Module (`simd/`)
-- **Purpose**: Vector operations
-- **Components**: Vector math, SIMD instructions
-- **Dependencies**: None
-
-### Plugins Module (`plugins/`)
-- **Purpose**: Extensibility
-- **Components**: Plugin loading, registry
-- **Dependencies**: `core/`
-
-### WDBX Module (`wdbx/`)
-- **Purpose**: CLI interface
-- **Components**: CLI processing, servers, configuration
-- **Dependencies**: All modules
+### Tests & Examples (`src/tests/`, `src/examples/`)
+- **Purpose**: House unit/integration harnesses mirroring the feature layout and runnable examples demonstrating best practices.
+- **Dependencies**: Import feature modules through `src/mod.zig` and exercise shared infrastructure.
 
 ## 🔗 Dependencies
 
 ```
-core/ ←─┬─ ai/ ←─┬─ ml/
-        │       │
-        ├─ net/ │
-        ├─ perf/┼─┬─ gpu/
-        ├─ api/─┼─┼─┬─ plugins/
-        ├─ simd/┼─┼─┼─┬─ wdbx/
-        └─ database/ ┼─┼─┼─┘
+shared/* ─┬────────────┬──────────────┐
+         │            │              │
+         ▼            ▼              ▼
+   framework/   features/*      src/tests/, src/examples/
+         │            │              │
+         └────┬───────┴─────┬────────┘
+              ▼             ▼
+     enhanced plugin   Framework runtime
+     system & registry orchestrate feature lifecycles
 ```
+
+- `shared/*` delivers the reusable building blocks consumed across the stack.
+- `framework/` activates features based on `FrameworkOptions`, using the plugin system and registry to wire dependencies.
+- `features/*` provide vertical capabilities and lean on shared utilities for storage, logging, SIMD, and platform access.
+- Tests and examples depend on the same public exports, ensuring parity with consumer usage.
 
 ## 🏗️ Build Integration
 
-- Module definitions in each subdirectory
-- Dependency resolution in build.zig
-- Platform-specific compilation
-- Comprehensive test coverage
+- Module wiring lives in `src/mod.zig`, which re-exports the framework, shared utilities, and feature families.
+- `build.zig` compiles the feature modules conditionally based on toggles exposed in `FrameworkOptions`.
+- Tests under `src/tests/` and `tests/` mirror the feature hierarchy for clarity.
+- Generated documentation references `features/*`, `shared/*`, and `framework/` to match the runtime layout.
 
 ## 📚 Usage
 
 ```zig
-// Import modules
 const abi = @import("abi");
-const db = abi.database.Db.init(allocator);
+const framework = try abi.init(allocator, .{ .enable_gpu = true, .enable_monitoring = true });
+defer framework.deinit();
 
-// Cross-module communication
-const perf = abi.perf.PerformanceMonitor.init();
-perf.startOperation("query");
-const results = try db.search(query_vector, 10);
-perf.endOperation();
+// Opt-in feature modules are available under `abi.features.*`
+var agent = try abi.features.ai.enhanced_agent.Agent.init(allocator, .{});
+defer agent.deinit();
+
+// Shared utilities remain accessible through `abi.shared.*`
+abi.shared.logging.global_logger.info("GPU feature online", .{});
 ```
-
-## 🔍 Module Discovery
-
-1. Check `mod.zig` files for documentation
-2. Run tests: `zig build test-[module]`
-3. View examples in `examples/`
-4. Generated API docs in `docs/api/`
 
 ## 🎯 Benefits
 
-- Clear separation of concerns
-- Minimal coupling between modules
-- Easy maintenance and testing
-- Scalable architecture
-- Intuitive navigation
+- Feature-based layout mirrors runtime toggles and clarifies ownership boundaries.
+- Shared primitives live in a single place, reducing duplication and easing audits.
+- Framework orchestration separates configuration from feature logic, simplifying testing.
+- Documentation, examples, and tests align with the in-tree structure, improving discoverability.

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -25,7 +25,7 @@
 - Location: `tests/*integration*`, `tests/test_web_server_*.zig`, `tests/test_plugin_*.zig`.
 - Scope: subsystem seams (agent routing + datastore, web server + plugins, GPU manager + kernels).
 - Tooling: `zig test` with feature flags (`-Dgpu=true`, `-Dsimd=true`, `-Denable_metrics=true`).
-- Requirements: cover cross-module behaviors, contract tests for connectors (`src/connectors`), regression harness for database sharding.
+- Requirements: cover cross-module behaviors, contract tests for connectors (`src/features/connectors`), regression harness for database sharding.
 - Data: use in-repo fixtures under `tests/fixtures/` (create as needed) and deterministic mocks.
 
 ### Performance & Load Tests
@@ -39,7 +39,7 @@
 - Location: dedicated suite `tests/security/` (to be created) plus fuzzers under `tools/`.
 - Scope: auth flows, schema validation, input sanitization, encryption, dependency scanning.
 - Tooling: static analysis (`zig build security-scan` target), fuzzing via `zig test --fuzz`, third-party scanners integrated in CI (e.g., cargo `cargo-audit` style equivalent for Zig packages when available).
-- Requirements: ensure every security-sensitive module (`src/security`, `src/plugins`, `src/server`) has both positive and negative tests; run dependency and secret scanners on every merge.
+- Requirements: ensure every security-sensitive module (`src/shared/enhanced_plugin_system.zig`, `src/framework`, `src/features/web`) has both positive and negative tests; run dependency and secret scanners on every merge.
 
 ### End-to-End Tests
 - Location: `tests/test_web_server_e2e.zig`, CLI workflow tests, scripted flows in `examples/` promoted to tests when stable.
@@ -49,14 +49,14 @@
 
 ## Coverage & Quality Metrics
 - **Code coverage**: compile tests with `-fprofile-instr-generate -fcoverage-mapping`; aggregate via `llvm-profdata`/`llvm-cov` and publish HTML under `zig-out/coverage/`.
-- **Branch coverage**: collect from `llvm-cov report`; enforce 90%+ for `src/core`, `src/server`, `src/plugins`, `src/database`.
+- **Branch coverage**: collect from `llvm-cov report`; enforce 90%+ for `src/shared/core`, `src/features/web`, `src/shared/enhanced_plugin_system.zig`, `src/features/database`.
 - **Mutation sampling**: quarterly run with `tools/mutagen.zig` (to implement) on critical modules.
 - **Static checks**: treat `zig fmt --check .` and `zig build lint` (add target) as mandatory gates.
 
 ## Environments
 - **Local**: developers run `zig build test`, targeted `zig test path`, and `zig build perf -- --quick` for smoke performance.
 - **CI**: matrix across targets (Linux, Windows), feature flags (`-Dgpu`, `-Dsimd`, `-Dhot_reload`), nightly extended runs with `--fuzz` and performance benchmarks.
-- **Pre-production**: weekly soak tests using `deploy/staging` scripts, capturing telemetry via Prometheus exporters in `src/monitoring`.
+- **Pre-production**: weekly soak tests using `deploy/staging` scripts, capturing telemetry via Prometheus exporters in `src/features/monitoring`.
 
 ## Test Data & Fixtures
 - Centralize fixtures under `tests/fixtures/` with subfolders (`agents/`, `plugins/`, `http/`, `database/`).


### PR DESCRIPTION
## Summary
- refresh the README project structure tree to match the current feature- and shared-module layout
- rewrite MODULE_ORGANIZATION.md with the new hierarchy, dependency flow, and usage guidance
- update GPU and testing guides to reference feature-based paths and shared systems

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68ce808bc14883319a26b818d533775f