### PR TITLE
framework: clean up module reexports

### DIFF
--- a/src/framework/mod.zig
+++ b/src/framework/mod.zig
@@ -1,3 +1,4 @@
+//! High-level runtime orchestration utilities for the ABI framework.
 const std = @import("std");
 
 pub const config = @import("config.zig");
@@ -11,6 +12,10 @@ pub const Framework = runtime.Framework;
 pub const featureLabel = config.featureLabel;
 pub const featureDescription = config.featureDescription;
 
+pub const feature_manager = @import("feature_manager.zig");
+pub const catalog = @import("catalog.zig");
+pub const state = @import("state.zig");
+
 pub fn deriveFeatureToggles(options: FrameworkOptions) config.FeatureToggles {
     return config.deriveFeatureToggles(options);
 }
@@ -18,10 +23,3 @@ pub fn deriveFeatureToggles(options: FrameworkOptions) config.FeatureToggles {
 test "framework module refAllDecls" {
     std.testing.refAllDecls(@This());
 }
-=======
-//! High-level runtime orchestration utilities for the ABI framework.
-
-pub const feature_manager = @import("feature_manager.zig");
-pub const catalog = @import("catalog.zig");
-pub const state = @import("state.zig");
-pub const runtime = @import("runtime.zig");


### PR DESCRIPTION
## Summary
- remove the stray merge separator and duplicate re-exports from `src/framework/mod.zig`
- keep the module documentation comment with the consolidated re-export block and avoid re-importing runtime twice

## Testing
- /tmp/zig-dev/zig fmt src/framework/mod.zig
- /tmp/zig-dev/zig build *(fails: duplicate symbol names in src/mod.zig unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ce808d42d48331b24581a6eda98a30