### PR TITLE
Align Zig version documentation with .zigversion

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,9 +21,11 @@ By participating in this project, you agree to abide by our Code of Conduct:
    ```
 
 2. **Set Up Development Environment**
-   - Install Zig 0.14.1 or later
+   - Install Zig 0.16.0-dev.254+6dd0270a1 (match the `.zigversion` file)
    - Install Bun (recommended): `curl -fsSL https://bun.sh/install | bash`
    - Set up your editor with Zig language support
+
+> **Compatibility:** Older setup notes targeting Zig 0.15.x remain later in this guide for reference only. They are no longer part of the supported toolchain but can help teams migrating legacy branches.
 
 3. **Build the Project**
 
@@ -285,7 +287,7 @@ Violations will be addressed by the project maintainers. We reserve the right to
 
 ### **Prerequisites**
 
-- **Zig 0.15.1 or later** (required for latest features)
+- **Zig 0.16.0-dev.254+6dd0270a1** (required; confirm against `.zigversion`)
 - **Git** for version control
 - **Basic understanding** of systems programming concepts
 - **Enthusiasm** for AI/ML and high-performance computing

--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -17,8 +17,8 @@ The ABI Framework is a high-performance, cross-platform Zig application that sup
 - ✅ **ARM64** (AArch64)
 
 ### Zig Versions
-- ✅ **0.15.1** (Latest Stable - Recommended)
-- ⚠️ **0.16.0-dev** (Development - Use with caution)
+- ✅ **0.16.0-dev.254+6dd0270a1** (current toolchain—match `.zigversion` on every environment)
+- ⚠️ **Legacy 0.15.x notes** remain later in this guide for maintainers of historical deployments; they are no longer part of the supported matrix.
 
 ## 🏗️ Build Requirements
 
@@ -63,10 +63,11 @@ winget install LLVM.LLVM
 
 #### Option 1: Official Installer (Recommended)
 ```bash
-# Download and install Zig 0.15.1
-wget https://ziglang.org/download/0.15.1/zig-linux-x86_64-0.15.1.tar.xz
-tar -xf zig-linux-x86_64-0.15.1.tar.xz
-sudo mv zig-linux-x86_64-0.15.1 /usr/local/zig
+# Download and install the repository's required Zig toolchain
+ZIG_VERSION=0.16.0-dev.254+6dd0270a1
+wget "https://ziglang.org/builds/zig-linux-x86_64-${ZIG_VERSION}.tar.xz"
+tar -xf "zig-linux-x86_64-${ZIG_VERSION}.tar.xz"
+sudo mv "zig-linux-x86_64-${ZIG_VERSION}" /usr/local/zig
 export PATH="/usr/local/zig:$PATH"
 ```
 
@@ -74,13 +75,15 @@ export PATH="/usr/local/zig:$PATH"
 ```bash
 git clone https://github.com/ziglang/zig
 cd zig
-git checkout 0.15.1
+git checkout 0.16.0-dev.254+6dd0270a1
 mkdir build
 cd build
 cmake ..
 make -j$(nproc)
 sudo make install
 ```
+
+> **Verification:** Run `zig version` and compare the output to `.zigversion` after installation to ensure the toolchain matches the repository expectation.
 
 ## 🔨 Build Instructions
 
@@ -218,8 +221,9 @@ RUN apt update && apt install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Zig
-RUN curl -L https://ziglang.org/download/0.15.1/zig-linux-x86_64-0.15.1.tar.xz | tar -xJ && \
-    mv zig-linux-x86_64-0.15.1 /usr/local/zig && \
+ARG ZIG_VERSION=0.16.0-dev.254+6dd0270a1
+RUN curl -L "https://ziglang.org/builds/zig-linux-x86_64-${ZIG_VERSION}.tar.xz" | tar -xJ && \
+    mv "zig-linux-x86_64-${ZIG_VERSION}" /usr/local/zig && \
     ln -s /usr/local/zig/zig /usr/local/bin/zig
 
 # Set working directory

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Abi AI Framework
 > Ultra-high-performance AI framework with GPU acceleration, lock-free concurrency, and platform-optimized implementations.
 
-[![Zig Version](https://img.shields.io/badge/Zig-0.16.0--dev-orange.svg)](https://ziglang.org/)
+[![Zig Version](https://img.shields.io/badge/Zig-0.16.0--dev.254%2B6dd0270a1-orange.svg)](https://ziglang.org/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/Platform-Cross--platform-green.svg)]()
 
@@ -24,9 +24,14 @@
 ## Installation
 
 ### Prerequisites
-- **Zig 0.16.0-dev** or later
+- **Zig 0.16.0-dev.254+6dd0270a1** (verify with `zig version` and the `.zigversion` file)
 - GPU drivers (optional, for acceleration)
 - OpenAI API key (for AI features)
+
+### Compatibility
+
+- **Current Toolchain**: Zig 0.16.0-dev.254+6dd0270a1. This repository's `.zigversion` file is the authoritative reference—match it exactly when installing Zig.
+- **Legacy Notes**: Historical guidance for Zig 0.15.x (including CI setups using `mlugg/setup-zig@v2` with Zig 0.15.0) remains in older sections below for teams maintaining legacy deployments. These paths are not part of the active test matrix.
 
 ### Quick Start
 ```bash
@@ -176,7 +181,7 @@ MIT License - see [LICENSE](LICENSE)
 
 > **Ultra-high-performance AI framework with GPU acceleration, lock-free concurrency, advanced monitoring, and platform-optimized implementations for Zig development.**
 
-[![Zig Version](https://img.shields.io/badge/Zig-0.15.1%2B-orange.svg)](https://ziglang.org/) • [Docs](https://donaldfilimon.github.io/abi/) • [CI: Pages](.github/workflows/deploy_docs.yml)
+[![Zig Version](https://img.shields.io/badge/Zig-0.16.0--dev.254%2B6dd0270a1-orange.svg)](https://ziglang.org/) • [Docs](https://donaldfilimon.github.io/abi/) • [CI: Pages](.github/workflows/deploy_docs.yml)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/Platform-Cross--platform-green.svg)](https://github.com/yourusername/abi)
 [![Build Status](https://img.shields.io/badge/Build-Passing-brightgreen.svg)]()
@@ -232,7 +237,7 @@ MIT License - see [LICENSE](LICENSE)
 ## 🚀 **Quick Start**
 
 ### **Prerequisites**
-- **Zig 0.15.1 or later** (GitHub Actions uses `mlugg/setup-zig@v2` with Zig 0.15.0)
+- **Zig 0.16.0-dev.254+6dd0270a1** (match `.zigversion`; see compatibility notes above for legacy branches)
 - GPU drivers (optional, for acceleration)
 - OpenAI API key (for AI agent features)
 
@@ -552,7 +557,7 @@ The framework includes production-ready deployment configurations:
 
 See [Production Deployment Guide](docs/PRODUCTION_DEPLOYMENT.md) for complete deployment instructions.
 
-## 🌍 **Cross-Platform Guide (Zig 0.16-dev)**
+## 🌍 **Cross-Platform Guide (Zig 0.16.0-dev.254+6dd0270a1)**
 
 ### **Targets**
 ```bash


### PR DESCRIPTION
## Summary
- update README badges, prerequisites, and cross-platform guide to reference Zig 0.16.0-dev.254+6dd0270a1 and highlight the `.zigversion` source of truth
- refresh CONTRIBUTING and DEPLOYMENT guides to require the same toolchain and add compatibility notes for legacy 0.15.x references
- include installation snippets and container setup instructions that fetch the exact Zig build expected by the repository

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68ce80958a6c8331acb6a9697549a2db