### PR TITLE
Update docs to reflect feature module layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,18 @@ zig build test
 ```
 abi/
 ├── src/                          # Source code
-│   ├── core/                     # Core utilities
+│   ├── features/                 # Feature families exported by abi.features
+│   │   ├── ai/                   # Agents, training loops, data structures
+│   │   ├── database/             # Vector store, sharding, HTTP façade
+│   │   ├── gpu/                  # Compute backends, kernels, demos
+│   │   ├── web/                  # HTTP/TCP servers, clients, bindings
+│   │   ├── monitoring/           # Metrics, tracing, regression tooling
+│   │   └── connectors/           # Third-party APIs and plugin bridges
 │   ├── framework/                # Runtime orchestration and lifecycle
-│   ├── ai/                       # AI/ML components
-│   ├── database/                 # Vector database
-│   ├── net/                      # Networking
-│   ├── perf/                     # Performance monitoring
-│   ├── gpu/                      # GPU acceleration
-│   ├── ml/                       # ML algorithms
-│   ├── simd/                     # SIMD operations
-│   └── wdbx/                     # CLI interface
+│   ├── shared/                   # Core utilities, platform, logging, SIMD
+│   ├── main.zig                  # CLI entry point
+│   ├── mod.zig                   # Public API surface
+│   └── root.zig                  # Legacy exports/compatibility layer
 ├── tests/                        # Test suite
 ├── docs/                         # Documentation
 ├── examples/                     # Usage examples
@@ -94,15 +96,15 @@ const results = try db.search(&embedding, 10, allocator);
 
 ## Modules
 
-- **`core/`**: Core utilities and framework foundation
-- **`framework/`**: Runtime orchestrator that wires features and plugins together
-- **`ai/`**: AI agents and machine learning components
-- **`database/`**: WDBX-AI vector database with HNSW indexing
-- **`net/`**: HTTP/TCP servers and client libraries
-- **`simd/`**: SIMD-accelerated operations
-- **`perf/`**: Performance monitoring and profiling
-- **`gpu/`**: GPU acceleration and rendering
-- **`ml/`**: Machine learning algorithms
+- **`features/ai/`**: AI agents, model registry, transformers, RL pipelines
+- **`features/database/`**: WDBX-AI vector database, sharding, unified clients
+- **`features/gpu/`**: GPU backend detection, compute kernels, unified memory
+- **`features/web/`**: HTTP/TCP servers, clients, and C bindings
+- **`features/monitoring/`**: Metrics, tracing, regression analysis, profiling
+- **`features/connectors/`**: External service adapters and plugin bridges
+- **`framework/`**: Runtime orchestrator coordinating feature lifecycles
+- **`shared/`**: Core utilities, logging, platform abstractions, SIMD helpers
+- **`ml/`**: Legacy ML compatibility layer (incrementally migrated into features)
 
 ## CLI
 
@@ -454,15 +456,15 @@ pub fn main() void {
 └─────────────────────────────────────────────────────────────┘
 ```
 
-## 📚 **Documentation**
+## 📚 **Further Reading**
 
-- **[Hosted Docs (GitHub Pages)](https://donaldfilimon.github.io/abi/)**
-- **[Development Guide](docs/DEVELOPMENT_GUIDE.md)** - Complete development workflow and architecture
-- **[API Reference](docs/api_reference.md)** - Complete API documentation
-- **[CLI Reference](docs/cli_reference.md)** - Command-line interface guide
-- **[Database Guide](docs/database_usage_guide.md)** - Vector database usage
-- **[Plugin System](docs/PLUGIN_SYSTEM.md)** - Plugin development guide
-- **[Production Deployment](docs/PRODUCTION_DEPLOYMENT.md)** - Deployment guide
+- **[Documentation Portal](docs/README.md)** - Landing page that links to generated and manual guides
+- **[Module Organization](docs/MODULE_ORGANIZATION.md)** - Current source tree and dependency overview
+- **[GPU Acceleration Guide](docs/GPU_AI_ACCELERATION.md)** - Feature deep dive for GPU-backed workloads
+- **[Testing Strategy](docs/TESTING_STRATEGY.md)** - Quality gates, coverage expectations, and tooling
+- **[Production Deployment](docs/PRODUCTION_DEPLOYMENT.md)** - Deployment runbooks and environment guidance
+- **[API Reference](docs/api_reference.md)** - Hand-authored API summary with links to generated docs
+- **[Generated Documentation](docs/generated/)** - Auto-generated API, module, and example references
 
 ## 🧪 **Testing & Quality**
 
@@ -539,7 +541,7 @@ pub const ExamplePlugin = struct {
 };
 ```
 
-See [Plugin System Documentation](docs/PLUGIN_SYSTEM.md) for detailed development guide.
+See the [Module Organization guide](docs/MODULE_ORGANIZATION.md) and generated module reference for plugin entry points.
 
 ## 🚀 **Production Deployment**
 

--- a/docs/GPU_AI_ACCELERATION.md
+++ b/docs/GPU_AI_ACCELERATION.md
@@ -32,7 +32,7 @@ The Abi AI Framework now includes comprehensive GPU acceleration for AI/ML opera
 ### **Core Components**
 
 ```
-src/gpu/compute/gpu_ai_acceleration.zig
+src/features/gpu/compute/gpu_ai_acceleration.zig
 ├── AIMLAcceleration          # Main acceleration manager with backend verification
 ├── Tensor                     # GPU-accelerated tensor operations
 ├── MatrixOps                  # Matrix operations with GPU kernel dispatch
@@ -102,8 +102,8 @@ The GPU acceleration integrates seamlessly with existing AI components:
 
 ```zig
 const std = @import("std");
-const gpu_accel = @import("../src/gpu/compute/gpu_ai_acceleration.zig");
-const gpu_renderer = @import("../src/gpu/core/gpu_renderer.zig");
+const gpu_accel = @import("../src/features/gpu/compute/gpu_ai_acceleration.zig");
+const gpu_renderer = @import("../src/features/gpu/core/gpu_renderer.zig");
 
 pub fn main() !void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
@@ -229,7 +229,7 @@ try dispatchMatmulKernel(a_buffer, b_buffer, c_buffer, m, n, p);
 
 ```zig
 // Using the GPU kernel system for custom operations
-const kernels = @import("../src/gpu/compute/kernels.zig");
+const kernels = @import("../src/features/gpu/compute/kernels.zig");
 
 // Create custom kernel configuration
 const config = kernels.KernelConfig{

--- a/docs/MODULE_ORGANIZATION.md
+++ b/docs/MODULE_ORGANIZATION.md
@@ -1,126 +1,114 @@
 # Abi Framework Module Organization
 
-Organized module structure with clear separation of concerns for the Abi AI Framework.
+Updated map of the reorganised Abi source tree. The new layout pivots around
+feature-oriented directories and shared runtime layers that are orchestrated via
+`src/mod.zig`.
 
 ## 📁 Module Architecture
 
 ```
 src/
-├── root.zig          # Main module interface
-├── core/             # Foundation utilities
-├── ai/               # AI/ML functionality
-├── database/         # Vector database
-├── net/              # Networking
-├── perf/             # Performance monitoring
-├── gpu/              # GPU computing
-├── ml/               # ML algorithms
-├── api/              # C API bindings
-├── simd/             # SIMD operations
-├── plugins/          # Plugin system
-└── wdbx/             # CLI interface
+├── mod.zig               # Top-level entrypoint that wires framework + features
+├── main.zig              # Legacy CLI entry
+├── root.zig              # Compatibility exports
+├── features/             # Feature families exported via src/features/mod.zig
+│   ├── ai/               # Agents, model registry, training loops
+│   ├── database/         # Vector store, sharding, HTTP adapters
+│   ├── gpu/              # GPU compute backends, memory and demos
+│   ├── web/              # HTTP/TCP servers, clients and bindings
+│   ├── monitoring/       # Telemetry, profiling and regression tooling
+│   └── connectors/       # Third-party API integrations and plugin bridges
+├── framework/            # Runtime orchestrator, feature registry, lifecycle
+│   ├── config.zig
+│   ├── feature_manager.zig
+│   ├── runtime.zig
+│   └── state.zig
+├── shared/               # Cross-cutting utilities reused everywhere
+│   ├── core/             # Error handling, lifecycle helpers, registry
+│   ├── utils/            # HTTP/JSON/math helpers
+│   ├── platform/         # OS abstractions and platform introspection
+│   ├── logging/          # Structured logging backends
+│   └── simd.zig          # Re-exported SIMD helpers
+└── simd.zig              # Legacy SIMD entry point (re-exported in shared)
 ```
 
 ## 🔧 Module Details
 
-### Core Module (`core/`)
-- **Purpose**: Framework foundation
-- **Components**: Memory management, error handling, cross-platform utilities
-- **Dependencies**: None
+### Feature Modules (`features/`)
+- **Purpose**: House capability-specific logic grouped by feature families.
+- **Components**:
+  - `ai/`: agents, transformers, reinforcement learning, data structures.
+  - `database/`: WDBX vector database, sharding, HTTP façade.
+  - `gpu/`: compute kernels, backend detection, memory pools, demos.
+  - `web/`: HTTP client/server stacks, C bindings, weather demo.
+  - `monitoring/`: metrics, tracing, regression analysis, Prometheus exports.
+  - `connectors/`: OpenAI/Ollama bridges and plugin-facing adapters.
+- **Dependencies**: Heavily reuse `shared/*` utilities and are orchestrated via
+  `framework/`.
 
-### AI Module (`ai/`)
-- **Purpose**: AI capabilities
-- **Components**: Neural networks, agents, embeddings
-- **Dependencies**: `core/`, `simd/`
+### Framework Runtime (`framework/`)
+- **Purpose**: Central coordination layer used by `abi.init`/`abi.shutdown`.
+- **Components**: Runtime state machine, feature discovery/catalogue,
+  configuration parsing, lifecycle management.
+- **Dependencies**: Consumes feature registries from `features/mod.zig` and core
+  primitives from `shared/core` and `shared/logging`.
 
-### Database Module (`database/`)
-- **Purpose**: Vector database operations
-- **Components**: HNSW indexing, vector storage, query optimization
-- **Dependencies**: `core/`, `simd/`
+### Shared Libraries (`shared/`)
+- **Purpose**: Foundation utilities and cross-cutting services shared by both
+  framework and features.
+- **Components**: Core lifecycle helpers, platform abstractions, logging
+  backends, utility collections, SIMD helpers.
+- **Dependencies**: Standalone where possible; some modules (e.g. logging)
+  depend on `shared/core`.
 
-### Networking Module (`net/`)
-- **Purpose**: HTTP client and communication
-- **Components**: HTTP client, curl wrapper
-- **Dependencies**: `core/`
-
-### Performance Module (`perf/`)
-- **Purpose**: Performance monitoring
-- **Components**: Metrics, profiling, memory tracking
-- **Dependencies**: `core/`
-
-### GPU Module (`gpu/`)
-- **Purpose**: GPU acceleration
-- **Components**: Buffer management, shaders, matrix ops
-- **Dependencies**: `core/`, `simd/`
-
-### ML Module (`ml/`)
-- **Purpose**: Machine learning algorithms
-- **Components**: Training, inference, optimization
-- **Dependencies**: `core/`, `simd/`, `perf/`
-
-### API Module (`api/`)
-- **Purpose**: C bindings
-- **Components**: C API, foreign interfaces
-- **Dependencies**: `core/`, `database/`
-
-### SIMD Module (`simd/`)
-- **Purpose**: Vector operations
-- **Components**: Vector math, SIMD instructions
-- **Dependencies**: None
-
-### Plugins Module (`plugins/`)
-- **Purpose**: Extensibility
-- **Components**: Plugin loading, registry
-- **Dependencies**: `core/`
-
-### WDBX Module (`wdbx/`)
-- **Purpose**: CLI interface
-- **Components**: CLI processing, servers, configuration
-- **Dependencies**: All modules
+### Legacy Entrypoints (`mod.zig`, `main.zig`, `root.zig`, `simd.zig`)
+- **Purpose**: Provide compatibility layers for existing consumers while the new
+  feature-first architecture settles.
+- **Components**: Public API surface (`mod.zig`), CLI entry (`main.zig`), legacy
+  exports (`root.zig`), SIMD convenience wrapper (`simd.zig`).
+- **Dependencies**: Bridge between external callers and the framework/feature
+  modules.
 
 ## 🔗 Dependencies
 
 ```
-core/ ←─┬─ ai/ ←─┬─ ml/
-        │       │
-        ├─ net/ │
-        ├─ perf/┼─┬─ gpu/
-        ├─ api/─┼─┼─┬─ plugins/
-        ├─ simd/┼─┼─┼─┬─ wdbx/
-        └─ database/ ┼─┼─┼─┘
+features/* ─┐
+            ├─▶ framework/runtime ─▶ shared/core
+shared/utils ─┘                     ├─▶ shared/logging
+                                   ├─▶ shared/platform
+                                   └─▶ shared/utils & shared/simd
 ```
 
 ## 🏗️ Build Integration
 
-- Module definitions in each subdirectory
-- Dependency resolution in build.zig
-- Platform-specific compilation
-- Comprehensive test coverage
+- Feature families are grouped under `src/features/mod.zig` for easy re-exports.
+- `src/mod.zig` exposes `abi.features` and `abi.framework` to callers.
+- Shared libraries live under `src/shared/*` and are imported where needed.
+- Build orchestration in `build.zig` pulls feature modules via the framework
+  runtime.
 
 ## 📚 Usage
 
 ```zig
-// Import modules
 const abi = @import("abi");
-const db = abi.database.Db.init(allocator);
+const framework = try abi.init(allocator, .{ .enable_gpu = true });
+defer framework.deinit();
 
-// Cross-module communication
-const perf = abi.perf.PerformanceMonitor.init();
-perf.startOperation("query");
-const results = try db.search(query_vector, 10);
-perf.endOperation();
+// Opt into a specific feature namespace
+const ai = abi.features.ai;
+const agent = try ai.Agent.init(allocator, .adaptive);
 ```
 
 ## 🔍 Module Discovery
 
-1. Check `mod.zig` files for documentation
-2. Run tests: `zig build test-[module]`
-3. View examples in `examples/`
-4. Generated API docs in `docs/api/`
+1. Inspect `src/features/mod.zig` for the list of available feature families.
+2. Explore `src/framework/` for runtime orchestration and lifecycle flows.
+3. Consult `src/shared/` for reusable utilities and platform abstractions.
+4. Browse generated docs in `docs/generated/` for symbol-level details.
 
 ## 🎯 Benefits
 
-- Clear separation of concerns
-- Minimal coupling between modules
-- Easy maintenance and testing
-- Scalable architecture
-- Intuitive navigation
+- Feature-centric layout that mirrors the runtime configuration surface.
+- Clear separation between orchestration (`framework/`) and shared utilities.
+- Easier discoverability through a consistent namespace (`abi.features.*`).
+- Explicit imports make it straightforward to reason about dependencies.

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -39,7 +39,7 @@
 - Location: dedicated suite `tests/security/` (to be created) plus fuzzers under `tools/`.
 - Scope: auth flows, schema validation, input sanitization, encryption, dependency scanning.
 - Tooling: static analysis (`zig build security-scan` target), fuzzing via `zig test --fuzz`, third-party scanners integrated in CI (e.g., cargo `cargo-audit` style equivalent for Zig packages when available).
-- Requirements: ensure every security-sensitive module (`src/security`, `src/plugins`, `src/server`) has both positive and negative tests; run dependency and secret scanners on every merge.
+- Requirements: ensure every security-sensitive module (`src/framework`, `src/shared/enhanced_plugin_system.zig`, `src/features/web`) has both positive and negative tests; run dependency and secret scanners on every merge.
 
 ### End-to-End Tests
 - Location: `tests/test_web_server_e2e.zig`, CLI workflow tests, scripted flows in `examples/` promoted to tests when stable.
@@ -49,7 +49,7 @@
 
 ## Coverage & Quality Metrics
 - **Code coverage**: compile tests with `-fprofile-instr-generate -fcoverage-mapping`; aggregate via `llvm-profdata`/`llvm-cov` and publish HTML under `zig-out/coverage/`.
-- **Branch coverage**: collect from `llvm-cov report`; enforce 90%+ for `src/core`, `src/server`, `src/plugins`, `src/database`.
+- **Branch coverage**: collect from `llvm-cov report`; enforce 90%+ for `src/shared/core`, `src/framework`, `src/features/web`, `src/features/database`, and `src/features/connectors`.
 - **Mutation sampling**: quarterly run with `tools/mutagen.zig` (to implement) on critical modules.
 - **Static checks**: treat `zig fmt --check .` and `zig build lint` (add target) as mandatory gates.
 


### PR DESCRIPTION
## Summary
- refresh the module organization guide to mirror the feature-first source layout and shared/framework modules
- update the README structure, module list, and further-reading links to point at the current docs set
- align testing strategy and GPU acceleration guide references with the new feature namespaces

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68ce963ef7408331a34ec1a8ccaa274c