### PR TITLE
build: run unit tests via run artifact

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -26,7 +26,8 @@ pub fn build(b: *std.Build) void {
     const unit_tests = b.addTest(.{
         .root_module = main_module,
     });
+    const run_unit_tests = b.addRunArtifact(unit_tests);
 
     const test_step = b.step("test", "Run all tests");
-    test_step.dependOn(&unit_tests.step);
+    test_step.dependOn(&run_unit_tests.step);
 }


### PR DESCRIPTION
## Summary
- ensure the unit test compile step is run through `b.addRunArtifact`
- depend the `test` step on the run step so `zig build test` executes the suite

## Testing
- zig build test *(fails: `zig` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce9777f6fc833186ca2552b4bba7a5