### PR TITLE
docs: document Db.freeResults cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,9 +305,11 @@ const row_id = try db.addEmbedding(&embedding);
 
 // Search for similar vectors
 const query = [_]f32{0.15, 0.25, 0.35, /* ... */};
-const results = try db.search(&query, 10, allocator);
-defer allocator.free(results);
+const matches = try db.search(&query, 10, allocator);
+defer abi.features.database.database.Db.freeResults(matches, allocator);
 ```
+
+> **Note:** Always release search metadata with `Db.freeResults` when you're done to reclaim allocator-backed resources.
 
 ### **WDBX Vector Database Features**
 


### PR DESCRIPTION
## Summary
- update the WDBX search example to use Db.freeResults for releasing metadata
- mention that Db.freeResults should be called to reclaim allocator-backed resources

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68ce9778bc588331a3687d5937875c11