### PR TITLE
Update WDBX example cleanup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ const matches = try db.search(&query, 10, allocator);
 defer abi.features.database.database.Db.freeResults(matches, allocator);
 ```
 
-> **Note:** Always release search metadata with `Db.freeResults` when you're done to reclaim allocator-backed resources.
+> **Note:** Always release search metadata with `Db.freeResults(matches, allocator)` when you're done so allocator-backed metadata gets reclaimed.
 
 ### **WDBX Vector Database Features**
 


### PR DESCRIPTION
## Summary
- clarify the WDBX vector database example cleanup by emphasizing the Db.freeResults call
- note explicitly that Db.freeResults(matches, allocator) reclaims allocator-backed metadata

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cffc510a4c8331b353f12206529444