### PR TITLE
docs: fix agent response deallocation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pub fn main() !void {
 
     // Process a message
     const response = try agent.process("Hello!", allocator);
-    defer allocator.free(response);
+    defer allocator.free(@constCast(response));
 }
 ```
 


### PR DESCRIPTION
## Summary
- use @constCast when freeing the quick-start agent reply buffer so the snippet compiles
- keep the surrounding guidance about freeing Agent.process responses intact

## Testing
- not run (not required for documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cffc51d5f88331b6e254ce5f318795