### PR TITLE
docs: clarify wdbx cli invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,13 @@ const results = try db.search(&embedding, 10, allocator);
 
 ```bash
 # Inspect available subcommands
-wdbx help
+./zig-out/bin/abi wdbx help
 
 # Launch the lightweight HTTP API (Ctrl+C to stop)
-wdbx http --host 0.0.0.0 --port 8080
+./zig-out/bin/abi wdbx http --host 0.0.0.0 --port 8080
 ```
+
+> If you install `abi` into your `PATH`, you can drop the `./zig-out/bin/` prefix and run commands like `abi wdbx http …` directly.
 
 ## Modules
 


### PR DESCRIPTION
## Summary
- update the WDBX CLI section in the README to show how to run commands via the abi executable
- add a note about dropping the zig-out prefix once the binary is installed on the PATH

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cffc498434833180357e375f68fb6e