### PR TITLE
docs: expand zig 0.16 migration playbook

### DIFF
--- a/MIGRATION_REPORT.md
+++ b/MIGRATION_REPORT.md
@@ -1,108 +1,222 @@
 # Zig 0.16-dev Migration Playbook
 
-## Strategic Objectives
-- **Maintain feature parity** while adopting Zig 0.16-dev language, stdlib, and build-system changes.
-- **Unlock GPU acceleration** across Vulkan, Metal, and CUDA backends using the refreshed async/event APIs.
-- **Lay neural-network foundations** for tensor-core optimized kernels and training workflows.
-- **De-risk future upgrades** by codifying playbooks for testing, observability, and security guardrails.
+This document is the authoritative playbook for the Zig 0.16-dev refactor. It defines strategy, ownership, deliverables, and the
+technical depth required so every workstream can execute autonomously while staying aligned with the overall migration intent.
 
-## Migration Strategy
-1. **Stabilize toolchain alignment**: pin Zig 0.16-dev.254+6dd0270a1, upgrade build metadata, and validate cross-platform bootstrap scripts.
-2. **Refactor core modules** in staged waves (allocators → stdlib updates → GPU → neural-network stack) with regression baselines between waves.
-3. **Parallelize validation** using CI matrix expansion, nightly benchmarks, and canary deployments for GPU hardware pools.
-4. **Institutionalize knowledge** via updated guides, reviewer checklists, and metrics dashboards to sustain the new baseline.
+---
 
-## Milestones & Owners
-| Milestone | Target Date | Success Criteria | Owner |
-| --- | --- | --- | --- |
-| Toolchain pin + build graph audit | 2025-09-22 | `zig build`/`zig build test` clean on all dev OS images | Dev Infra (A. Singh) |
-| Allocator + stdlib refactor | 2025-10-01 | Allocator policy tests pass; no regressions in memory diagnostics | Runtime Team (L. Gomez) |
-| GPU backend enablement | 2025-10-12 | Vulkan/Metal/CUDA smoke tests green; shader transpile scripts updated | GPU Team (M. Ito) |
-| Neural-network kernel uplift | 2025-10-20 | Tensor-core matmul 1.8× speedup; training loop convergence parity | ML Systems (R. Chen) |
-| Observability & security sign-off | 2025-10-25 | Dashboards live; threat model & SBOM refreshed | SRE/Security (K. Patel) |
-| Final migration review | 2025-10-27 | Reviewer checklist cleared; release notes drafted | Release Eng (S. Walker) |
+## 1. Strategy, Scope, and Governance
 
-## Risk Register
-| Risk | Impact | Probability | Owner | Mitigation |
+### 1.1 Strategic Objectives
+- **Maintain feature parity** while adopting Zig 0.16-dev language, stdlib, and build-system changes across all supported
+  products.
+- **Unlock GPU acceleration** across Vulkan, Metal, and CUDA backends by aligning with the refreshed async/event APIs and build
+  knobs.
+- **Lay neural-network foundations** for tensor-core optimized kernels, fused ops, and resilient training workflows.
+- **De-risk future upgrades** by codifying testing, observability, and security guardrails that become the default operating mode
+  for the platform.
+
+### 1.2 Guiding Principles
+- **Wave-based execution**: deliver incremental, reviewable waves with regression baselines before advancing.
+- **Owner accountability**: each milestone has a directly responsible individual (DRI) and an escalation deputy.
+- **Fail-fast validation**: expand CI, benchmarks, and telemetry to surface breakage within the same working day.
+- **Documentation-first**: every change is accompanied by updated runbooks, reviewer checklists, and migration notes.
+
+### 1.3 Governance Cadence
+- **Weekly steering sync** (Dev Infra, Runtime, GPU, ML Systems, SRE/Security) to unblock cross-cutting issues.
+- **Daily async standup** in `#zig-migration` Slack with blockers, risk changes, and test status.
+- **Change control**: high-risk merges (GPU, allocator) require dual approval from owning team + release engineering.
+
+---
+
+## 2. Milestones, Deliverables, and Owners
+
+| Milestone | Target Date | Success Criteria | Primary Owner | Deputy |
 | --- | --- | --- | --- | --- |
-| Upstream Zig breaking change lands mid-migration | Build failures across CI | Medium | Dev Infra | Track nightly Zig changelog, freeze snapshot after RC, mirror binaries internally |
-| GPU driver/toolchain mismatch (Metal 4 / CUDA 12.5) | GPU tests fail on macOS/Linux | High | GPU Team | Maintain driver matrix, pre-warm CI AMIs, provide fallback software rasterizer mode |
-| Allocator regression introduces leaks | Runtime instability | Medium | Runtime Team | Expand leak detectors, nightly fuzzing, require allocator-specific review |
-| Neural-net kernels miss tensor-core utilization | Performance degradation | Medium | ML Systems | Profile via Nsight/Metal Perf HUD, compare against baseline kernels, escalate to vendor support |
-| Observability gaps hide regressions | Slow incident response | Low | SRE | Enforce tracing spans, synthetic monitors per backend, alert fatigue review |
+| Toolchain pin + build graph audit | 2025-09-22 | `zig build`/`zig build test` green on Linux/macOS/Windows dev images; build.zig graph documented | Dev Infra (A. Singh) | Release Eng (S. Walker) |
+| Allocator + stdlib refactor | 2025-10-01 | Allocator policy tests pass; memory diagnostics regression ≤1%; stdlib API usage conforms to 0.16-dev | Runtime (L. Gomez) | Dev Infra (E. Chen) |
+| GPU backend enablement | 2025-10-12 | Vulkan/Metal/CUDA smoke + performance tests green; shader toolchain refreshed; feature flags documented | GPU (M. Ito) | ML Systems (R. Chen) |
+| Neural-network kernel uplift | 2025-10-20 | Tensor-core matmul ≥1.8× speedup; training convergence parity; ops library API locked | ML Systems (R. Chen) | Runtime (J. Patel) |
+| Observability & security sign-off | 2025-10-25 | Dashboards live; tracing coverage checklist complete; SBOM & threat model updated | SRE/Security (K. Patel) | Dev Infra (A. Singh) |
+| Final migration review | 2025-10-27 | Reviewer checklist cleared; release notes drafted; rollback plan rehearsed | Release Eng (S. Walker) | Program Mgmt (T. Rivera) |
 
-## Module Inventory Snapshot
-- **Core Runtime**: `src/runtime/allocator.zig`, `src/runtime/context.zig`, `src/runtime/async.zig` (ownership: Runtime Team).
-- **Compiler/Build Glue**: `build.zig`, `build.zig.zon`, `scripts/toolchain/*.sh` (ownership: Dev Infra).
-- **GPU Backends**: `src/gpu/vulkan/*.zig`, `src/gpu/metal/*.zig`, `src/gpu/cuda/*.zig`, shader assets in `assets/shaders/` (ownership: GPU Team).
-- **Neural Network Stack**: `src/nn/tensor.zig`, `src/nn/ops/*.zig`, `src/nn/train/*.zig` plus benchmarks under `benchmarks/nn/` (ownership: ML Systems).
-- **Observability & Security**: `src/telemetry/*.zig`, `tools/security/*.py`, CI workflows in `.github/workflows/` (shared by SRE/Security).
+Milestones are exit criteria for wave completion; each owner is responsible for ensuring regression baselines and documentation
+are archived in the migration repository.
 
-## Technical Workstreams
+---
 
-### Build-System Deltas
-- Adopt `std.Build.Step` graph updates: replace deprecated `.builder` field usage with `b` references and ensure custom steps emit `b.allocator` for scratch allocations.
-- Normalize module registration via `b.addModule("abi", .{ .source_file = .{ .path = "src/mod.zig" } });` and migrate dependent packages to `module.createImport()` semantics.
-- Update cross-compilation targets to rely on `std.zig.CrossTarget` with architecture triples, ensuring WASI and Android targets reflect new enum variants.
-- Regenerate `build.zig.zon` with SHA256 checksums for third-party packages compatible with 0.16-dev; verify license metadata remains intact.
+## 3. Module Inventory & Ownership
 
-### Stdlib / API Updates
-- Replace legacy `std.os.time.Timestamp` usage with `std.time.Timestamp` and adopt monotonic clock helpers.
-- Migrate `std.json.Value` handling to the new `parseFromSlice` interface and update error propagation to typed `error{ ParseError, InvalidType }` sets.
-- Refactor async runtime to align with `std.Channel` API adjustments (`.close()` explicit, `try channel.close();` semantics).
-- Audit `std.meta` usage for renamed helpers (`std.meta.trait.fields` → `std.meta.fields`, etc.) and add compatibility shims where necessary.
+| Domain | Key Modules & Artifacts | Owner Team | Notes |
+| --- | --- | --- | --- |
+| Core Runtime | `src/runtime/allocator.zig`, `src/runtime/context.zig`, `src/runtime/async.zig` | Runtime | Align async primitives with new `std.Channel` semantics; ensure allocator instrumentation hooks emit telemetry. |
+| Compiler / Build Glue | `build.zig`, `build.zig.zon`, `scripts/toolchain/*.sh`, `.zigversion` | Dev Infra | Responsible for toolchain pinning, build graph modernization, dependency integrity. |
+| GPU Backends | `src/gpu/vulkan/*.zig`, `src/gpu/metal/*.zig`, `src/gpu/cuda/*.zig`, `assets/shaders/*`, `tools/shaderc/*` | GPU | Own shader transpilation, backend toggles, and driver validation scripts. |
+| Neural Network Stack | `src/nn/tensor.zig`, `src/nn/ops/*.zig`, `src/nn/train/*.zig`, `benchmarks/nn/*`, `tests/nn/*` | ML Systems | Deliver tensor-core kernels, fused ops, and convergence benchmarks. |
+| Observability | `src/telemetry/*.zig`, `tools/metrics/*`, dashboards in `reports/observability/*` | SRE | Ensure logging/tracing schema, exporters, and dashboards align with new metrics. |
+| Security & Compliance | `tools/security/*.py`, `deploy/*`, container manifests, SBOM scripts | Security | Maintain secure defaults, patch cadence, and compliance reporting. |
+| Release Tooling | `.github/workflows/*.yml`, `scripts/release/*`, `docs/release_notes.md` | Release Eng | Gate releases and maintain canary promotion scripts. |
 
-### Allocator Policies
-- Default allocator remains `std.heap.page_allocator`; introduce scoped `ArenaAllocator` for neural-net graph compilation to avoid fragmentation.
-- Create profiling toggles that wrap allocators with `std.heap.LoggingAllocator` under debug builds and push telemetry counters through `telemetry/alloc.zig`.
-- Enforce zero-cost abstractions by converting ad-hoc `Allocator` pointers to `anytype` generics when call sites are specialized.
-- Document fallback strategy for systems without large page support: auto-detect and switch to `GeneralPurposeAllocator(.{})` with guard-page monitoring enabled.
+Owners must keep module inventories updated in the runbook after each wave, noting new files or deprecations.
 
-### GPU Backend Enablement
-- **Vulkan**: update descriptor set layouts to `std.vulkan.descriptor` helpers, migrate synchronization to timeline semaphores, and confirm SPIR-V generation via `tools/shaderc` using Zig build steps.
-- **Metal**: adopt Zig 0.16 `@cImport` updates, refresh Metal shading language bindings, and ensure argument buffers map to new resource index macros.
-- **CUDA**: align CUDA driver API bindings with `extern` calling convention changes; regenerate PTX kernels with tensor-core paths compiled for `sm_90a`.
-- Shared requirements: integrate GPU backend selection into `zig build` options (`-Dgpu-backend=vulkan|metal|cuda`), ensure fallback CPU path remains functional, and capture backend metrics via observability pipeline.
+---
 
-### Neural-Network Foundations
-- **Tensor Core Enablement**: use WMMA intrinsics where available; add architecture detection to pick FP8/BF16 kernels and guard fallback code paths.
-- **Operator Library**: refactor `ops` module to expose fused kernels (conv+bias+activation), adopt Zig iterators for shape inference, and document error sets for invalid tensor layouts.
-- **Training Loop**: rebuild optimizer modules to leverage async awaitables for gradient aggregation, introduce checkpoint/rollback support, and ensure determinism via seeded RNG wrappers.
-- **Benchmark Harness**: update `benchmarks/nn/` to compare old vs. new kernels, capturing throughput, memory footprint, and convergence metrics.
+## 4. Risk Register and Contingencies
 
-## CI & Benchmark Plan
-- Expand GitHub Actions matrix to cover Linux (x86_64, aarch64), macOS (ARM64, x86_64), and Windows (x86_64) with Zig 0.16-dev toolchain cache.
-- Add GPU self-hosted runners tagged per backend; nightly workflow executes `zig build gpu-tests -Dgpu-backend=<backend>` and publishes flamegraphs.
-- Introduce smoke benchmark job `zig build bench --summary all` with reduced dataset and weekly long-form benchmarks using `tools/run_benchmarks.sh`.
-- Set promotion gates: migrations cannot merge without green CI matrix, benchmark regression <5%, and manual sign-off for GPU jobs.
+| Risk | Impact | Probability | Owner | Mitigation | Trigger / Contingency |
+| --- | --- | --- | --- | --- | --- |
+| Upstream Zig breaking change lands mid-migration | Build failures across CI pipelines | Medium | Dev Infra | Track nightly Zig changelog, freeze snapshot after RC, mirror binaries internally | If break detected, revert to last known-good snapshot and raise upstream issue within 24h. |
+| GPU driver/toolchain mismatch (Metal 4 / CUDA 12.5) | GPU test failures on macOS/Linux | High | GPU | Maintain driver matrix, pre-warm CI AMIs, provide fallback software rasterizer | If driver incompatibility found, switch CI to fallback runner pool and block merges touching GPU code. |
+| Allocator regression introduces leaks | Runtime instability in prod workloads | Medium | Runtime | Expand leak detectors, nightly fuzzing, allocator-focused reviews | On leak detection, freeze allocator merges and initiate bisect with instrumentation build. |
+| Neural-net kernels miss tensor-core utilization | Performance degradation vs. baseline | Medium | ML Systems | Profile via Nsight/Metal Perf HUD, compare against baseline kernels, vendor escalation | If <1.5× uplift, trigger optimization tiger team to tune kernels before GA. |
+| Observability gaps hide regressions | Slow incident response | Low | SRE | Enforce tracing spans, synthetic monitors per backend, alert fatigue review | If SLA breach occurs without alert, halt rollout until observability fixes land. |
+| Security regressions from new dependencies | Compliance or vulnerability exposure | Low | Security | Automated SBOM diff scanning, container hardening, secure code review gates | If critical CVE found, revert dependency or apply hotfix within 48h. |
 
-## Observability Requirements
-- Emit structured logs using `telemetry/log.zig` with new fields for Zig version, allocator policy, and GPU backend.
-- Instrument async runtimes with tracing spans exported to OpenTelemetry collector; include GPU queue timelines and allocator stats.
-- Update dashboards (Grafana + Loki + Tempo) with migration-specific panels: build/test duration, GPU kernel occupancy, allocator fragmentation.
-- Configure synthetic probes hitting inference/training endpoints for each backend; alert when latency or error budget deviates >10%.
+Owners update impact/probability weekly; mitigations must have associated tasks in the migration tracker.
 
-## Security Considerations
-- Refresh threat model including GPU driver attack surface; validate sandboxing on macOS via system extensions and Linux via cgroups/SELinux profiles.
-- Regenerate SBOM (CycloneDX) using Zig build metadata; ensure supply chain scanning covers new dependencies.
-- Enforce secure coding guidelines: no unchecked pointer casts, validated FFI boundaries for CUDA driver, and secrets redaction in observability pipelines.
-- Perform dependency audit for tooling scripts; ensure container images updated with security patches alongside Zig upgrade.
+---
 
-## Reviewer Checklist
-1. Confirm `.zigversion` and `build.zig.zon` pin Zig 0.16-dev snapshot and match CI images.
-2. Validate build graph changes: no deprecated API usage, custom steps compile, `zig fmt` clean.
-3. Review allocator updates for leak detection hooks, debug toggles, and documented fallbacks.
-4. Execute GPU backend smoke tests (all platforms) and inspect generated shaders/PTX artifacts.
-5. Run neural-network benchmarks ensuring performance goals met and convergence plots attached to PR.
-6. Verify CI and observability dashboards updated with new metrics, alerts configured, and runbooks linked.
-7. Complete security review: SBOM regenerated, threat model updated, secrets scans green.
-8. Approve documentation updates across guides, ensuring migration playbook references correct owners and timelines.
+## 5. Technical Workstreams
 
-## Appendices
+Each subsection captures the delta from pre-0.16 state, required tasks, validation steps, and deliverables.
+
+### 5.1 Build-System Deltas
+- **Graph Modernization**: Replace deprecated `.builder` references with the new `b` handle, ensure custom steps allocate scratch
+  memory via `b.allocator`, and refactor step dependencies to explicit `dependOn` calls.
+- **Module Registration**: Normalize module definitions using `b.addModule("abi", .{ .source_file = .{ .path = "src/mod.zig" } });`
+  and migrate dependents to `module.dependOn()` / `createImport()` semantics. Document module graph in `docs/build_graph.md`.
+- **Cross Compilation**: Adopt `std.zig.CrossTarget` for target resolution, update target triples (notably WASI preview2 and
+  Android API level enums), and regenerate cached artifacts per target.
+- **Dependency Metadata**: Regenerate `build.zig.zon` with SHA256 checksums, license fields, and compatibility notes; verify
+  `zig fetch` works offline via mirrored tarballs.
+- **Toolchain Automation**: Update `scripts/toolchain/*` to install Zig 0.16-dev snapshot, seed caches, and validate using `zig
+  env`. Document bootstrap instructions in `DEPLOYMENT_GUIDE.md`.
+
+**Validation:** `zig build`, `zig build test`, `zig fmt`, and dry-run of cross targets (`zig build -Dtarget=wasm32-wasi`). Capture
+logs in CI artifact bucket.
+
+### 5.2 Stdlib and API Updates
+- **Time APIs**: Swap `std.os.time.Timestamp` for `std.time.Timestamp`, using monotonic clocks for scheduler logic; adjust tests
+  to tolerate nanosecond precision.
+- **JSON Handling**: Migrate to `std.json.Parser.parseFromSlice`, updating error propagation to typed `error{ParseError,
+  InvalidType}` sets and adding fuzz tests for schema drift.
+- **Async Primitives**: Refactor to new `std.Channel` behavior (`close()` explicit, iteration semantics changed), audit awaiting
+  patterns, and ensure cancellation tokens propagate errors.
+- **Reflection Helpers**: Update `std.meta` usages (`trait.fields` → `fields`, `Child` rename) and add compatibility wrappers
+  where necessary until downstream consumers migrate.
+- **Error Sets & Testing**: Document error-set changes in module docs and regenerate snapshots for API clients.
+
+**Validation:** Run unit tests, API compatibility tests under `tests/api/*`, and contract tests with SDK consumers.
+
+### 5.3 Allocator Policies and Instrumentation
+- **Allocator Topology**: Retain `std.heap.page_allocator` as default, introduce scoped `ArenaAllocator` for neural-network graph
+  builds, and evaluate `GeneralPurposeAllocator(.{})` for platforms lacking large pages.
+- **Instrumentation Hooks**: Wrap allocators with `std.heap.LoggingAllocator` under debug builds; export counters via
+  `telemetry/alloc.zig` (alloc/free rate, high-water marks) to dashboards.
+- **API Contracts**: Convert ad-hoc `*Allocator` parameters to `anytype` generics where call sites specialize, improving
+  optimization opportunities.
+- **Fallback Strategy**: Auto-detect huge page support; if unavailable, enable guard-page monitoring and log warnings with
+  remediation steps.
+- **Testing**: Extend allocator-specific tests under `tests/runtime/allocator.zig`, add soak test nightly job `zig build
+  allocator-soak`.
+
+### 5.4 GPU Backend Enablement
+- **Feature Flags**: Introduce `-Dgpu-backend=<vulkan|metal|cuda|cpu>` build option with compile-time dispatch tables and
+  documented defaults in `docs/gpu_backends.md`.
+- **Vulkan**: Adopt `std.vulkan.descriptor` helpers, migrate synchronization to timeline semaphores, validate descriptor set
+  layouts via `vkconfig`, and ensure SPIR-V generation pipelines (via `tools/shaderc`) emit debug info toggles.
+- **Metal**: Adjust `@cImport` bindings to Zig 0.16 rules, regenerate Metal headers, ensure argument buffers follow new resource
+  index macros, and test on macOS ARM/x86 hardware.
+- **CUDA**: Align driver API bindings with `extern` calling convention updates, regenerate PTX kernels optimized for `sm_90a`
+  tensor cores, and run Nsight Compute regression scripts.
+- **Shared Requirements**: Maintain CPU fallback path parity, expose backend telemetry (queue depth, kernel latency), and
+  document driver prerequisites.
+
+**Validation:** `zig build gpu-tests -Dgpu-backend=<backend>`, run shader compilation CI job, execute real-hardware canary tests
+on staging clusters, and capture flamegraphs.
+
+### 5.5 Neural-Network Foundations
+- **Tensor Core Enablement**: Detect architecture capabilities (FP8/BF16/TF32) at runtime, select WMMA kernels accordingly, and
+  provide CPU reference implementations for verification.
+- **Operator Library**: Refactor `ops` module to expose fused kernels (conv+bias+activation, attention block), implement shape
+  inference via iterators, and document tensor layout requirements and error sets.
+- **Training Loop**: Rebuild optimizer modules to leverage async awaitables for gradient aggregation, add checkpoint/rollback
+  support, deterministic seeding wrappers, and align logging with observability schema.
+- **Data Pipeline Integration**: Ensure data loaders adapt to Zig 0.16 IO changes, provide streaming dataset interface, and add
+  instrumentation for throughput / latency.
+- **Benchmark Harness**: Update `benchmarks/nn/*` to compare pre/post kernels, capture throughput, memory footprint, and
+  convergence metrics; surface results in Grafana panel.
+
+**Validation:** `zig build nn-tests`, nightly benchmark suite via `tools/run_benchmarks.sh --suite nn --compare-baseline`, and
+compare convergence plots stored in `reports/nn/`.
+
+---
+
+## 6. CI and Benchmark Execution Plan
+- **Matrix Expansion**: GitHub Actions workflows cover Linux (x86_64, aarch64), macOS (ARM64, x86_64), and Windows (x86_64) using
+  cached Zig 0.16-dev toolchains.
+- **GPU Runners**: Add self-hosted runners tagged `gpu:vulkan`, `gpu:metal`, `gpu:cuda`; nightly workflow executes `zig build
+  gpu-tests` for each backend and uploads flamegraphs + telemetry snapshots.
+- **Benchmark Cadence**: Introduce smoke benchmark job `zig build bench --summary all` per PR; weekly long-form benchmarks via
+  `tools/run_benchmarks.sh` with baseline diff reports archived in `reports/benchmarks/`.
+- **Promotion Gates**: Merges blocked unless CI matrix green, benchmark regression <5%, GPU jobs manually signed off by owning
+  team.
+- **Alerting**: CI failure notifications routed to #zig-migration; autopage release engineering on repeated failures.
+
+---
+
+## 7. Observability Requirements
+- **Logging**: Emit structured logs via `telemetry/log.zig`, including Zig version, allocator policy, GPU backend, and
+  performance counters; ensure logs parse in Loki.
+- **Tracing**: Instrument async runtimes with OpenTelemetry spans, capturing queue wait times, GPU submissions, and allocator
+  events. Export to Tempo with 7-day retention during migration.
+- **Metrics**: Update Grafana dashboards with migration panels (build/test duration, GPU kernel occupancy, allocator
+  fragmentation, nn convergence). Provide runbooks linking metrics to remediation steps.
+- **Synthetic Monitoring**: Deploy probes per backend hitting inference/training endpoints; configure alerts for >10% latency or
+  error budget deviations.
+- **Telemetry Validation**: Add CI job `zig build telemetry-test` to verify instrumentation compiles and emits expected schema.
+
+---
+
+## 8. Security and Compliance Considerations
+- **Threat Modeling**: Refresh GPU driver attack surface analysis; document isolation strategies (macOS system extensions,
+  Linux cgroups/SELinux profiles) in `docs/security/zig016.md`.
+- **Supply Chain**: Regenerate CycloneDX SBOM via Zig build metadata, diff against previous release, and feed into dependency
+  scanners; ensure new packages meet license policy.
+- **Secure Coding**: Enforce guidelines—no unchecked pointer casts, validated FFI boundaries for CUDA driver, secrets redaction in
+  telemetry exporters. Integrate with `tools/security/lint.py` pre-submit hook.
+- **Container & Runtime Hardening**: Update base images with patched libraries, enable kernel lockdown on GPU nodes, and verify
+  TLS certificates for remote shader compilation services.
+- **Incident Response**: Define rollback plan and contact tree in `SECURITY.md`; run tabletop exercise before final rollout.
+
+---
+
+## 9. Reviewer Checklist and Exit Criteria
+1. Confirm `.zigversion` and `build.zig.zon` pin the approved Zig 0.16-dev snapshot and match CI toolchains.
+2. Validate build graph updates: no deprecated APIs remain, custom steps compile, `zig fmt` is clean.
+3. Review allocator changes for leak detection hooks, debug toggles, and documented fallbacks (including guard-page logic).
+4. Execute GPU backend smoke tests across platforms; inspect generated shaders/PTX artifacts into `reports/gpu/`.
+5. Run neural-network benchmarks; ensure performance targets met and convergence plots attached to PR.
+6. Confirm CI workflows and observability dashboards updated with new metrics and alerts; provide screenshots or links.
+7. Complete security review: SBOM regenerated, threat model updated, secrets scans green, container images signed.
+8. Verify documentation updates (guides, runbooks, module inventories) reflect latest ownership and timelines.
+9. Ensure rollback procedure tested and logged in release checklist before sign-off.
+
+---
+
+## 10. Appendices
 - **Reference Commands**:
   - `zig version`
   - `zig build --summary all`
   - `zig build test --summary all`
   - `zig build gpu-tests -Dgpu-backend=<vulkan|metal|cuda>`
+  - `zig build nn-tests`
   - `tools/run_benchmarks.sh --suite nn --compare-baseline`
-- **Escalation Contacts**: #zig-migration Slack channel, on-call rotation (PagerDuty schedule "ABI Platform").
+- **Artifact Repositories**:
+  - CI logs: `s3://abi-ci-artifacts/zig016/`
+  - Benchmarks: `reports/benchmarks/`
+  - Observability dashboards: Grafana folder `Zig 0.16 Migration`
+- **Escalation Contacts**: `#zig-migration` Slack channel, PagerDuty schedule “ABI Platform”, program manager T. Rivera.
+
+This playbook should be treated as a living document. Update sections as deliverables close, risks evolve, or upstream Zig
+changes introduce new constraints.


### PR DESCRIPTION
## Summary
- restructure the Zig 0.16-dev migration report into a strategy-led playbook with governance, milestones, and ownership details
- expand technical guidance for build-system, stdlib, allocator, GPU backend, and neural-network workstreams
- document CI, benchmarking, observability, security, and reviewer requirements so the guide functions as an actionable prompt

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cffc2f36188331ae7ae5a501beca6c