### PR TITLE
docs: clarify wdbx http command

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ build system:
 abi help                    # Show commands
 abi chat                    # AI chat session
 abi train <data>           # Train neural network
-./zig-out/bin/abi wdbx server --http   # Start HTTP server
+./zig-out/bin/abi wdbx http --host 0.0.0.0 --port 8080   # Start HTTP server
 abi benchmark              # Performance tests
 abi analyze <file>         # Text analysis
 
@@ -360,7 +360,7 @@ The ABI vector database provides enterprise-grade performance with:
 ./zig-out/bin/abi wdbx add "1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0"
 
 # Start HTTP REST API server
-./zig-out/bin/abi wdbx http 8080
+./zig-out/bin/abi wdbx http --port 8080
 ```
 
 #### **HTTP REST API**
@@ -368,7 +368,7 @@ The ABI vector database provides enterprise-grade performance with:
 Start the server and access endpoints:
 
 ```bash
-./zig-out/bin/abi wdbx http 8080
+./zig-out/bin/abi wdbx http --port 8080
 ```
 
 **API Endpoints:**


### PR DESCRIPTION
## Summary
- document the supported `wdbx http` invocation in the CLI quickstart
- update vector database examples to use the `--port` flag instead of an unsupported positional argument

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cffc489f548331878a4d561052fe2a