### PR TITLE
Run unit tests via zig build test

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -30,7 +30,6 @@ pub fn build(b: *std.Build) void {
     const unit_tests = b.addTest(.{
         .root_module = main_module,
     });
-    const run_unit_tests = b.addRunArtifact(unit_tests);
 
     if (enable_vulkan) {
         exe.linkSystemLibrary("vulkan");
@@ -54,6 +53,8 @@ pub fn build(b: *std.Build) void {
             else => {},
         }
     }
+
+    const run_unit_tests = b.addRunArtifact(unit_tests);
 
     const test_step = b.step("test", "Run all tests");
     test_step.dependOn(&run_unit_tests.step);


### PR DESCRIPTION
## Summary
- ensure the unit test artifact is run through the build system's `test` step so `zig build test` executes the suite

## Testing
- `zig build test` *(fails: `zig` is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cffc55bc188331ba345802002a2c36