### PR TITLE
docs: sync documentation with feature modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,9 @@ pub fn main() void {
 
 - **[Documentation Portal](docs/README.md)** - Landing page that links to generated and manual guides
 - **[Module Organization](docs/MODULE_ORGANIZATION.md)** - Current source tree and dependency overview
+- **[Architecture & Feature Reference](docs/generated/MODULE_REFERENCE.md)** - Generated inventory of feature modules wired through `src/mod.zig`
+- **[Vector Database Guide](docs/api/database.md)** - WDBX storage engine configuration, sharding, and HTTP surfaces
+- **[AI Agent Guide](docs/api/ai.md)** - Agent personas, enhanced pipelines, and training utilities
 - **[GPU Acceleration Guide](docs/GPU_AI_ACCELERATION.md)** - Feature deep dive for GPU-backed workloads
 - **[Testing Strategy](docs/TESTING_STRATEGY.md)** - Quality gates, coverage expectations, and tooling
 - **[Production Deployment](docs/PRODUCTION_DEPLOYMENT.md)** - Deployment runbooks and environment guidance

--- a/docs/MODULE_ORGANIZATION.md
+++ b/docs/MODULE_ORGANIZATION.md
@@ -8,28 +8,71 @@ feature-oriented directories and shared runtime layers that are orchestrated via
 
 ```
 src/
-├── mod.zig               # Top-level entrypoint that wires framework + features
-├── main.zig              # Legacy CLI entry
-├── root.zig              # Compatibility exports
-├── features/             # Feature families exported via src/features/mod.zig
-│   ├── ai/               # Agents, model registry, training loops
-│   ├── database/         # Vector store, sharding, HTTP adapters
-│   ├── gpu/              # GPU compute backends, memory and demos
-│   ├── web/              # HTTP/TCP servers, clients and bindings
-│   ├── monitoring/       # Telemetry, profiling and regression tooling
-│   └── connectors/       # Third-party API integrations and plugin bridges
-├── framework/            # Runtime orchestrator, feature registry, lifecycle
+├── mod.zig                   # Public entrypoint exporting framework, features, and shared layers
+├── main.zig                  # Legacy CLI entry
+├── root.zig                  # Compatibility exports
+├── simd.zig                  # Legacy SIMD entry point (re-exported via shared)
+├── features/                 # Feature families exported via src/features/mod.zig
+│   ├── mod.zig               # Aggregates feature namespaces
+│   ├── ai/                   # Agents, transformers, registries, training loops
+│   │   ├── mod.zig
+│   │   ├── agent.zig
+│   │   ├── enhanced_agent.zig
+│   │   ├── transformer.zig
+│   │   ├── reinforcement_learning.zig
+│   │   └── data_structures/
+│   ├── database/             # Vector store engine, sharding, HTTP/CLI adapters
+│   │   ├── mod.zig
+│   │   ├── database.zig
+│   │   ├── config.zig
+│   │   ├── http.zig
+│   │   └── utils.zig
+│   ├── gpu/                  # GPU compute backends, memory, demos, benchmarking
+│   │   ├── mod.zig
+│   │   ├── core/
+│   │   ├── compute/
+│   │   ├── memory/
+│   │   ├── backends/
+│   │   ├── libraries/
+│   │   └── optimizations.zig
+│   ├── web/                  # HTTP/TCP servers, clients, bindings, demos
+│   │   ├── mod.zig
+│   │   ├── http_client.zig
+│   │   ├── web_server.zig
+│   │   └── weather.zig
+│   ├── monitoring/           # Telemetry, profiling, regression tooling
+│   │   └── mod.zig
+│   └── connectors/           # Third-party API integrations and plugin bridges
+│       ├── mod.zig
+│       └── plugin.zig
+├── framework/                # Runtime orchestrator, feature registry, lifecycle
+│   ├── mod.zig
+│   ├── catalog.zig
 │   ├── config.zig
 │   ├── feature_manager.zig
 │   ├── runtime.zig
 │   └── state.zig
-├── shared/               # Cross-cutting utilities reused everywhere
-│   ├── core/             # Error handling, lifecycle helpers, registry
-│   ├── utils/            # HTTP/JSON/math helpers
-│   ├── platform/         # OS abstractions and platform introspection
-│   ├── logging/          # Structured logging backends
-│   └── simd.zig          # Re-exported SIMD helpers
-└── simd.zig              # Legacy SIMD entry point (re-exported in shared)```
+└── shared/                   # Cross-cutting utilities reused everywhere
+    ├── mod.zig               # Plugin system façade
+    ├── core/                 # Error handling, lifecycle helpers, config, framework glue
+    │   ├── mod.zig
+    │   ├── core.zig
+    │   ├── config.zig
+    │   ├── framework.zig
+    │   └── lifecycle.zig
+    ├── utils/                # HTTP/JSON/math/crypto/net helpers
+    │   ├── mod.zig
+    │   ├── json/
+    │   ├── math/
+    │   ├── crypto/
+    │   ├── net/
+    │   └── http/
+    ├── logging/              # Structured logging backends
+    │   └── mod.zig
+    ├── platform/             # OS abstractions and platform introspection
+    │   └── mod.zig
+    └── simd.zig              # Re-exported SIMD helpers shared across features
+```
 
 ## 🔧 Module Details
 

--- a/docs/api/ai.md
+++ b/docs/api/ai.md
@@ -1,6 +1,7 @@
 # AI and Machine Learning API
 
-This document provides comprehensive API documentation for the `ai` module.
+This document provides comprehensive API documentation for the `abi.features.ai`
+namespace that is re-exported from `src/mod.zig`.
 
 ## Table of Contents
 
@@ -24,9 +25,22 @@ The AI module provides multi-persona agents, neural networks, and machine learni
 ## Examples
 
 ```zig
-var agent = try abi.ai.Agent.init(allocator, .creative);
-defer agent.deinit();
+const std = @import("std");
+const abi = @import("abi");
 
-const response = try agent.generate("Tell me a story", .{});
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    const ai = abi.features.ai;
+    var agent = try ai.agent.Agent.init(allocator, .{ .name = "Storyteller", .persona = .creative });
+    defer agent.deinit();
+
+    const reply = try agent.process("Tell me a story", allocator);
+    defer allocator.free(reply);
+
+    std.log.info("Agent reply: {s}", .{reply});
+}
 ```
 

--- a/docs/api/database.md
+++ b/docs/api/database.md
@@ -1,6 +1,7 @@
 # Vector Database API
 
-This document provides comprehensive API documentation for the `database` module.
+This document provides comprehensive API documentation for the `abi.features.database`
+namespace that exposes the WDBX vector database feature family.
 
 ## Table of Contents
 
@@ -61,15 +62,17 @@ const std = @import("std");
 const abi = @import("abi");
 
 pub fn main() !void {
-    var db = try abi.database.Db.open("vectors.wdbx", true);
+    const database = abi.features.database;
+    var db = try database.database.Db.open("vectors.wdbx", true);
     defer db.close();
 
-    // Initialize with 384-dimensional vectors
+    // Initialise the store for 384-dimensional vectors
     try db.init(384);
 
     // Add a vector
     const embedding = [_]f32{0.1, 0.2, 0.3} ++ ([_]f32{0.0} ** 381);
     const id = try db.addEmbedding(&embedding);
+    std.log.info("Stored embedding id: {}", .{id});
 }
 ```
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -4,17 +4,19 @@ Welcome to the comprehensive API documentation for the ABI AI Framework.
 
 ## Modules
 
-### Core Modules
+### Feature Namespaces (`abi.features.*`)
 
-- [**Database API**](database.md) - Vector database operations
-- [**AI/ML API**](ai.md) - AI agents and neural networks
-- [**SIMD API**](simd.md) - SIMD-accelerated operations
+- [**AI & Agents**](ai.md) — `abi.features.ai.*` personas, enhanced pipelines, and training utilities
+- [**Vector Database**](database.md) — `abi.features.database.*` storage engine, configuration, and HTTP/CLI front-ends
+- [**GPU Tooling**](../GPU_AI_ACCELERATION.md) — `abi.features.gpu.*` compute kernels, backends, and profiling suites
+- [**Web & Connectors**](http_client.md) — `abi.features.web.*` networking clients/servers plus connector bridges
 
-### Infrastructure
+### Framework & Shared Layers
 
-- [**HTTP Client**](http_client.md) - Enhanced HTTP client
-- [**Plugin System**](plugins.md) - Extensibility framework
-- [**WDBX Utilities**](wdbx.md) - Database management tools
+- [**Framework Runtime**](../MODULE_ORGANIZATION.md#-module-architecture) — `abi.framework.*` feature toggles, lifecycle, plugin coordination
+- [**Plugin System**](plugins.md) — `abi.shared.*` registries, loaders, and interfaces used by the runtime
+- [**SIMD & Utilities**](simd.md) — `abi.simd` helpers alongside `abi.utils`/`abi.platform`
+- [**WDBX Utilities**](wdbx.md) — Operational helpers layered on top of the database feature
 
 ## Quick Start
 

--- a/docs/api/plugins.md
+++ b/docs/api/plugins.md
@@ -1,6 +1,9 @@
 # Plugin System API
 
-This document provides comprehensive API documentation for the `plugins` module.
+This document provides comprehensive API documentation for the plugin system
+exposed via `abi.framework` and `abi.shared.*`. The runtime owns discovery and
+registration while the shared layer exposes registries, loaders, and plugin
+interfaces.
 
 ## Table of Contents
 
@@ -16,8 +19,31 @@ Dynamic plugin system for extending framework functionality.
 
 ### Plugin Types
 
-- **Database plugins**: Custom storage backends
-- **AI/ML plugins**: Model implementations
-- **Processing plugins**: Data transformers
-- **I/O plugins**: Custom protocols
+- **Database plugins**: Custom storage backends registered through
+  `abi.shared.types.PluginType.vector_database`
+- **AI/ML plugins**: Model implementations exposed under
+  `abi.shared.types.PluginType.neural_network`
+- **Processing plugins**: Data transformers and pipelines
+- **I/O plugins**: Custom protocols and connector bridges
+
+## Example
+
+```zig
+const std = @import("std");
+const abi = @import("abi");
+
+pub fn main() !void {
+    var framework = try abi.init(std.heap.page_allocator, .{
+        .plugin_paths = &.{ "./plugins" },
+        .auto_discover_plugins = true,
+        .auto_register_plugins = true,
+    });
+    defer framework.deinit();
+
+    try framework.refreshPlugins();
+
+    const registry = framework.pluginRegistry();
+    std.log.info("Loaded plugins: {d}", .{registry.getPluginCount()});
+}
+```
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -528,11 +528,12 @@ pub fn main() !void {
     defer context.deinit();
 
     // Initialize AI agent
-    var agent = try abi.ai.Agent.init(std.heap.page_allocator, .creative);
+    const ai = abi.features.ai;
+    var agent = try ai.agent.Agent.init(std.heap.page_allocator, .{ .name = "Creative", .persona = .creative });
     defer agent.deinit();
 
     // Initialize neural network
-    var network = try abi.neural.NeuralNetwork.init(std.heap.page_allocator);
+    var network = try ai.neural.NeuralNetwork.init(std.heap.page_allocator, .{});
     defer network.deinit();
 
     // Add layers

--- a/docs/generated/API_REFERENCE.md
+++ b/docs/generated/API_REFERENCE.md
@@ -6,165 +6,125 @@ description: "Complete API reference for ABI with detailed function documentatio
 
 # ABI API Reference
 
-## 🗄️ Database API
+## 🗄️ Database Feature (`abi.features.database`)
 
-### Database
-Main database interface for vector operations.
+### `database.database.Db`
+Primary interface for working with the WDBX vector store.
 
-#### Methods
+#### Constructors
+- `open(path: []const u8, create_if_missing: bool) DbError!*Db` — open or create
+a database file.
 
-##### `init(allocator: Allocator, config: DatabaseConfig) !Database`
-Initialize a new database instance.
+#### Core Methods
+- `init(self: *Db, dim: u16) DbError!void` — initialise file metadata for the
+  given dimensionality.
+- `addEmbedding(self: *Db, embedding: []const f32) DbError!u64` — append a
+  vector and return its identifier.
+- `search(self: *Db, query: []const f32, top_k: usize, allocator: std.mem.Allocator)
+  DbError![]Result` — perform ANN search (caller frees the returned slice).
+- `close(self: *Db) void` — flush data and close the file handle.
 
-**Parameters:**
-- `allocator`: Memory allocator to use
-- `config`: Database configuration
+#### Common Errors
+- `DbError.DimensionMismatch` — vector length differs from the configured
+  dimensionality.
+- `DbError.CorruptedDatabase` — header or on-disk layout is invalid.
+- `DbError.OutOfMemory` — allocation failed while performing the operation.
 
-**Returns:** Initialized database instance
+## 🧠 AI Feature (`abi.features.ai`)
 
-**Errors:** `DatabaseError.OutOfMemory`, `DatabaseError.InvalidConfig`
+### `ai.agent.Agent`
+Lightweight persona-driven agent with bounded history.
 
-##### `insert(self: *Database, vector: []const f32, metadata: ?[]const u8) !u64`
-Insert a vector into the database.
+- `init(allocator: std.mem.Allocator, config: AgentConfig) AgentError!*Agent`
+- `process(self: *Agent, input: []const u8, allocator: std.mem.Allocator)
+  AgentError![]const u8`
+- `clearHistory(self: *Agent) void`
+- `deinit(self: *Agent) void`
 
-**Parameters:**
-- `vector`: Vector data (must match configured dimension)
-- `metadata`: Optional metadata string
+Key config fields: `name`, `persona`, `enable_history`, `max_history_items`.
 
-**Returns:** Unique ID for the inserted vector
+### `ai.neural.NeuralNetwork`
+Composable neural network pipeline for experimentation.
 
-**Performance:** ~2.5ms for 1000 vectors
+- `init(allocator: std.mem.Allocator, config: TrainingConfig) !*NeuralNetwork`
+- `addLayer(self: *NeuralNetwork, config: LayerConfig) !void`
+- `forward(self: *NeuralNetwork, input: []const f32) ![]f32`
+- `deinit(self: *NeuralNetwork) void`
 
-##### `search(self: *Database, query: []const f32, k: usize) ![]SearchResult`
-Search for k nearest neighbors.
+Supporting types:
+- `LayerConfig` — layer type (`.Dense`, `.Embedding`, etc.), sizes, activation.
+- `TrainingConfig` — learning rate, batch size, precision, checkpoint options.
 
-**Parameters:**
-- `query`: Query vector
-- `k`: Number of results to return
+## ⚡ SIMD & Shared Utilities
 
-**Returns:** Array of search results (caller must free)
+### `abi.simd`
+- `add(result: []f32, a: []const f32, b: []const f32) void`
+- `subtract(result: []f32, a: []const f32, b: []const f32) void`
+- `multiply(result: []f32, a: []const f32, b: []const f32) void`
+- `normalize(result: []f32, input: []const f32) void`
 
-**Performance:** ~13ms for 10k vectors, k=10
+### `abi.utils`
+Collection of helpers grouped under `shared/utils/*` (JSON, HTTP, math, crypto,
+filesystem). Refer to the module organisation guide for detailed namespaces.
 
-## 🧠 AI API
+## 🔌 Framework & Plugin Runtime (`abi.framework`)
 
-### NeuralNetwork
-Neural network for machine learning operations.
+### `framework.Framework`
+Coordinates feature toggles and plugin lifecycle.
 
-#### Methods
+- `init(allocator: std.mem.Allocator, options: FrameworkOptions) !Framework`
+  (via `abi.init`).
+- `refreshPlugins(self: *Framework) !void` — discover plugins across configured
+  paths.
+- `addPluginPath(self: *Framework, path: []const u8) !void`
+- `pluginRegistry(self: *Framework) *abi.shared.registry.PluginRegistry` — access
+  registry APIs from `src/shared/registry.zig`.
+- `enableFeature(self: *Framework, feature: abi.framework.config.Feature) bool`
+- `disableFeature(self: *Framework, feature: abi.framework.config.Feature) bool`
+- `writeSummary(self: *const Framework, writer: anytype) !void`
 
-##### `createNetwork(allocator: Allocator, config: NetworkConfig) !NeuralNetwork`
-Create a new neural network.
+### `FrameworkOptions`
+Configure runtime behaviour.
 
-**Parameters:**
-- `allocator`: Memory allocator
-- `config`: Network configuration
-
-**Returns:** Initialized neural network
-
-##### `train(self: *NeuralNetwork, data: []const TrainingData) !f32`
-Train the neural network.
-
-**Parameters:**
-- `data`: Training data array
-
-**Returns:** Final training loss
-
-##### `predict(self: *NeuralNetwork, input: []const f32) ![]f32`
-Make predictions using the trained network.
-
-**Parameters:**
-- `input`: Input vector
-
-**Returns:** Prediction results (caller must free)
-
-## ⚡ SIMD API
-
-### Vector Operations
-SIMD-optimized vector operations.
-
-#### Functions
-
-##### `add(result: []f32, a: []const f32, b: []const f32) void`
-Add two vectors element-wise.
-
-**Parameters:**
-- `result`: Output vector (must be same size as inputs)
-- `a`: First input vector
-- `b`: Second input vector
-
-**Performance:** ~3μs for 2048 elements
-
-##### `normalize(result: []f32, input: []const f32) void`
-Normalize a vector to unit length.
-
-**Parameters:**
-- `result`: Output normalized vector
-- `input`: Input vector to normalize
-
-## 🔌 Plugin API
-
-### Plugin System
-Extensible plugin architecture.
-
-#### Functions
-
-##### `loadPlugin(path: []const u8) !Plugin`
-Load a plugin from file.
-
-**Parameters:**
-- `path`: Path to plugin file
-
-**Returns:** Loaded plugin instance
-
-##### `executePlugin(plugin: Plugin, function: []const u8, args: []const u8) ![]u8`
-Execute a plugin function.
-
-**Parameters:**
-- `plugin`: Plugin instance
-- `function`: Function name to execute
-- `args`: JSON-encoded arguments
-
-**Returns:** JSON-encoded result (caller must free)
-
-## 📊 Data Types
-
-### SearchResult
 ```zig
-pub const SearchResult = struct {
-    id: u64,
-    distance: f32,
-    metadata: ?[]const u8,
+const options = abi.framework.FrameworkOptions{
+    .auto_discover_plugins = true,
+    .auto_register_plugins = true,
+    .plugin_paths = &.{ "./plugins" },
 };
 ```
 
-### TrainingData
-```zig
-pub const TrainingData = struct {
-    input: []const f32,
-    output: []const f32,
-};
-```
+Feature toggles are derived via `abi.framework.deriveFeatureToggles(options)` and
+mirror the `FeatureTag` enum in `src/features/mod.zig`.
 
-## ⚠️ Error Types
+### Plugin Registry (`abi.shared`)
 
-### DatabaseError
-```zig
-pub const DatabaseError = error{
-    OutOfMemory,
-    InvalidConfig,
-    VectorDimensionMismatch,
-    IndexNotFound,
-    StorageError,
-};
-```
+`framework.pluginRegistry()` exposes the shared registry with methods such as:
+- `loadPlugin(path: []const u8) PluginError!void`
+- `startAllPlugins(self: *PluginRegistry) !void`
+- `getPluginCount(self: *PluginRegistry) usize`
+- `writeStatus(self: *PluginRegistry, writer: anytype) !void`
 
-### AIError
-```zig
-pub const AIError = error{
-    InvalidNetworkConfig,
-    TrainingDataEmpty,
-    ConvergenceFailed,
-    InvalidInputSize,
-};
-```
+Plugin metadata types live under `abi.shared.types` (`PluginInfo`, `PluginType`,
+`PluginConfig`).
+
+## 🌐 Web & Connectors (`abi.features.web`)
+
+Key modules include `http_client.zig` and `web_server.zig`.
+
+- `HttpClient.init(allocator: std.mem.Allocator, config: HttpClient.Config)
+  !*HttpClient`
+- `HttpClient.get(self: *HttpClient, url: []const u8, allocator: std.mem.Allocator)
+  ![]u8`
+- `HttpClient.deinit(self: *HttpClient) void`
+
+Connector modules follow the same pattern but wrap external APIs or plugin
+bridges.
+
+## 🧾 Notes
+
+- All slices returned from feature modules (database search results, neural
+  network outputs, HTTP responses) must be freed by the caller using the
+  allocator passed into the call.
+- Namespaces are stabilised behind `abi.features.*`, so prefer those imports over
+  historical `abi.database`/`abi.ai` references.

--- a/docs/generated/EXAMPLES.md
+++ b/docs/generated/EXAMPLES.md
@@ -18,14 +18,12 @@ pub fn main() !void {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    // Initialize database
-    const config = abi.DatabaseConfig{
-        .max_vectors = 10000,
-        .vector_dimension = 128,
-        .enable_caching = true,
-    };
-    var db = try abi.database.init(allocator, config);
-    defer db.deinit();
+    const database = abi.features.database;
+    var db = try database.database.Db.open("vectors.wdbx", true);
+    defer db.close();
+
+    // Initialise storage
+    try db.init(128);
 
     // Insert sample vectors
     for (0..100) |i| {
@@ -33,13 +31,13 @@ pub fn main() !void {
         for (&vector, 0..) |*v, j| {
             v.* = @as(f32, @floatFromInt(i + j)) * 0.1;
         }
-        const id = try db.insert(&vector, "vector_{}");
-        std.log.info("Inserted vector with ID: {}", .{id});
+        const id = try db.addEmbedding(&vector);
+        std.log.info("Stored vector with ID: {}", .{id});
     }
 
     // Search for similar vectors
     const query = [_]f32{1.0} ** 128;
-    const results = try db.search(&query, 5);
+    const results = try db.search(&query, 5, allocator);
     defer allocator.free(results);
 
     std.log.info("Found {} similar vectors:", .{results.len});
@@ -53,55 +51,35 @@ pub fn main() !void {
 
 ### Neural Network Training
 ```zig
-pub fn trainModel() !void {
+pub fn buildModel() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    // Create network
-    const config = abi.NetworkConfig{
-        .input_size = 128,
-        .hidden_sizes = &[_]usize{64, 32},
-        .output_size = 10,
+    const ai = abi.features.ai;
+    var network = try ai.neural.NeuralNetwork.init(allocator, .{
         .learning_rate = 0.01,
         .batch_size = 32,
-    };
-    var network = try abi.ai.createNetwork(allocator, config);
+    });
     defer network.deinit();
 
-    // Generate training data
-    var training_data = std.array_list.Managed(abi.TrainingData).init(allocator);
-    defer training_data.deinit();
+    try network.addLayer(.{
+        .type = .Dense,
+        .input_size = 128,
+        .output_size = 64,
+        .activation = .ReLU,
+    });
+    try network.addLayer(.{
+        .type = .Dense,
+        .input_size = 64,
+        .output_size = 10,
+    });
 
-    for (0..1000) |i| {
-        var input: [128]f32 = undefined;
-        var output: [10]f32 = undefined;
+    const sample = [_]f32{0.5} ** 128;
+    const logits = try network.forward(&sample);
+    defer allocator.free(logits);
 
-        // Generate random input
-        for (&input) |*v| {
-            v.* = std.rand.DefaultPrng.init(@as(u64, i)).random().float(f32);
-        }
-
-        // Generate target output (one-hot encoding)
-        @memset(&output, 0);
-        output[i % 10] = 1.0;
-
-        try training_data.append(abi.TrainingData{
-            .input = &input,
-            .output = &output,
-        });
-    }
-
-    // Train network
-    const loss = try network.train(training_data.items);
-    std.log.info("Training completed with loss: {}", .{loss});
-
-    // Test prediction
-    const test_input = [_]f32{0.5} ** 128;
-    const prediction = try network.predict(&test_input);
-    defer allocator.free(prediction);
-
-    std.log.info("Prediction: {any}", .{prediction});
+    std.log.info("Forward pass complete with {} outputs", .{logits.len});
 }
 ```
 
@@ -178,20 +156,17 @@ export fn process_data(input: [*c]const u8, input_len: usize, output: [*c]u8, ou
 
 // Using the plugin
 pub fn usePlugin() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+    var framework = try abi.init(std.heap.page_allocator, .{
+        .plugin_paths = &.{ "./plugins" },
+        .auto_discover_plugins = true,
+        .auto_register_plugins = true,
+    });
+    defer framework.deinit();
 
-    // Load plugin
-    const plugin = try abi.plugins.loadPlugin("plugin_example.zig");
-    defer plugin.deinit();
+    try framework.refreshPlugins();
 
-    // Execute plugin function
-    const input = "hello world";
-    const result = try abi.plugins.executePlugin(plugin, "process_data", input);
-    defer allocator.free(result);
-
-    std.log.info("Plugin result: {s}", .{result});
+    const registry = framework.pluginRegistry();
+    std.log.info("Loaded plugins: {d}", .{registry.getPluginCount()});
 }
 ```
 
@@ -204,37 +179,32 @@ pub fn batchOperations() !void {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    var db = try abi.database.init(allocator, abi.DatabaseConfig{});
-    defer db.deinit();
+    const database = abi.features.database;
+    var db = try database.database.Db.open("vectors.wdbx", true);
+    defer db.close();
+    try db.init(128);
 
-    // Batch insert
-    const batch_size = 1000;
-    var vectors = try allocator.alloc([]f32, batch_size);
-    defer {
-        for (vectors) |vec| allocator.free(vec);
-        allocator.free(vectors);
-    }
+    const batch_size = 512;
+    var vectors = try allocator.alloc([128]f32, batch_size);
+    defer allocator.free(vectors);
 
-    // Generate batch data
     for (vectors, 0..) |*vec, i| {
-        vec.* = try allocator.alloc(f32, 128);
         for (vec.*, 0..) |*v, j| {
             v.* = @as(f32, @floatFromInt(i + j)) * 0.01;
         }
     }
 
-    // Insert batch
     const start_time = std.time.nanoTimestamp();
     for (vectors) |vec| {
-        _ = try db.insert(vec, null);
+        _ = try db.addEmbedding(&vec);
     }
     const end_time = std.time.nanoTimestamp();
 
-    const duration = @as(f64, @floatFromInt(end_time - start_time)) / 1000.0; // Convert to milliseconds
-    const throughput = @as(f64, @floatFromInt(batch_size)) / (duration / 1000.0);
+    const duration_ms = @as(f64, @floatFromInt(end_time - start_time)) / 1_000_000.0;
+    const throughput = @as(f64, @floatFromInt(batch_size)) / (duration_ms / 1000.0);
 
-    std.log.info("Batch insert: {} vectors in {}ms", .{ batch_size, duration });
-    std.log.info("Throughput: {} vectors/sec", .{throughput});
+    std.log.info("Batch insert: {} vectors in {d:.2}ms", .{ batch_size, duration_ms });
+    std.log.info("Throughput: {d:.2} vectors/sec", .{throughput});
 }
 ```
 
@@ -247,29 +217,29 @@ pub fn robustOperations() !void {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    var db = abi.database.init(allocator, abi.DatabaseConfig{}) catch |err| switch (err) {
+    const database = abi.features.database;
+    var db = database.database.Db.open("vectors.wdbx", true) catch |err| switch (err) {
         error.OutOfMemory => {
             std.log.err("Failed to allocate memory for database");
             return;
         },
-        error.InvalidConfig => {
-            std.log.err("Invalid database configuration");
+        else => return err,
+    };
+    defer db.close();
+
+    db.init(128) catch |err| switch (err) {
+        database.database.Db.DbError.DimensionMismatch => {
+            std.log.err("Invalid dimensionality");
             return;
         },
         else => return err,
     };
-    defer db.deinit();
 
-    // Safe vector operations
     const vector = [_]f32{1.0, 2.0, 3.0} ** 43; // 128 dimensions
 
-    const id = db.insert(&vector, "test") catch |err| switch (err) {
-        error.VectorDimensionMismatch => {
+    const id = db.addEmbedding(&vector) catch |err| switch (err) {
+        database.database.Db.DbError.DimensionMismatch => {
             std.log.err("Vector dimension mismatch");
-            return;
-        },
-        error.StorageError => {
-            std.log.err("Storage operation failed");
             return;
         },
         else => return err,

--- a/docs/generated/MODULE_REFERENCE.md
+++ b/docs/generated/MODULE_REFERENCE.md
@@ -6,191 +6,177 @@ description: "Comprehensive reference for all ABI modules and components"
 
 # ABI Module Reference
 
-## 📦 Core Modules
+## 🚩 Entrypoint
 
-### `abi` - Main Module
-The primary module containing all core functionality.
+### `abi` — Main Module
+Central import that wires the framework runtime, feature namespaces, and shared
+libraries. The file `src/mod.zig` exposes curated accessors instead of direct
+path imports so consumers can stay aligned with internal refactors.
 
-#### Key Components:
-- **Database Engine**: High-performance vector database with HNSW indexing
-- **AI System**: Neural networks and machine learning capabilities
-- **SIMD Operations**: Optimized vector operations
-- **Plugin System**: Extensible architecture for custom functionality
+#### Key Exports
+- `abi.features` — grouped feature families (`ai`, `database`, `gpu`, `web`,
+  `monitoring`, `connectors`)
+- `abi.framework` — runtime orchestration, feature toggles, and lifecycle APIs
+- `abi.utils` / `abi.core` / `abi.logging` / `abi.platform` — shared utility
+  layers
+- `abi.simd` — SIMD helpers re-exported from `src/shared/simd.zig`
 
-### `abi.database` - Database Module
-Vector database operations and management.
+## 🧩 Feature Namespaces (`abi.features.*`)
 
-#### Functions:
+### `abi.features.ai`
+Comprehensive AI toolkit including agents, enhanced transformer pipelines,
+distributed training, and model registries. Major files:
+
+- `agent.zig` / `enhanced_agent.zig` — persona-driven assistants with history
+  management
+- `transformer.zig`, `reinforcement_learning.zig`, `neural.zig` — model
+  implementations
+- `model_registry.zig`, `model_serialization.zig` — lifecycle management for AI
+  assets
+
+Usage:
+
 ```zig
-// Initialize database
-pub fn init(allocator: Allocator, config: DatabaseConfig) !Database
-
-// Insert vector
-pub fn insert(self: *Database, vector: []const f32, metadata: ?[]const u8) !u64
-
-// Search vectors
-pub fn search(self: *Database, query: []const f32, k: usize) ![]SearchResult
-
-// Update vector
-pub fn update(self: *Database, id: u64, vector: []const f32) !void
-
-// Delete vector
-pub fn delete(self: *Database, id: u64) !void
+const ai = abi.features.ai;
+var agent = try ai.agent.Agent.init(allocator, .{ .name = "Helper" });
+defer agent.deinit();
 ```
 
-### `abi.ai` - AI Module
-Artificial intelligence and machine learning capabilities.
+### `abi.features.database`
+WDBX vector database engine and surrounding tooling.
 
-#### Functions:
+- `database.zig` — storage engine with SIMD-accelerated search
+- `config.zig` — `WdbxConfig` parsing/validation
+- `http.zig` / `cli.zig` — service surfaces layered on the core engine
+- `database_sharding.zig` / `unified.zig` — distributed operations
+
+Usage:
+
 ```zig
-// Create neural network
-pub fn createNetwork(allocator: Allocator, config: NetworkConfig) !NeuralNetwork
-
-// Train network
-pub fn train(self: *NeuralNetwork, data: []const TrainingData) !f32
-
-// Predict/Infer
-pub fn predict(self: *NeuralNetwork, input: []const f32) ![]f32
-
-// Enhanced agent operations
-pub fn createAgent(allocator: Allocator, config: AgentConfig) !EnhancedAgent
+const database = abi.features.database;
+var db = try database.database.Db.open("vectors.wdbx", true);
+defer db.close();
+try db.init(768);
 ```
 
-### `abi.simd` - SIMD Module
-SIMD-optimized vector operations.
+### `abi.features.gpu`
+GPU accelerators, memory orchestration, backend selection, and benchmarking.
+Subdirectories include `compute/`, `memory/`, `backends/`, `libraries/`, and
+`testing/` for platform-specific functionality.
 
-#### Functions:
+### `abi.features.web`
+HTTP clients/servers, C bindings, and demos that surface ABI functionality over
+the network. Core files: `http_client.zig`, `web_server.zig`, `wdbx_http.zig`,
+and `weather.zig`.
+
+### `abi.features.monitoring`
+Telemetry, profiling, regression tooling, and metrics exporters consolidated in
+`monitoring/mod.zig` and supporting files.
+
+### `abi.features.connectors`
+Bridges to third-party APIs and plugin wrappers (e.g. `plugin.zig`) that let the
+runtime load external capability providers.
+
+## 🧠 Framework Runtime (`abi.framework.*`)
+
+The framework namespace coordinates features, plugin discovery, and lifecycle
+management.
+
+- `config.zig` — `FrameworkOptions`, feature toggles, labels, and descriptions
+- `runtime.zig` — `Framework` struct with methods such as `refreshPlugins`,
+  `enableFeature`, and `writeSummary`
+- `feature_manager.zig`, `catalog.zig`, `state.zig` — advanced orchestration and
+  registry plumbing
+
+Initialization example:
+
 ```zig
-// Vector addition
-pub fn add(result: []f32, a: []const f32, b: []const f32) void
+var framework = try abi.init(std.heap.page_allocator, .{
+    .auto_discover_plugins = true,
+    .plugin_paths = &.{ "./plugins" },
+});
+defer framework.deinit();
 
-// Vector subtraction
-pub fn subtract(result: []f32, a: []const f32, b: []const f32) void
-
-// Vector multiplication
-pub fn multiply(result: []f32, a: []const f32, b: []const f32) void
-
-// Vector normalization
-pub fn normalize(result: []f32, input: []const f32) void
+try framework.refreshPlugins();
 ```
 
-### `abi.plugins` - Plugin System
-Extensible plugin architecture.
+## 🛠 Shared Libraries (`abi.core`, `abi.utils`, `abi.logging`, `abi.platform`)
 
-#### Functions:
+- `abi.core` → `src/shared/core/mod.zig` (error types, lifecycle, framework
+  glue)
+- `abi.utils` → `src/shared/utils/mod.zig` (JSON, math, crypto, HTTP, FS, and
+  string helpers)
+- `abi.logging` → `src/shared/logging/mod.zig` (structured logging backends)
+- `abi.platform` → `src/shared/platform/mod.zig` (OS/platform detection and
+  capability reporting)
+- `abi.simd` → `src/shared/simd.zig` (SIMD intrinsics surfaced to features)
+- `src/shared/mod.zig` — plugin façade exposing `PluginRegistry`, loader, and
+  interface types used by the framework
+
+## 🔌 Plugin System
+
+Plugins are coordinated by the framework but implemented in the shared layer:
+
+- Use `abi.init` with `FrameworkOptions` to configure discovery/registration
+- Call `framework.pluginRegistry()` to access the shared registry API
+- Plugin metadata/types live under `abi.shared.types` (via
+  `@import("shared/types.zig")` inside the runtime)
+
+Example snippet:
+
 ```zig
-// Load plugin
-pub fn loadPlugin(path: []const u8) !Plugin
-
-// Register plugin
-pub fn registerPlugin(plugin: Plugin) !void
-
-// Execute plugin function
-pub fn executePlugin(plugin: Plugin, function: []const u8, args: []const u8) ![]u8
+const registry = framework.pluginRegistry();
+try registry.loadPlugin("./plugins/example_plugin.so");
+std.log.info("Plugins ready: {d}", .{registry.getPluginCount()});
 ```
 
-## 🔧 Configuration Types
+## 🚀 Usage Patterns
 
-### DatabaseConfig
+### Feature-Oriented Workflow
+
 ```zig
-pub const DatabaseConfig = struct {
-    max_vectors: usize = 1000000,
-    vector_dimension: usize = 128,
-    index_type: IndexType = .hnsw,
-    storage_path: ?[]const u8 = null,
-    enable_caching: bool = true,
-    cache_size: usize = 1024 * 1024, // 1MB
-};
-```
-
-### NetworkConfig
-```zig
-pub const NetworkConfig = struct {
-    input_size: usize,
-    hidden_sizes: []const usize,
-    output_size: usize,
-    activation: ActivationType = .relu,
-    learning_rate: f32 = 0.01,
-    batch_size: usize = 32,
-};
-```
-
-## 📊 Performance Characteristics
-
-| Operation | Performance | Memory Usage |
-|-----------|-------------|--------------|
-| Vector Insert | ~2.5ms (1000 vectors) | ~512 bytes/vector |
-| Vector Search | ~13ms (10k vectors, k=10) | ~160 bytes/result |
-| Neural Training | ~30μs/iteration | ~1MB/network |
-| SIMD Operations | ~3μs (2048 elements) | ~16KB/batch |
-
-## 🚀 Usage Examples
-
-### Basic Database Usage
-```zig
-const std = @import("std");
 const abi = @import("abi");
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+var framework = try abi.init(std.heap.page_allocator, .{});
+defer framework.deinit();
 
-    // Initialize database
-    const config = abi.DatabaseConfig{
-        .max_vectors = 10000,
-        .vector_dimension = 128,
-    };
-    var db = try abi.database.init(allocator, config);
-    defer db.deinit();
+const ai = abi.features.ai;
+var agent = try ai.agent.Agent.init(std.heap.page_allocator, .{ .name = "Ops" });
+defer agent.deinit();
 
-    // Insert vectors
-    const vector = [_]f32{1.0, 2.0, 3.0} ** 43; // 128 dimensions
-    const id = try db.insert(&vector, "sample_data");
-
-    // Search for similar vectors
-    const results = try db.search(&vector, 10);
-    defer allocator.free(results);
-
-    std.log.info("Found {} similar vectors", .{results.len});
-}
+const reply = try agent.process("status", std.heap.page_allocator);
+defer std.heap.page_allocator.free(reply);
 ```
 
-### Neural Network Training
+### Database & HTTP Integration
+
 ```zig
-const config = abi.NetworkConfig{
-    .input_size = 128,
-    .hidden_sizes = &[_]usize{64, 32},
-    .output_size = 10,
-    .learning_rate = 0.01,
-};
+const abi = @import("abi");
 
-var network = try abi.ai.createNetwork(allocator, config);
-defer network.deinit();
+const database = abi.features.database;
+var db = try database.database.Db.open("vectors.wdbx", true);
+defer db.close();
+try db.init(512);
 
-// Training data
-const training_data = [_]abi.TrainingData{
-    .{ .input = &input1, .output = &output1 },
-    .{ .input = &input2, .output = &output2 },
-};
-
-// Train network
-const loss = try network.train(&training_data);
-std.log.info("Training loss: {}", .{loss});
+const web = abi.features.web;
+var client = try web.http_client.HttpClient.init(std.heap.page_allocator, .{});
+defer client.deinit();
 ```
 
-## 🔍 Error Handling
+### SIMD Helpers
 
-All functions return appropriate error types:
-- `DatabaseError` - Database-specific errors
-- `AIError` - AI/ML operation errors
-- `SIMDError` - SIMD operation errors
-- `PluginError` - Plugin system errors
+```zig
+var buffer = try allocator.alloc(f32, 1024);
+defer allocator.free(buffer);
+abi.simd.normalize(buffer, buffer);
+```
 
-## 📈 Performance Tips
+## 🎯 Benefits of the Feature-Centric Layout
 
-1. **Use appropriate vector dimensions** - 128-512 dimensions typically optimal
-2. **Batch operations** - Group multiple operations for better performance
-3. **Enable caching** - Significant performance improvement for repeated queries
-4. **SIMD optimization** - Automatically enabled for supported operations
-5. **Memory management** - Use arena allocators for bulk operations
+- Aligns documentation with the actual `src/features/*` directory structure
+- Keeps shared utilities clearly separated from orchestration concerns
+- Encourages consumers to adopt `abi.features.*` namespaces, reducing churn
+  during refactors
+- Simplifies discovery: inspect `src/features/mod.zig` for feature families,
+  `src/framework/` for lifecycle management, and `src/shared/` for reusable
+  building blocks


### PR DESCRIPTION
## Summary
- refresh the module organization guide to reflect the feature-first layout and shared/framework directories
- point README further reading and API docs at the existing feature, database, and agent guides
- rewrite generated references and examples to consume `abi.features.*` and the framework/plugin runtime exports

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68cffc3a64c483319f5dd8ad7c210aa1