### PR TITLE
docs: fix windows troubleshooting link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,7 @@ Welcome to the comprehensive documentation for ABI, a high-performance vector da
 ### Developer Resources
 - **[Code Index]({{ '/generated/CODE_API_INDEX/' | relative_url }})** - Auto-generated API index from source
 - **[Native Docs]({{ '/zig-docs/' | relative_url }})** - Zig compiler-generated documentation
-- **[Windows Zig std Troubleshooting]({{ '/docs/ZIG_STD_WINDOWS_FIX.html' | relative_url }})** - Workarounds when the stdlib docs fail to load on Windows
+- **[Windows Zig std Troubleshooting]({{ '/ZIG_STD_WINDOWS_FIX.html' | relative_url }})** - Workarounds when the stdlib docs fail to load on Windows
 - **[Search]({{ '/index.html' | relative_url }})** - Interactive documentation browser
 
 ## 🔍 Features


### PR DESCRIPTION
## Summary
- fix the Windows troubleshooting link on the docs home page so it points to the generated page

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d03e0365508331be4607b50fce364a