### PR TITLE
tools: harden zig docs discovery and manual picker

### DIFF
--- a/docs/WINDOWS_ZIG_STD_DOCS_FIX.md
+++ b/docs/WINDOWS_ZIG_STD_DOCS_FIX.md
@@ -19,7 +19,7 @@ The interactive PowerShell module (`Zig-DocsInteractive`) orchestrates each stag
    Zig-DocsInteractive
    ```
 
-3. Follow the on-screen menu. Choose **option 6** for the full automated pipeline or drill into individual steps for targeted actions.
+3. Follow the on-screen menu. Option **1** replays the last known good configuration, option **2** cycles every detected Zig build automatically, option **3** lets you pick or add a version manually, option **4** triggers the WSL fallback, and option **5** opens the live health dashboard.
 
 The module stores its adaptive state under `%LOCALAPPDATA%\ZigDocs\state.json` and keeps execution logs in `%LOCALAPPDATA%\ZigDocs\logs`. Delete these files if you want to start fresh.
 
@@ -29,21 +29,20 @@ The module stores its adaptive state under `%LOCALAPPDATA%\ZigDocs\state.json` a
 
 | Stage | What Happens | Key Commands | Saved Signals |
 | --- | --- | --- | --- |
-| 1. Environment Verification | Confirms Zig availability, PATH health, and configuration | `zig version`, `zig env` | `lastSuccess`, `failureStreak`, timestamped history |
-| 2. Version Switching & PATH Management | Selects or adds Zig installations, rewrites PATH without touching the registry | `Use-Zig` equivalent logic via menu option 2 | Preferred Zig locations |
-| 3. Docs Server (Windows) | Starts `zig std --no-open-browser`, auto-detects the port, and opens your browser | `zig std --no-open-browser` | `lastPort`, preferred browser |
-| 4. Docs Server (WSL) | Runs the same command via `wsl`, ideal when Windows builds fail | `wsl zig std --no-open-browser` | Host/port captured from WSL output |
-| 5. Diagnostics & Network Tests | Probes `sources.tar`, runs `Test-NetConnection`, and suggests DevTools checks | `Invoke-WebRequest`, `Test-NetConnection` | Probe success/failure entries |
-| 6. Adaptive Feedback | Consolidates history, warns after repeated failures, and recommends fallbacks | Internal state machine | Menu summaries, failure streak |
+| 1. Candidate Discovery & Environment Snapshot | Auto-detects Zig binaries (`C:\tools\zig\**\zig.exe`, PATH, WSL), captures versions, and records the current locale. | `Get-ChildItem`, `zig version`, `zig env` | `zigCandidates`, `versionMetadata`, `lastStatus`, `locale` |
+| 2. Windows Docs Launch | Starts `zig std --no-open-browser`, monitors stdout/stderr for regressions (`unable to serve /sources.tar`, port binding errors), and launches a browser with locale-aware arguments. | `zig std --no-open-browser`, browser CLI | `lastPort`, `lastSuccessfulVersion`, `preferredBrowser` |
+| 3. Auto-Rotation & Heuristics | Option 2 cycles through detected versions, ranks them by last success and semantic version, and increments per-version failure counters (skipping those above the threshold). | `Invoke-ZigDocsWindowsSession`, failure counter updates | `versionFailures`, `failureThreshold`, `history` |
+| 4. Health Dashboard & Self-Learning State | Option 5 renders the color-coded dashboard, lets you tweak thresholds, and manage browser preferences while reviewing the recent action log. | `Show-ZigDocsDashboard` | `totalSuccesses`, `totalFailures`, `preferredBrowser`, `history` |
+| 5. WSL Fallback Heuristics | Option 4 launches `zig std` inside WSL, auto-detects mirrored networking vs. bridged IPs, and keeps state aligned with the Windows attempts. | `wsl.exe zig std`, `hostname -I` | `lastSuccessfulMode`, `lastPort` |
 
-The **Full Automated Pipeline** (menu option 6) chains stages 1 → 3 → 5, giving you a one-command recovery path. You can interrupt and resume at any stage because state and logs persist across sessions.
+The auto-rotation workflow replaces the old pipeline option. You can trigger it any time via menu option 2, and the launcher remembers the last working setup so option 1 can replay it instantly.
 
 ---
 
 ## Installing Zig Builds for the Pipeline
 
 * Download official Zig archives to `C:\tools\zig\<version>` (or a location of your choice).
-* Add each folder—or its `zig.exe`—to the candidate list when prompted by menu option 2.
+* Add each folder—or its `zig.exe`—to the candidate list via the manual picker (menu option 3 → **A**) if the auto-discovery step does not find it automatically.
 * The module sanitizes PATH entries so the selected Zig version always takes priority without permanently modifying the system PATH.
 
 For checksums and release discovery, continue to rely on the official Zig download page. The pipeline assumes the binaries you provide are trusted.
@@ -68,22 +67,20 @@ The optional `-ZigCandidates` parameter seeds the selector with known installati
 
 ### Menu Options
 
-1. **Check Environment** – Runs `zig version` and `zig env`, logging the results.
-2. **Switch Zig Version** – Lets you pick or add Zig locations, then refreshes PATH.
-3. **Run Docs Server (Windows)** – Starts the Windows binary, detects the port, and launches your preferred browser.
-4. **Run Docs Server (WSL)** – Invokes Zig inside WSL and opens the resulting URL.
-5. **Diagnostics & Network Tests** – Downloads `sources.tar`, runs `Test-NetConnection`, and reminds you to inspect browser DevTools.
-6. **Full Automated Pipeline** – Executes options 1 → 3 → 5 sequentially.
-7. **Set Preferred Browser** – Persists the browser command (e.g., `msedge.exe --inprivate`).
-8. **Exit** – Saves state and quits.
+1. **Run docs server with last known good version** – Replays the configuration that succeeded most recently, including PATH rewrites and browser launch parameters.
+2. **Try all versions automatically** – Rotates through detected Zig builds, skipping those that exceeded the failure threshold until one succeeds.
+3. **Choose a version manually** – Presents the ranked list, lets you launch any candidate immediately, and opens a mini-menu where **A** adds new folders/executables, **D** removes stale entries (including their failure counters), **R** rescans auto-detected paths, and **Enter** returns to the top-level menu.
+4. **Run in WSL fallback** – Invokes Zig inside WSL, detects mirrored networking vs. bridged IPs, and launches the docs URL from Windows.
+5. **Show health dashboard** – Displays success/failure statistics, per-version counters, preferred browser configuration, and allows adjusting the failure threshold.
+6. **Exit** – Saves state and quits.
 
-After each action the module updates its history pane. Multiple failures trigger yellow warnings nudging you toward the WSL fallback.
+After each action the module updates its history pane, and the summary banner promotes the WSL fallback whenever repeated failures are detected.
 
 ---
 
 ## PowerShell Module Internals
 
-The script is implemented in `tools/zig_docs_interactive.ps1` and is designed for PowerShell 5.1+ or PowerShell 7.x on Windows.
+The script is implemented in `tools/zig_docs_interactive.ps1` and is designed for PowerShell 5.1+ or PowerShell 7.x on Windows. Candidate discovery now avoids the PowerShell 7-only `Get-ChildItem -Depth` flag by performing a bounded breadth-first scan, so auto-detection works even on stock Windows 10 shells.
 
 ```powershell
 # tools/zig_docs_interactive.ps1 (excerpt)
@@ -94,21 +91,27 @@ function Zig-DocsInteractive {
   $state = Load-ZigDocsState -StatePath $storage.StatePath -ZigCandidates $ZigCandidates
   $state | Add-Member -MemberType NoteProperty -Name BaseDir -Value $storage.BaseDir -Force
 
-  $zigExe = Resolve-ZigExecutable -Candidates $state.zigCandidates
-
   while ($true) {
+    $candidates = Get-ZigDocsCandidates -State $state -AdditionalCandidates $ZigCandidates
+    $sorted     = Sort-ZigDocsCandidates -State $state -Candidates $candidates
+
     Clear-Host
-    Write-Host "Zig Docs Interactive Menu" -ForegroundColor Cyan
-    # ... menu rendering ...
-    switch (Read-Host "Select an option") {
-      '1' { Invoke-ZigDocsEnvironmentCheck -ZigExe $zigExe -LogPath $storage.LogPath }
-      '2' { $zigExe = Invoke-ZigDocsVersionSwitch -State $state -LogPath $storage.LogPath }
-      '3' { Invoke-ZigDocsServerWindows -ZigExe $zigExe -State $state -LogPath $storage.LogPath }
+    Write-Host "Zig Docs Interactive" -ForegroundColor Cyan
+    Write-Host "1. Run docs server with last known good version"
+    Write-Host "2. Try all versions automatically"
+    Write-Host "3. Choose a version manually"
+    Write-Host "4. Run in WSL fallback"
+    Write-Host "5. Show health dashboard"
+    Write-Host "Q. Exit"
+    Show-ZigDocsSummary -State $state -Candidates $sorted
+
+    switch ((Read-Host "Select an option").ToUpperInvariant()) {
+      '1' { Invoke-ZigDocsWindowsSession -State $state -Candidate (Get-ZigDocsLastGoodCandidate -State $state -Candidates $sorted) -LogPath $storage.LogPath }
+      '2' { foreach ($candidate in $sorted) { if (-not $candidate.Skip) { if ((Invoke-ZigDocsWindowsSession -State $state -Candidate $candidate -LogPath $storage.LogPath).success) { break } } } }
+      '3' { # manual picker + add new candidate }
       '4' { Invoke-ZigDocsServerWsl -State $state -LogPath $storage.LogPath }
-      '5' { Invoke-ZigDocsDiagnostics -State $state -LogPath $storage.LogPath }
-      '6' { Invoke-ZigDocsAutomatedPipeline -State $state -ZigExe $zigExe -LogPath $storage.LogPath }
-      '7' { $state.preferredBrowser = Read-Host "Browser command or blank to clear" }
-      '8' { break }
+      '5' { Show-ZigDocsDashboard -State $state }
+      'Q' { break }
       default { Write-Host "Invalid selection" -ForegroundColor Red }
     }
   }
@@ -124,8 +127,8 @@ Supporting functions handle storage, logging, PATH rewrites, docs server orchest
 
 ## Adaptive State & Logging
 
-* **State file (`state.json`)** – Captures `lastSuccess`, `failureStreak`, Zig candidates, preferred browser, and the last known docs port.
-* **History array** – Stores the latest 50 actions with timestamps and success flags. The menu summarizes the last five entries at the top of every screen.
+* **State file (`state.json`)** – Tracks the last successful version and path, preferred execution mode (Windows vs. WSL), the failure counter per Zig version, the health dashboard threshold, preferred browser command, locale, and the most recent docs port.
+* **History array** – Stores the latest 50 actions with timestamps and success flags. The menu summarizes recent entries and the health dashboard colour-codes streaks.
 * **Logs** – Daily log files under `%LOCALAPPDATA%\ZigDocs\logs` record each action, making it easier to correlate PowerShell output with browser issues.
 
 Delete the state file if you want to reset recommendations, or archive the logs to share with teammates when debugging.
@@ -134,16 +137,16 @@ Delete the state file if you want to reset recommendations, or archive the logs 
 
 ## Automated Pipeline Output & Next Steps
 
-When you run option 6, the module reports each stage:
+When you run option 2, the module walks the detected versions in priority order (last known good first, then newest releases with the fewest failures) until it finds a Zig toolchain that can serve docs successfully:
 
 ```text
-Running automated pipeline...
-✔ Environment check passed
-✔ Docs server running at http://127.0.0.1:39999/
-✔ Diagnostics completed (sources.tar reachable)
+Testing C:\tools\zig\0.12.0\zig.exe
+Docs server running at http://127.0.0.1:39999/
+Testing C:\tools\zig\0.11.0\zig.exe
+Docs server failed: Known Windows regression: sources.tar failure
 ```
 
-If the Windows server fails, the failure streak increments and the next menu render will highlight the WSL fallback. Select option 4 to launch the same docs server under Linux userland while still using your Windows browser.
+Each failed attempt increments the per-version failure counter. Versions that exceed the configured threshold are skipped automatically until you lower the limit from the dashboard or record a later success. If the Windows server keeps failing, the summary banner recommends the WSL fallback (option 4), which uses mirrored networking when available and otherwise selects the correct IP from `hostname -I` inside the distribution.
 
 ---
 

--- a/tools/zig_docs_interactive.ps1
+++ b/tools/zig_docs_interactive.ps1
@@ -21,12 +21,24 @@ function Load-ZigDocsState {
   )
 
   $defaultState = [ordered]@{
-    lastSuccess      = $null
-    failureStreak    = 0
-    history          = @()
-    preferredBrowser = $null
-    lastPort         = $null
-    zigCandidates    = $ZigCandidates
+    lastSuccess            = $null
+    lastSuccessTimestamp   = $null
+    lastSuccessfulVersion  = $null
+    lastSuccessfulPath     = $null
+    lastSuccessfulMode     = "Windows"
+    failureStreak          = 0
+    history                = @()
+    preferredBrowser       = $null
+    lastPort               = $null
+    zigCandidates          = $ZigCandidates
+    versionFailures        = @{}
+    failureThreshold       = 3
+    totalSuccesses         = 0
+    totalFailures          = 0
+    lastStatus             = "unknown"
+    lastAttemptTimestamp   = $null
+    versionMetadata        = @{}
+    locale                 = "en-US"
   }
 
   if (Test-Path $StatePath) {
@@ -39,9 +51,32 @@ function Load-ZigDocsState {
             $state | Add-Member -NotePropertyName $key -NotePropertyValue $defaultState[$key]
           }
         }
-        if (-not $state.zigCandidates) {
-          $state.zigCandidates = $ZigCandidates
+        if (-not $state.zigCandidates) { $state.zigCandidates = $ZigCandidates }
+        $state.zigCandidates = @($state.zigCandidates | Where-Object { $_ })
+        if (-not $state.versionFailures) { $state.versionFailures = @{} }
+        elseif ($state.versionFailures -isnot [hashtable]) {
+          $converted = @{}
+          foreach ($prop in $state.versionFailures.PSObject.Properties) {
+            $converted[$prop.Name] = $prop.Value
+          }
+          $state.versionFailures = $converted
         }
+        if (-not $state.failureThreshold) { $state.failureThreshold = 3 }
+        if (-not $state.totalSuccesses) { $state.totalSuccesses = 0 }
+        if (-not $state.totalFailures) { $state.totalFailures = 0 }
+        if (-not $state.lastStatus) { $state.lastStatus = "unknown" }
+        if (-not $state.versionMetadata) { $state.versionMetadata = @{} }
+        elseif ($state.versionMetadata -isnot [hashtable]) {
+          $convertedMeta = @{}
+          foreach ($prop in $state.versionMetadata.PSObject.Properties) {
+            $convertedMeta[$prop.Name] = $prop.Value
+          }
+          $state.versionMetadata = $convertedMeta
+        }
+        if (-not $state.locale) { $state.locale = "en-US" }
+        if (-not $state.lastSuccessfulMode) { $state.lastSuccessfulMode = "Windows" }
+        if (-not $state.lastSuccessfulPath) { $state.lastSuccessfulPath = $null }
+        if (-not $state.lastSuccessTimestamp) { $state.lastSuccessTimestamp = $null }
         return $state
       }
     } catch {
@@ -73,12 +108,148 @@ function Write-ZigDocsLog {
   Add-Content -LiteralPath $LogPath -Value $entry
 }
 
+function Wait-ZigDocsUser {
+  param(
+    [string]$Message = "Press Enter to continue..."
+  )
+
+  [void](Read-Host $Message)
+}
+
+function Get-ZigDocsPlatform {
+  if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows)) {
+    return "Windows"
+  }
+  if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Linux)) {
+    return "Linux"
+  }
+  if ([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::OSX)) {
+    return "macOS"
+  }
+  return "Unknown"
+}
+
+function Get-ZigDocsPathSeparator {
+  if (Get-ZigDocsPlatform -eq "Windows") {
+    return ';'
+  }
+  return ':'
+}
+
+function Get-ZigDocsLocale {
+  param(
+    [pscustomobject]$State
+  )
+
+  if ($State.locale) {
+    return $State.locale
+  }
+  try {
+    return ([System.Globalization.CultureInfo]::CurrentCulture.Name)
+  } catch {
+    return "en-US"
+  }
+}
+
+function Get-ZigDocsLimitedDepthFiles {
+  param(
+    [string]$Root,
+    [string]$TargetName,
+    [int]$MaxDepth = 2
+  )
+
+  if (-not $Root) { return @() }
+
+  $resolvedRoot = $null
+  try {
+    $resolvedRoot = (Resolve-Path -LiteralPath $Root -ErrorAction Stop).Path
+  } catch {
+    $resolvedRoot = $Root
+  }
+
+  $queue = New-Object System.Collections.Queue
+  $queue.Enqueue([pscustomobject]@{ Path = $resolvedRoot; Depth = 0 })
+  $seen = @{}
+  $matches = @()
+
+  while ($queue.Count -gt 0) {
+    $current = $queue.Dequeue()
+    if (-not $current.Path) { continue }
+    if ($seen.ContainsKey($current.Path)) { continue }
+    $seen[$current.Path] = $true
+
+    try {
+      $children = Get-ChildItem -LiteralPath $current.Path -Force -ErrorAction Stop
+    } catch {
+      continue
+    }
+
+    foreach ($child in $children) {
+      if ($child.PSIsContainer) {
+        if ($current.Depth -lt $MaxDepth) {
+          $queue.Enqueue([pscustomobject]@{ Path = $child.FullName; Depth = $current.Depth + 1 })
+        }
+        continue
+      }
+
+      if ($child.Name -and $TargetName -and ($child.Name -ieq $TargetName)) {
+        $matches += $child.FullName
+      }
+    }
+  }
+
+  return $matches
+}
+
+function Get-ZigDocsBinaryMatches {
+  param(
+    [string]$Root,
+    [string]$BinaryName,
+    [int]$MaxDepth = 2
+  )
+
+  if (-not $Root) { return @() }
+
+  $items = @()
+  $hasWildcards = $Root -match '[\*\?]'
+
+  if ($hasWildcards) {
+    try {
+      $items = Get-ChildItem -Path $Root -Force -ErrorAction Stop
+    } catch {
+      return @()
+    }
+  } elseif (Test-Path $Root) {
+    try {
+      $items = @(Get-Item -LiteralPath $Root -Force -ErrorAction Stop)
+    } catch {
+      return @()
+    }
+  } else {
+    return @()
+  }
+
+  $matches = @()
+
+  foreach ($item in $items) {
+    if (-not $item) { continue }
+    if ($item.PSIsContainer) {
+      $matches += Get-ZigDocsLimitedDepthFiles -Root $item.FullName -TargetName $BinaryName -MaxDepth $MaxDepth
+    } elseif ($item.Name -and ($item.Name -ieq $BinaryName)) {
+      $matches += $item.FullName
+    }
+  }
+
+  return $matches
+}
+
 function Add-ZigDocsHistory {
   param(
     [pscustomobject]$State,
     [string]$Action,
     [bool]$Success,
-    [string]$Details = ""
+    [string]$Details = "",
+    [bool]$RecordStats = $true
   )
 
   $record = [ordered]@{
@@ -89,34 +260,513 @@ function Add-ZigDocsHistory {
   }
   $State.history = @($State.history + ([pscustomobject]$record) | Select-Object -Last 50)
 
-  if ($Success) {
-    $State.failureStreak = 0
-    $State.lastSuccess = $Action
-  } else {
-    $State.failureStreak++
+  if ($RecordStats) {
+    $State.lastAttemptTimestamp = $record.timestamp
+    if ($Success) {
+      $State.failureStreak = 0
+      $State.lastSuccess = $Action
+      $State.lastStatus = "success"
+      $State.totalSuccesses++
+      $State.lastSuccessTimestamp = $record.timestamp
+    } else {
+      $State.failureStreak++
+      $State.lastStatus = "failure"
+      $State.totalFailures++
+    }
   }
 }
 
-function Resolve-ZigExecutable {
+function Resolve-ZigCandidatePath {
   param(
-    [string[]]$Candidates
+    [string]$Candidate
   )
 
-  foreach ($candidate in $Candidates) {
-    if (-not $candidate) { continue }
-    if ($candidate -eq "zig") {
-      return $candidate
+  if (-not $Candidate) { return $null }
+  $platform = Get-ZigDocsPlatform
+  $binaryName = if ($platform -eq "Windows") { "zig.exe" } else { "zig" }
+
+  if ($Candidate -eq "zig") {
+    $cmd = Get-Command zig -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
+    return "zig"
+  }
+
+  if (-not (Test-Path $Candidate)) {
+    return $null
+  }
+
+  $item = Get-Item $Candidate
+  if ($item.PSIsContainer) {
+    $exe = Join-Path $Candidate $binaryName
+    if (Test-Path $exe) { return $exe }
+    return $null
+  }
+
+  if ($item.Name -ieq $binaryName) { return $item.FullName }
+  if ($platform -ne "Windows" -and $item.Extension -eq "") { return $item.FullName }
+  return $null
+}
+
+function Get-ZigVersionInfo {
+  param(
+    [string]$ZigPath
+  )
+
+  if (-not $ZigPath) { return $null }
+  try {
+    $versionOutput = (& $ZigPath version 2>$null).Trim()
+    if (-not $versionOutput) { return $null }
+    $parsed = $null
+    try {
+      $parsed = [version]$versionOutput
+    } catch {
+      $parsed = $null
     }
-    if (Test-Path $candidate) {
-      if ((Get-Item $candidate).PSIsContainer) {
-        $exe = Join-Path $candidate "zig.exe"
-        if (Test-Path $exe) { return $exe }
-      } elseif ($candidate.ToLower().EndsWith("zig.exe")) {
-        return $candidate
-      }
+    return [pscustomobject]@{
+      Raw    = $versionOutput
+      Parsed = $parsed
+    }
+  } catch {
+    return $null
+  }
+}
+
+function Get-ZigDocsCandidateKey {
+  param(
+    [string]$Path
+  )
+
+  if (-not $Path) { return $null }
+  if ($Path -eq "zig") { return "zig" }
+  try {
+    return [System.IO.Path]::GetFullPath($Path)
+  } catch {
+    return $Path
+  }
+}
+
+function Find-ZigDocsInstallations {
+  param(
+    [pscustomobject]$State,
+    [string[]]$AdditionalCandidates
+  )
+
+  $platform = Get-ZigDocsPlatform
+  $binaryName = if ($platform -eq "Windows") { "zig.exe" } else { "zig" }
+  $results = New-Object System.Collections.Generic.List[string]
+
+  foreach ($candidate in @($State.zigCandidates) + $AdditionalCandidates) {
+    if ($candidate) { $results.Add($candidate) }
+  }
+
+  if ($platform -eq "Windows") {
+    $searchRoots = @("C:\\tools\\zig")
+    if ($env:ProgramFiles) {
+      $searchRoots += @(Join-Path $env:ProgramFiles "zig", Join-Path $env:ProgramFiles "zig-*", Join-Path $env:ProgramFiles "Zig")
+    }
+    if (${env:ProgramFiles(x86)}) {
+      $searchRoots += @(Join-Path ${env:ProgramFiles(x86)} "zig", Join-Path ${env:ProgramFiles(x86)} "zig-*")
+    }
+    if ($env:LOCALAPPDATA) {
+      $searchRoots += @(Join-Path $env:LOCALAPPDATA "Programs\\zig")
+    }
+    $searchRoots = $searchRoots | Where-Object { $_ }
+
+    foreach ($root in $searchRoots) {
+      try {
+        $matches = Get-ZigDocsBinaryMatches -Root $root -BinaryName $binaryName -MaxDepth 2
+        foreach ($match in $matches) { $results.Add($match) }
+      } catch {}
+    }
+  } else {
+    $searchPaths = @(
+      "/usr/local/bin/zig",
+      "/usr/bin/zig",
+      (Join-Path $HOME "zig"),
+      (Join-Path $HOME ".local/bin/zig"),
+      (Join-Path $HOME "tools/zig"),
+      (Join-Path $HOME "Downloads/zig")
+    ) | Where-Object { $_ }
+
+    foreach ($path in $searchPaths) {
+      if (Test-Path $path) { $results.Add($path) }
     }
   }
-  return "zig"
+
+  return $results.ToArray() | Where-Object { $_ } | Select-Object -Unique
+}
+
+function Remove-ZigDocsCandidate {
+  param(
+    [pscustomobject]$State,
+    [pscustomobject]$Candidate
+  )
+
+  if (-not $State -or -not $Candidate) { return }
+
+  $key = $Candidate.Key
+  if (-not $key) { return }
+
+  $State.zigCandidates = @(
+    $State.zigCandidates | ForEach-Object {
+      $resolved = Resolve-ZigCandidatePath -Candidate $_
+      $candidateKey = Get-ZigDocsCandidateKey -Path $resolved
+      if ($candidateKey -ne $key) { $_ }
+    }
+  )
+
+  if ($State.versionFailures.ContainsKey($key)) { $State.versionFailures.Remove($key) }
+  if ($State.versionMetadata.ContainsKey($key)) { $State.versionMetadata.Remove($key) }
+
+  if ($State.lastSuccessfulVersion -eq $key) {
+    $State.lastSuccessfulVersion = $null
+    $State.lastSuccessfulPath = $null
+  }
+}
+
+function Get-ZigDocsCandidates {
+  param(
+    [pscustomobject]$State,
+    [string[]]$AdditionalCandidates
+  )
+
+  $rawCandidates = Find-ZigDocsInstallations -State $State -AdditionalCandidates $AdditionalCandidates
+  $platform = Get-ZigDocsPlatform
+  $list = @()
+
+  foreach ($candidate in $rawCandidates) {
+    $resolved = Resolve-ZigCandidatePath -Candidate $candidate
+    if (-not $resolved) { continue }
+    $key = Get-ZigDocsCandidateKey -Path $resolved
+    if (-not $key) { continue }
+    $versionInfo = $null
+    $versionRaw = $null
+    $versionParsed = $null
+    if ($State.versionMetadata.ContainsKey($key)) {
+      $cached = $State.versionMetadata[$key]
+      if ($cached -and $cached.version) {
+        $versionRaw = $cached.version
+        try { $versionParsed = [version]$cached.version } catch {}
+      }
+    }
+    if (-not $versionRaw) {
+      $info = Get-ZigVersionInfo -ZigPath $resolved
+      if ($info) {
+        $versionRaw = $info.Raw
+        $versionParsed = $info.Parsed
+      }
+      if (-not $State.versionMetadata.ContainsKey($key)) {
+        $State.versionMetadata[$key] = @{ path = $resolved; version = $versionRaw }
+      } else {
+        $State.versionMetadata[$key].path = $resolved
+        $State.versionMetadata[$key].version = $versionRaw
+      }
+    }
+    $failureCount = 0
+    if ($State.versionFailures.ContainsKey($key)) {
+      $failureCount = [int]$State.versionFailures[$key]
+    }
+    $list += [pscustomobject]@{
+      Path          = $resolved
+      Key           = $key
+      Version       = $versionRaw
+      VersionParsed = $versionParsed
+      FailureCount  = $failureCount
+      Skip          = ($failureCount -ge [int]$State.failureThreshold)
+      Platform      = $platform
+    }
+  }
+
+  return $list | Sort-Object -Property Path -Unique
+}
+
+function Sort-ZigDocsCandidates {
+  param(
+    [pscustomobject]$State,
+    [pscustomobject[]]$Candidates
+  )
+
+  $ordered = $Candidates | Sort-Object -Property @(
+    @{ Expression = { if ($_.Skip) { 1 } else { 0 } } },
+    @{ Expression = { if ($State.lastSuccessfulVersion -and ($_.Key -eq $State.lastSuccessfulVersion)) { 0 } else { 1 } } },
+    @{ Expression = { $_.FailureCount } },
+    @{ Expression = { if ($_.VersionParsed) { $_.VersionParsed } else { [version]::new(0,0) } }; Descending = $true }
+  )
+
+  return $ordered
+}
+
+function Get-ZigDocsLastGoodCandidate {
+  param(
+    [pscustomobject]$State,
+    [pscustomobject[]]$Candidates
+  )
+
+  if ($State.lastSuccessfulVersion) {
+    $match = $Candidates | Where-Object { $_.Key -eq $State.lastSuccessfulVersion -and -not $_.Skip }
+    if ($match) { return $match | Select-Object -First 1 }
+  }
+  return ($Candidates | Where-Object { -not $_.Skip } | Select-Object -First 1)
+}
+
+function Update-ZigDocsVersionOutcome {
+  param(
+    [pscustomobject]$State,
+    [pscustomobject]$Candidate,
+    [bool]$Success,
+    [string]$Mode,
+    [string]$Details = ""
+  )
+
+  if (-not $Candidate) { return }
+  $key = $Candidate.Key
+  if (-not $State.versionFailures.ContainsKey($key)) { $State.versionFailures[$key] = 0 }
+
+  if ($Success) {
+    $State.versionFailures[$key] = 0
+    $State.lastSuccessfulVersion = $key
+    $State.lastSuccessfulPath = $Candidate.Path
+    $State.lastSuccessfulMode = $Mode
+    if ($Candidate.Version) {
+      $State.versionMetadata[$key] = @{ path = $Candidate.Path; version = $Candidate.Version }
+    }
+  } else {
+    $State.versionFailures[$key] = ([int]$State.versionFailures[$key]) + 1
+  }
+
+  $detailsValue = if ([string]::IsNullOrWhiteSpace($Details)) { $Candidate.Path } else { $Details }
+  Add-ZigDocsHistory -State $State -Action "Attempt-$Mode" -Success $Success -Details $detailsValue
+}
+
+function Launch-ZigDocsBrowser {
+  param(
+    [pscustomobject]$State,
+    [string]$Url,
+    [string]$LogPath
+  )
+
+  if (-not $Url) { return }
+
+  $locale = Get-ZigDocsLocale -State $State
+  $platform = Get-ZigDocsPlatform
+  $candidates = @()
+
+  function Convert-BrowserCommand {
+    param([string]$Command)
+    if (-not $Command) { return $null }
+    $parts = [System.Management.Automation.PSParser]::Tokenize($Command, [ref]$null) | Where-Object { $_.Type -eq 'String' -or $_.Type -eq 'CommandArgument' }
+    $values = @()
+    foreach ($part in $parts) { $values += $part.Content }
+    if ($values.Count -eq 0) { return $null }
+    $args = @()
+    if ($values.Count -gt 1) { $args = $values[1..($values.Count-1)] }
+    return [pscustomobject]@{ Command = $values[0]; Args = $args }
+  }
+
+  $preferred = Convert-BrowserCommand -Command $State.preferredBrowser
+  if ($preferred) { $candidates += $preferred }
+
+  if ($platform -eq "Windows") {
+    $candidates += @(
+      @{ Command = "chrome.exe"; Args = @("--incognito", "--lang=$locale") },
+      @{ Command = "msedge.exe"; Args = @("--inprivate", "--lang=$locale") },
+      @{ Command = "firefox.exe"; Args = @("-private-window", "--lang=$locale") }
+    )
+  } elseif ($platform -eq "macOS") {
+    $candidates += @(
+      @{ Command = "open"; Args = @("-a", "Google Chrome", "--args", "--incognito", "--lang=$locale") },
+      @{ Command = "open"; Args = @("-a", "Microsoft Edge", "--args", "--inprivate", "--lang=$locale") },
+      @{ Command = "open"; Args = @("-a", "Firefox", "--args", "-private-window", "--lang=$locale") }
+    )
+  } else {
+    $candidates += @(
+      @{ Command = "google-chrome"; Args = @("--incognito", "--lang=$locale") },
+      @{ Command = "chromium"; Args = @("--incognito", "--lang=$locale") },
+      @{ Command = "firefox"; Args = @("-private-window", "--lang=$locale") },
+      @{ Command = "xdg-open"; Args = @() }
+    )
+  }
+
+  foreach ($browser in $candidates) {
+    if (-not $browser) { continue }
+    $command = $browser.Command
+    $args = @()
+    if ($browser.Args) { $args += $browser.Args }
+    $args += $Url
+
+    $canLaunch = $true
+    if ($command -ne "open" -and $command -ne "xdg-open" -and $command -ne "zig" -and $command -notlike "*\\" -and $command -notlike "*/*") {
+      $cmd = Get-Command $command -ErrorAction SilentlyContinue
+      if (-not $cmd) {
+        $canLaunch = $false
+      } elseif ($cmd.Source) {
+        $command = $cmd.Source
+      }
+    } elseif ((Test-Path $command) -eq $false -and ($command -ne "open") -and ($command -ne "xdg-open")) {
+      $canLaunch = $false
+    }
+
+    if (-not $canLaunch) { continue }
+
+    try {
+      Start-Process -FilePath $command -ArgumentList $args -WindowStyle Normal | Out-Null
+      Write-ZigDocsLog -LogPath $LogPath -Message "Browser launch via $command" -Level "INFO"
+      return
+    } catch {
+      Write-ZigDocsLog -LogPath $LogPath -Message "Browser launch failed for $command: $($_.Exception.Message)" -Level "WARN"
+    }
+  }
+
+  try {
+    Start-Process $Url | Out-Null
+    Write-ZigDocsLog -LogPath $LogPath -Message "Browser fallback via shell" -Level "INFO"
+  } catch {
+    Write-ZigDocsLog -LogPath $LogPath -Message "Browser fallback failed: $($_.Exception.Message)" -Level "ERROR"
+  }
+}
+
+function Get-ZigDocsErrorPatterns {
+  return @(
+    @{ Regex = 'unable to serve /sources\.tar'; Reason = 'Known Windows regression: sources.tar failure' },
+    @{ Regex = 'Access is denied'; Reason = 'Access denied while serving docs' },
+    @{ Regex = 'error:.*ListenError'; Reason = 'Port binding failure' }
+  )
+}
+
+function Detect-ZigDocsKnownError {
+  param(
+    [string]$Content
+  )
+
+  if (-not $Content) { return $null }
+  foreach ($pattern in Get-ZigDocsErrorPatterns) {
+    if ($Content -match $pattern.Regex) {
+      return $pattern.Reason
+    }
+  }
+  return $null
+}
+
+function Test-WslMirroredNetworking {
+  try {
+    $status = wsl.exe --status 2>$null
+    if (-not $status) { return $false }
+    if ($status -match 'Mirrored networking:\s*Enabled') { return $true }
+    if ($status -match 'Default Version:\s*2') { return $true }
+  } catch {}
+  return $false
+}
+
+function Get-WslHostAddress {
+  try {
+    $addresses = wsl.exe -e sh -lc "hostname -I" 2>$null
+    if ($addresses) {
+      $first = ($addresses -split '\s+')[0]
+      if ($first) { return $first }
+    }
+  } catch {}
+  return "127.0.0.1"
+}
+
+function Format-ZigDocsTimestamp {
+  param(
+    [string]$Timestamp
+  )
+
+  if (-not $Timestamp) { return "Never" }
+  try {
+    $dt = [DateTime]::Parse($Timestamp)
+    return $dt.ToLocalTime().ToString("MM/dd/yyyy hh:mm tt", [System.Globalization.CultureInfo]::GetCultureInfo("en-US"))
+  } catch {
+    return $Timestamp
+  }
+}
+
+function Show-ZigDocsDashboard {
+  param(
+    [pscustomobject]$State
+  )
+
+  Clear-Host
+  Write-Host "Zig Docs Health Dashboard" -ForegroundColor Cyan
+  Write-Host "==========================="
+
+  $statusColor = "Yellow"
+  if ($State.failureStreak -ge $State.failureThreshold) {
+    $statusColor = "Red"
+  } elseif ($State.lastStatus -eq "success") {
+    $statusColor = "Green"
+  }
+
+  $statusLine = "Status: $($State.lastStatus.ToUpper())"
+  Write-Host $statusLine -ForegroundColor $statusColor
+
+  Write-Host "Last success: $(Format-ZigDocsTimestamp -Timestamp $State.lastSuccessTimestamp)" -ForegroundColor Green
+  if ($State.lastSuccessfulPath) {
+    Write-Host "Last good version: $($State.lastSuccessfulPath)" -ForegroundColor Green
+  }
+  Write-Host "Last mode: $($State.lastSuccessfulMode)" -ForegroundColor Cyan
+  Write-Host "Total successes: $($State.totalSuccesses)" -ForegroundColor Green
+  Write-Host "Total failures: $($State.totalFailures)" -ForegroundColor Yellow
+
+  if ($State.versionFailures.Count -gt 0) {
+    Write-Host "Failure counters (skip after $($State.failureThreshold)):" -ForegroundColor Yellow
+    foreach ($entry in $State.versionFailures.GetEnumerator() | Sort-Object -Property Value -Descending) {
+      $metadata = $null
+      if ($State.versionMetadata.ContainsKey($entry.Key)) {
+        $metadata = $State.versionMetadata[$entry.Key]
+      }
+      $label = if ($metadata -and $metadata.version) { "[$($metadata.version)] $($metadata.path)" } else { $entry.Key }
+      $color = if ($entry.Value -ge $State.failureThreshold) { "Red" } else { "Yellow" }
+      Write-Host "  $label => $($entry.Value) failures" -ForegroundColor $color
+    }
+  }
+
+  $browserLabel = if ([string]::IsNullOrWhiteSpace($State.preferredBrowser)) { 'auto' } else { $State.preferredBrowser }
+  Write-Host "Preferred browser: $browserLabel" -ForegroundColor Cyan
+  Write-Host "Locale: $(Get-ZigDocsLocale -State $State)" -ForegroundColor Cyan
+
+  if ($State.history.Count -gt 0) {
+    Write-Host "Recent activity:" -ForegroundColor Cyan
+    $State.history | Select-Object -Last 5 | ForEach-Object {
+      $flag = if ($_.success) { "✔" } else { "✖" }
+      Write-Host "  $flag [$($_.timestamp)] $($_.action) — $($_.details)"
+    }
+  }
+
+  Write-Host ""
+  Write-Host "Options:" -ForegroundColor Cyan
+  Write-Host "  [B] Update preferred browser"
+  Write-Host "  [T] Adjust failure threshold (current: $($State.failureThreshold))"
+  Write-Host "  [Enter] Return to menu"
+
+  $choice = Read-Host "Select"
+  switch -Regex ($choice) {
+    '^[Bb]$' {
+      $browser = Read-Host "Enter browser command (leave blank for auto)"
+      if ([string]::IsNullOrWhiteSpace($browser)) {
+        $State.preferredBrowser = $null
+        Write-Host "Preferred browser cleared." -ForegroundColor Yellow
+      } else {
+        $State.preferredBrowser = $browser
+        Write-Host "Preferred browser set to $browser" -ForegroundColor Green
+      }
+      Wait-ZigDocsUser
+    }
+    '^[Tt]$' {
+      $value = Read-Host "Enter new failure threshold"
+      if ($value -as [int]) {
+        $State.failureThreshold = [int]$value
+        Write-Host "Failure threshold updated to $value" -ForegroundColor Green
+      } else {
+        Write-Host "Invalid threshold" -ForegroundColor Red
+      }
+      Wait-ZigDocsUser
+    }
+    default {
+      # no-op, return
+    }
+  }
 }
 
 function Invoke-ZigDocsEnvironmentCheck {
@@ -138,46 +788,6 @@ function Invoke-ZigDocsEnvironmentCheck {
   }
 }
 
-function Invoke-ZigDocsVersionSwitch {
-  param(
-    [pscustomobject]$State,
-    [string]$LogPath
-  )
-
-  $options = @($State.zigCandidates | Where-Object { $_ })
-  if (-not $options) {
-    $options = @("zig")
-  }
-  Write-Host "Available Zig locations:" -ForegroundColor Cyan
-  for ($i = 0; $i -lt $options.Count; $i++) {
-    Write-Host "[$($i + 1)] $($options[$i])"
-  }
-  Write-Host "[A] Add new location"
-  $choice = Read-Host "Select option"
-
-  if ($choice -match '^[Aa]$') {
-    $newPath = Read-Host "Enter full path to Zig folder or zig.exe"
-    if ($newPath) {
-      $State.zigCandidates = @($newPath) + $State.zigCandidates
-      Write-ZigDocsLog -LogPath $LogPath -Message "Added Zig candidate '$newPath'" -Level "INFO"
-      return Resolve-ZigExecutable -Candidates @($newPath)
-    }
-    return $null
-  }
-
-  if ($choice -as [int]) {
-    $index = [int]$choice - 1
-    if ($index -ge 0 -and $index -lt $options.Count) {
-      $selected = $options[$index]
-      Write-ZigDocsLog -LogPath $LogPath -Message "Selected Zig candidate '$selected'" -Level "INFO"
-      return Resolve-ZigExecutable -Candidates @($selected)
-    }
-  }
-
-  Write-Warning "No Zig path selected."
-  return $null
-}
-
 function Update-PathForZig {
   param(
     [string]$ZigPath,
@@ -187,8 +797,9 @@ function Update-PathForZig {
   if (-not $ZigPath) { return }
   if (Test-Path $ZigPath) {
     $dir = if ((Get-Item $ZigPath).PSIsContainer) { $ZigPath } else { Split-Path $ZigPath }
-    $clean = ($env:PATH -split ';' | Where-Object { $_ -and ($_ -notlike '*\\zig\\*') }) -join ';'
-    $env:PATH = "$dir;" + $clean
+    $separator = Get-ZigDocsPathSeparator
+    $clean = ($env:PATH -split [regex]::Escape($separator) | Where-Object { $_ -and ($_ -notlike '*zig*') }) -join $separator
+    $env:PATH = "$dir$separator" + $clean
     Write-Host "PATH updated for $dir" -ForegroundColor Green
     Write-ZigDocsLog -LogPath $LogPath -Message "PATH updated for '$dir'" -Level "INFO"
   } else {
@@ -212,11 +823,16 @@ function Invoke-ZigDocsServerWindows {
   Write-Host "Launching Zig docs server on Windows..." -ForegroundColor Cyan
   Write-ZigDocsLog -LogPath $LogPath -Message "Starting Windows docs server via '$ZigExe'" -Level "INFO"
 
-  $proc = Start-Process -FilePath $ZigExe -ArgumentList "std","--no-open-browser" -RedirectStandardOutput $logFile -RedirectStandardError $errFile -PassThru
+  $arguments = @("std", "--no-open-browser")
+  $proc = Start-Process -FilePath $ZigExe -ArgumentList $arguments -RedirectStandardOutput $logFile -RedirectStandardError $errFile -PassThru
 
   $url = $null
+  $failureReason = $null
   for ($i = 0; $i -lt 30; $i++) {
     Start-Sleep -Seconds 1
+    if ($proc.HasExited) {
+      break
+    }
     if (Test-Path $logFile) {
       $content = Get-Content -LiteralPath $logFile -Raw
       $match = [regex]::Match($content, 'http://127\.0\.0\.1:(?<port>\d+)/')
@@ -225,19 +841,37 @@ function Invoke-ZigDocsServerWindows {
         $State.lastPort = $match.Groups['port'].Value
         break
       }
+      $detected = Detect-ZigDocsKnownError -Content $content
+      if ($detected) {
+        $failureReason = $detected
+        break
+      }
+    }
+    if (Test-Path $errFile) {
+      $errContent = Get-Content -LiteralPath $errFile -Raw
+      $detected = Detect-ZigDocsKnownError -Content $errContent
+      if ($detected) {
+        $failureReason = $detected
+        break
+      }
     }
   }
 
-  if ($url) {
+  if ($url -and -not $failureReason) {
     Write-Host "Docs server running at $url" -ForegroundColor Green
     Write-ZigDocsLog -LogPath $LogPath -Message "Docs server detected at $url (PID $($proc.Id))" -Level "INFO"
-    $browser = $State.preferredBrowser
-    if ($browser) {
-      Start-Process $browser $url
-    } else {
-      Start-Process $url
-    }
+    Launch-ZigDocsBrowser -State $State -Url $url -LogPath $LogPath
     return @{ success = $true; pid = $proc.Id; url = $url }
+  }
+
+  if (-not $proc.HasExited) {
+    try { $proc | Stop-Process -Force } catch {}
+  }
+
+  if ($failureReason) {
+    Write-Warning "Docs server failed: $failureReason"
+    Write-ZigDocsLog -LogPath $LogPath -Message "Docs server failure: $failureReason" -Level "ERROR"
+    return @{ success = $false; pid = $proc.Id; url = $null; error = $failureReason }
   }
 
   Write-Warning "Unable to detect docs server URL. See $errFile for details."
@@ -254,22 +888,40 @@ function Invoke-ZigDocsServerWsl {
   Write-Host "Launching Zig docs server inside WSL..." -ForegroundColor Cyan
   Write-ZigDocsLog -LogPath $LogPath -Message "Starting WSL docs server" -Level "INFO"
   try {
-    $output = wsl zig std --no-open-browser 2>&1
-    $match = [regex]::Match($output, 'http://127\.0\.0\.1:(?<port>\d+)/')
-    if (-not $match.Success) {
-      $match = [regex]::Match($output, 'http://(?<host>[\d\.]+):(?<port>\d+)/')
-    }
+    $output = wsl.exe zig std --no-open-browser 2>&1
+    $match = [regex]::Match($output, 'http://(?<host>[\d\.]+):(?<port>\d+)/')
+    $host = $null
+    $port = $null
     if ($match.Success) {
-      $url = $match.Value
-      $State.lastPort = $match.Groups['port'].Value
-      Write-Host "WSL docs server running at $url" -ForegroundColor Green
-      Write-ZigDocsLog -LogPath $LogPath -Message "WSL docs server ready at $url" -Level "INFO"
-      Start-Process $url
-      return $true
+      $host = if ($match.Groups['host'].Value) { $match.Groups['host'].Value } else { '127.0.0.1' }
+      $port = $match.Groups['port'].Value
+    } else {
+      $match = [regex]::Match($output, 'http://127\.0\.0\.1:(?<port>\d+)/')
+      if ($match.Success) {
+        $host = '127.0.0.1'
+        $port = $match.Groups['port'].Value
+      }
     }
-    Write-Warning "Unable to parse docs server URL from WSL output."
-    Write-ZigDocsLog -LogPath $LogPath -Message "Could not parse WSL docs server output" -Level "ERROR"
-    return $false
+
+    if (-not $port) {
+      Write-Warning "Unable to parse docs server URL from WSL output."
+      Write-ZigDocsLog -LogPath $LogPath -Message "Could not parse WSL docs server output" -Level "ERROR"
+      return $false
+    }
+
+    $mirrored = Test-WslMirroredNetworking
+    if ($mirrored) {
+      $host = '127.0.0.1'
+    } elseif (-not $host -or $host -eq '127.0.0.1') {
+      $host = Get-WslHostAddress
+    }
+
+    $url = "http://$host:$port/"
+    $State.lastPort = $port
+    Write-Host "WSL docs server running at $url" -ForegroundColor Green
+    Write-ZigDocsLog -LogPath $LogPath -Message "WSL docs server ready at $url (mirrored: $mirrored)" -Level "INFO"
+    Launch-ZigDocsBrowser -State $State -Url $url -LogPath $LogPath
+    return $true
   } catch {
     Write-Warning "WSL docs server failed: $($_.Exception.Message)"
     Write-ZigDocsLog -LogPath $LogPath -Message "WSL docs server error: $($_.Exception.Message)" -Level "ERROR"
@@ -313,45 +965,85 @@ function Invoke-ZigDocsDiagnostics {
   Write-ZigDocsLog -LogPath $LogPath -Message "Diagnostics executed" -Level "INFO"
 }
 
+function Invoke-ZigDocsWindowsSession {
+  param(
+    [pscustomobject]$State,
+    [pscustomobject]$Candidate,
+    [string]$LogPath
+  )
+
+  if (-not $Candidate) {
+    Write-Warning "No Zig candidate available."
+    return @{ success = $false; message = "No candidate" }
+  }
+
+  Update-PathForZig -ZigPath $Candidate.Path -LogPath $LogPath
+  $envSuccess = Invoke-ZigDocsEnvironmentCheck -ZigExe $Candidate.Path -LogPath $LogPath
+  Add-ZigDocsHistory -State $State -Action "Environment" -Success $envSuccess -Details $Candidate.Path -RecordStats:$false
+  if (-not $envSuccess) {
+    Update-ZigDocsVersionOutcome -State $State -Candidate $Candidate -Success $false -Mode "Windows" -Details "Environment check failed"
+    return @{ success = $false; message = "Environment check failed" }
+  }
+
+  $result = Invoke-ZigDocsServerWindows -ZigExe $Candidate.Path -State $State -LogPath $LogPath
+  $detail = if ($result.url) { $result.url } elseif ($result.error) { $result.error } else { $null }
+  Update-ZigDocsVersionOutcome -State $State -Candidate $Candidate -Success $result.success -Mode "Windows" -Details $detail
+  $message = if ($result.success) { $result.url } elseif ($result.error) { $result.error } else { "Launch failed" }
+  return @{ success = $result.success; message = $message; candidate = $Candidate; url = $result.url }
+}
+
 function Invoke-ZigDocsAutomatedPipeline {
   param(
     [pscustomobject]$State,
-    [string]$ZigExe,
+    [pscustomobject]$Candidate,
     [string]$LogPath
   )
 
   Write-Host "Running automated pipeline..." -ForegroundColor Cyan
   $results = @()
-  $results += @{ stage = "environment"; success = Invoke-ZigDocsEnvironmentCheck -ZigExe $ZigExe -LogPath $LogPath }
-  if (-not $results[-1].success) {
+  $envSuccess = Invoke-ZigDocsEnvironmentCheck -ZigExe $Candidate.Path -LogPath $LogPath
+  $results += @{ stage = "environment"; success = $envSuccess }
+  if (-not $envSuccess) {
+    Update-ZigDocsVersionOutcome -State $State -Candidate $Candidate -Success $false -Mode "Windows" -Details "Environment check failed"
     return $results
   }
-  $server = Invoke-ZigDocsServerWindows -ZigExe $ZigExe -State $State -LogPath $LogPath
+  $server = Invoke-ZigDocsServerWindows -ZigExe $Candidate.Path -State $State -LogPath $LogPath
   $results += @{ stage = "docs-server"; success = $server.success }
   if (-not $server.success) {
+    $detail = if ($server.error) { $server.error } else { "Launch failed" }
+    Update-ZigDocsVersionOutcome -State $State -Candidate $Candidate -Success $false -Mode "Windows" -Details $detail
     return $results
   }
   Invoke-ZigDocsDiagnostics -State $State -LogPath $LogPath
   $results += @{ stage = "diagnostics"; success = $true }
+  Update-ZigDocsVersionOutcome -State $State -Candidate $Candidate -Success $true -Mode "Windows" -Details $server.url
   return $results
 }
 
 function Show-ZigDocsSummary {
   param(
-    [pscustomobject]$State
+    [pscustomobject]$State,
+    [pscustomobject[]]$Candidates
   )
 
-  if ($State.history.Count -gt 0) {
-    Write-Host "Recent activity:" -ForegroundColor Cyan
-    $State.history | Select-Object -Last 5 | ForEach-Object {
-      $flag = if ($_.success) { "✔" } else { "✖" }
-      Write-Host "$flag [$($_.timestamp)] $($_.action) — $($_.details)"
+  $statusColor = if ($State.lastStatus -eq "success") { "Green" } elseif ($State.failureStreak -ge $State.failureThreshold) { "Red" } else { "Yellow" }
+  Write-Host "Status: $($State.lastStatus) (failures in a row: $($State.failureStreak))" -ForegroundColor $statusColor
+  if ($State.lastSuccessfulPath) {
+    Write-Host "Last good path: $($State.lastSuccessfulPath)" -ForegroundColor Green
+  }
+  if ($Candidates -and $Candidates.Count -gt 0) {
+    $nextCandidate = Get-ZigDocsLastGoodCandidate -State $State -Candidates $Candidates
+    if ($nextCandidate) {
+      $label = if ($nextCandidate.Version) { $nextCandidate.Version } else { "unknown" }
+      Write-Host "Next candidate: $label ($($nextCandidate.Path))" -ForegroundColor Cyan
     }
   }
-  if ($State.failureStreak -ge 2) {
-    Write-Host "Multiple failures detected. Consider using option 4 (WSL fallback)." -ForegroundColor Yellow
-  } elseif ($State.lastSuccess) {
-    Write-Host "Last success: $($State.lastSuccess)" -ForegroundColor Green
+  if ($State.history.Count -gt 0) {
+    Write-Host "Recent activity:" -ForegroundColor Cyan
+    $State.history | Select-Object -Last 3 | ForEach-Object {
+      $flag = if ($_.success) { "✔" } else { "✖" }
+      Write-Host "  $flag [$($_.timestamp)] $($_.action) — $($_.details)"
+    }
   }
 }
 
@@ -364,80 +1056,168 @@ function Zig-DocsInteractive {
   $state = Load-ZigDocsState -StatePath $storage.StatePath -ZigCandidates $ZigCandidates
   $state | Add-Member -MemberType NoteProperty -Name BaseDir -Value $storage.BaseDir -Force
 
-  $zigExe = Resolve-ZigExecutable -Candidates $state.zigCandidates
-
   while ($true) {
+    $candidates = Get-ZigDocsCandidates -State $state -AdditionalCandidates $ZigCandidates
+    $sorted = Sort-ZigDocsCandidates -State $state -Candidates $candidates
+
     Clear-Host
-    Write-Host "Zig Docs Interactive Menu" -ForegroundColor Cyan
-    Write-Host "=========================="
-    Write-Host "1. Check Environment"
-    Write-Host "2. Switch Zig Version"
-    Write-Host "3. Run Docs Server (Windows)"
-    Write-Host "4. Run Docs Server (WSL)"
-    Write-Host "5. Diagnostics & Network Tests"
-    Write-Host "6. Full Automated Pipeline"
-    Write-Host "7. Set Preferred Browser"
-    Write-Host "8. Exit"
-    Show-ZigDocsSummary -State $state
+    Write-Host "Zig Docs Interactive" -ForegroundColor Cyan
+    Write-Host "====================="
+    Write-Host "1. Run docs server with last known good version"
+    Write-Host "2. Try all versions automatically"
+    Write-Host "3. Choose a version manually"
+    Write-Host "4. Run in WSL fallback"
+    Write-Host "5. Show health dashboard"
+    Write-Host "Q. Exit"
+    Show-ZigDocsSummary -State $state -Candidates $sorted
+
     $choice = Read-Host "Select an option"
 
-    switch ($choice) {
+    switch ($choice.ToUpperInvariant()) {
       '1' {
-        $success = Invoke-ZigDocsEnvironmentCheck -ZigExe $zigExe -LogPath $storage.LogPath
-        Add-ZigDocsHistory -State $state -Action "Environment" -Success $success -Details $zigExe
-        Pause
+        $candidate = Get-ZigDocsLastGoodCandidate -State $state -Candidates $sorted
+        if (-not $candidate) {
+          Write-Warning "No eligible Zig versions detected."
+          Wait-ZigDocsUser
+          continue
+        }
+        $result = Invoke-ZigDocsWindowsSession -State $state -Candidate $candidate -LogPath $storage.LogPath
+        if ($result.success) {
+          Write-Host $result.message -ForegroundColor Green
+        } else {
+          Write-Host $result.message -ForegroundColor Yellow
+        }
+        Wait-ZigDocsUser
       }
       '2' {
-        $newExe = Invoke-ZigDocsVersionSwitch -State $state -LogPath $storage.LogPath
-        if ($newExe) {
-          Update-PathForZig -ZigPath $newExe -LogPath $storage.LogPath
-          $zigExe = Resolve-ZigExecutable -Candidates @($newExe)
-          Add-ZigDocsHistory -State $state -Action "Switch" -Success $true -Details $zigExe
+        $success = $false
+        foreach ($candidate in $sorted) {
+          if ($candidate.Skip) { continue }
+          Write-Host "Testing $($candidate.Path)" -ForegroundColor Cyan
+          $result = Invoke-ZigDocsWindowsSession -State $state -Candidate $candidate -LogPath $storage.LogPath
+          if ($result.success) {
+            Write-Host "Success with $($candidate.Path)" -ForegroundColor Green
+            $success = $true
+            break
+          } else {
+            Write-Host "Failed: $($result.message)" -ForegroundColor Yellow
+          }
         }
-        Pause
+        if (-not $success) {
+          Write-Warning "No Zig version completed successfully."
+        }
+        Wait-ZigDocsUser
       }
       '3' {
-        Update-PathForZig -ZigPath $zigExe -LogPath $storage.LogPath
-        $result = Invoke-ZigDocsServerWindows -ZigExe $zigExe -State $state -LogPath $storage.LogPath
-        Add-ZigDocsHistory -State $state -Action "Docs-Windows" -Success $result.success -Details $result.url
-        Pause
+        $manualLoop = $true
+        while ($manualLoop) {
+          $manualCandidates = Sort-ZigDocsCandidates -State $state -Candidates (Get-ZigDocsCandidates -State $state -AdditionalCandidates $ZigCandidates)
+          if (-not $manualCandidates -or $manualCandidates.Count -eq 0) {
+            Write-Warning "No Zig versions available."
+            Wait-ZigDocsUser
+            break
+          }
+
+          Clear-Host
+          Write-Host "Manual Candidate Selection" -ForegroundColor Cyan
+          Write-Host "=========================="
+          for ($i = 0; $i -lt $manualCandidates.Count; $i++) {
+            $candidate = $manualCandidates[$i]
+            $indicator = if ($candidate.Skip) { "(skipped)" } elseif ($candidate.Key -eq $state.lastSuccessfulVersion) { "(last good)" } else { "" }
+            $versionLabel = if ($candidate.Version) { $candidate.Version } else { "unknown" }
+            Write-Host "[$($i + 1)] $versionLabel — $($candidate.Path) $indicator"
+          }
+          Write-Host "[A] Add new location" -ForegroundColor Cyan
+          Write-Host "[D] Delete a location" -ForegroundColor Cyan
+          Write-Host "[R] Refresh detection" -ForegroundColor Cyan
+          Write-Host "[Enter] Return to main menu" -ForegroundColor Cyan
+
+          $manual = Read-Host "Select version"
+          $choiceValue = $manual.ToUpperInvariant()
+
+          if ([string]::IsNullOrWhiteSpace($manual)) {
+            $manualLoop = $false
+            break
+          } elseif ($choiceValue -eq 'A') {
+            $newPath = (Read-Host "Enter full path to Zig folder or executable").Trim()
+            if (-not [string]::IsNullOrWhiteSpace($newPath)) {
+              $state.zigCandidates = @($newPath) + ($state.zigCandidates | Where-Object { $_ -ne $newPath })
+              $resolved = Resolve-ZigCandidatePath -Candidate $newPath
+              $key = Get-ZigDocsCandidateKey -Path $resolved
+              if ($resolved -and $key) {
+                $info = Get-ZigVersionInfo -ZigPath $resolved
+                if ($info) {
+                  $state.versionMetadata[$key] = @{ path = $resolved; version = $info.Raw }
+                }
+              }
+              Write-ZigDocsLog -LogPath $storage.LogPath -Message "Added manual Zig candidate $newPath" -Level "INFO"
+              Add-ZigDocsHistory -State $state -Action "Candidate-Add" -Success $true -Details $newPath -RecordStats:$false
+              Write-Host "Candidate added." -ForegroundColor Green
+              Wait-ZigDocsUser
+            }
+          } elseif ($choiceValue -eq 'D') {
+            $removeInput = Read-Host "Enter the number of the candidate to delete"
+            if ($removeInput -as [int]) {
+              $removeIndex = [int]$removeInput - 1
+              if ($removeIndex -ge 0 -and $removeIndex -lt $manualCandidates.Count) {
+                $target = $manualCandidates[$removeIndex]
+                Remove-ZigDocsCandidate -State $state -Candidate $target
+                Write-ZigDocsLog -LogPath $storage.LogPath -Message "Removed Zig candidate $($target.Path)" -Level "INFO"
+                Add-ZigDocsHistory -State $state -Action "Candidate-Remove" -Success $true -Details $target.Path -RecordStats:$false
+                Write-Host "Candidate removed." -ForegroundColor Yellow
+              } else {
+                Write-Warning "Invalid selection for removal."
+              }
+            } else {
+              Write-Warning "Removal requires a numeric selection."
+            }
+            Wait-ZigDocsUser
+          } elseif ($choiceValue -eq 'R') {
+            Write-Host "Candidate list refreshed." -ForegroundColor Cyan
+            Wait-ZigDocsUser
+          } elseif ($manual -as [int]) {
+            $index = [int]$manual - 1
+            if ($index -ge 0 -and $index -lt $manualCandidates.Count) {
+              $candidate = $manualCandidates[$index]
+              if ($candidate.Skip) {
+                Write-Warning "Version skipped after repeated failures. Adjust threshold in dashboard to retry."
+              } else {
+                $result = Invoke-ZigDocsWindowsSession -State $state -Candidate $candidate -LogPath $storage.LogPath
+                if ($result.success) {
+                  Write-Host $result.message -ForegroundColor Green
+                } else {
+                  Write-Host $result.message -ForegroundColor Yellow
+                }
+              }
+            } else {
+              Write-Warning "Invalid selection."
+            }
+            Wait-ZigDocsUser
+          } else {
+            Write-Warning "Unrecognized selection."
+            Wait-ZigDocsUser
+          }
+        }
       }
       '4' {
         $success = Invoke-ZigDocsServerWsl -State $state -LogPath $storage.LogPath
-        Add-ZigDocsHistory -State $state -Action "Docs-WSL" -Success $success
-        Pause
+        if ($success) {
+          $state.lastSuccessfulMode = "WSL"
+          Add-ZigDocsHistory -State $state -Action "Docs-WSL" -Success $true -Details "WSL server" -RecordStats:$true
+        } else {
+          Add-ZigDocsHistory -State $state -Action "Docs-WSL" -Success $false -Details "WSL failure" -RecordStats:$true
+        }
+        Wait-ZigDocsUser
       }
       '5' {
-        Invoke-ZigDocsDiagnostics -State $state -LogPath $storage.LogPath
-        Add-ZigDocsHistory -State $state -Action "Diagnostics" -Success $true
-        Pause
+        Show-ZigDocsDashboard -State $state
       }
-      '6' {
-        Update-PathForZig -ZigPath $zigExe -LogPath $storage.LogPath
-        $results = Invoke-ZigDocsAutomatedPipeline -State $state -ZigExe $zigExe -LogPath $storage.LogPath
-        $success = $results | Where-Object { -not $_.success } | Measure-Object | Select-Object -ExpandProperty Count
-        Add-ZigDocsHistory -State $state -Action "Pipeline" -Success ($success -eq 0)
-        Pause
-      }
-      '7' {
-        $browser = Read-Host "Enter browser command (e.g. chrome.exe, msedge.exe) or leave blank to reset"
-        if ($browser) {
-          $state.preferredBrowser = $browser
-          Write-Host "Preferred browser set to $browser" -ForegroundColor Green
-          Write-ZigDocsLog -LogPath $storage.LogPath -Message "Preferred browser set to $browser" -Level "INFO"
-        } else {
-          $state.preferredBrowser = $null
-          Write-Host "Preferred browser cleared." -ForegroundColor Yellow
-          Write-ZigDocsLog -LogPath $storage.LogPath -Message "Preferred browser cleared" -Level "INFO"
-        }
-        Pause
-      }
-      '8' {
+      'Q' {
         break
       }
-      Default {
+      default {
         Write-Host "Invalid selection" -ForegroundColor Red
-        Pause
+        Wait-ZigDocsUser
       }
     }
   }


### PR DESCRIPTION
## Summary
- replace PowerShell 7-only discovery flags with a bounded breadth-first scan so Zig binaries are auto-detected on stock Windows shells
- extend the manual candidate picker with a persistent loop that supports adding, deleting, and rescanning Zig locations while updating cached metadata
- document the new picker shortcuts and note the compatibility improvements in the Windows recovery guide

## Testing
- Not run (PowerShell unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d011a33f44833196ea7700746ac3a6