### PR TITLE
docs: add layouts for manual pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,15 +485,15 @@ pub fn main() void {
 
 ## 📚 **Further Reading**
 
-- **[Documentation Portal](docs/README.md)** - Landing page that links to generated and manual guides
-- **[Module Organization](docs/MODULE_ORGANIZATION.md)** - Current source tree and dependency overview
+- **[Documentation Portal](https://donaldfilimon.github.io/abi/)** - Landing page that links to generated and manual guides
+- **[Module Organization](https://donaldfilimon.github.io/abi/module-organization/)** - Current source tree and dependency overview
 - **[Architecture & Feature Reference](docs/generated/MODULE_REFERENCE.md)** - Generated inventory of feature modules wired through `src/mod.zig`
 - **[Vector Database Guide](docs/api/database.md)** - WDBX storage engine configuration, sharding, and HTTP surfaces
 - **[AI Agent Guide](docs/api/ai.md)** - Agent personas, enhanced pipelines, and training utilities
-- **[GPU Acceleration Guide](docs/GPU_AI_ACCELERATION.md)** - Feature deep dive for GPU-backed workloads
-- **[Testing Strategy](docs/TESTING_STRATEGY.md)** - Quality gates, coverage expectations, and tooling
-- **[Production Deployment](docs/PRODUCTION_DEPLOYMENT.md)** - Deployment runbooks and environment guidance
-- **[API Reference](docs/api_reference.md)** - Hand-authored API summary with links to generated docs
+- **[GPU Acceleration Guide](https://donaldfilimon.github.io/abi/gpu-ai-acceleration/)** - Feature deep dive for GPU-backed workloads
+- **[Testing Strategy](https://donaldfilimon.github.io/abi/testing-strategy/)** - Quality gates, coverage expectations, and tooling
+- **[Production Deployment](https://donaldfilimon.github.io/abi/production-deployment/)** - Deployment runbooks and environment guidance
+- **[API Reference](https://donaldfilimon.github.io/abi/manual-api-reference/)** - Hand-authored API summary with links to generated docs
 - **[Generated Documentation](docs/generated/)** - Auto-generated API, module, and example references
 
 ## 🧪 **Testing & Quality**
@@ -571,7 +571,7 @@ pub const ExamplePlugin = struct {
 };
 ```
 
-See the [Module Organization guide](docs/MODULE_ORGANIZATION.md) and generated module reference for plugin entry points.
+See the [Module Organization guide](https://donaldfilimon.github.io/abi/module-organization/) and generated module reference for plugin entry points.
 
 ## 🚀 **Production Deployment**
 
@@ -582,7 +582,7 @@ The framework includes production-ready deployment configurations:
 - **Performance Validation**: 2,777+ ops/sec with 99.98% uptime
 - **Automated Scripts**: Windows (PowerShell) and Linux deployment scripts
 
-See [Production Deployment Guide](docs/PRODUCTION_DEPLOYMENT.md) for complete deployment instructions.
+See [Production Deployment Guide](https://donaldfilimon.github.io/abi/production-deployment/) for complete deployment instructions.
 
 ## 🌍 **Cross-Platform Guide (Zig 0.16.0-dev.254+6dd0270a1)**
 

--- a/docs/GPU_AI_ACCELERATION.md
+++ b/docs/GPU_AI_ACCELERATION.md
@@ -1,3 +1,10 @@
+---
+layout: documentation
+title: "GPU AI Acceleration"
+description: "How to configure ABI for high-throughput GPU-accelerated inference and training workloads."
+permalink: /gpu-ai-acceleration/
+---
+
 # 🚀 GPU AI/ML Acceleration Guide
 
 > **Harness the power of GPU acceleration for high-performance AI and machine learning workloads**

--- a/docs/MODULE_ORGANIZATION.md
+++ b/docs/MODULE_ORGANIZATION.md
@@ -1,3 +1,10 @@
+---
+layout: documentation
+title: "Module Organization"
+description: "Recommended structure and design patterns for arranging ABI's modules."
+permalink: /module-organization/
+---
+
 # Abi Framework Module Organization
 
 Updated map of the reorganised Abi source tree. The new layout pivots around

--- a/docs/PRODUCTION_DEPLOYMENT.md
+++ b/docs/PRODUCTION_DEPLOYMENT.md
@@ -1,3 +1,10 @@
+---
+layout: documentation
+title: "Production Deployment"
+description: "Checklist and best practices for deploying ABI safely into production environments."
+permalink: /production-deployment/
+---
+
 # WDBX Production Deployment Guide
 
 ## 🎯 Performance Metrics

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,7 @@ Welcome to the comprehensive documentation for ABI, a high-performance vector da
 ### Developer Resources
 - **[Code Index]({{ '/generated/CODE_API_INDEX/' | relative_url }})** - Auto-generated API index from source
 - **[Native Docs]({{ '/zig-docs/' | relative_url }})** - Zig compiler-generated documentation
-- **[Windows Zig std Troubleshooting]({{ '/docs/ZIG_STD_WINDOWS_FIX.html' | relative_url }})** - Workarounds when the stdlib docs fail to load on Windows
+- **[Windows Zig std Troubleshooting]({{ '/zig-std-windows-fix/' | relative_url }})** - Workarounds when the stdlib docs fail to load on Windows
 - **[Search]({{ '/index.html' | relative_url }})** - Interactive documentation browser
 
 ## 🔍 Features

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -1,3 +1,10 @@
+---
+layout: documentation
+title: "Testing Strategy"
+description: "Unified approach for validating ABI across functionality, performance, and reliability."
+permalink: /testing-strategy/
+---
+
 # Testing Strategy
 
 ## Purpose

--- a/docs/WINDOWS_ZIG_STD_DOCS_FIX.md
+++ b/docs/WINDOWS_ZIG_STD_DOCS_FIX.md
@@ -1,3 +1,10 @@
+---
+layout: documentation
+title: "Windows zig std Docs Pipeline"
+description: "Automated pipeline and CLI helpers for restoring Zig standard library docs on Windows."
+permalink: /windows-zig-std-docs-fix/
+---
+
 # Unified Pipeline & Dynamic Interactive CLI/UX for `zig std` on Windows
 
 **Complete End-to-End Pipeline with Integrated CLI Interfaces and Interactive UX Module**

--- a/docs/ZIG_STD_WINDOWS_FIX.md
+++ b/docs/ZIG_STD_WINDOWS_FIX.md
@@ -1,3 +1,10 @@
+---
+layout: documentation
+title: "Fix zig std on Windows"
+description: "Step-by-step recovery guide for Zig standard library documentation failures on Windows."
+permalink: /zig-std-windows-fix/
+---
+
 # Fixing `zig std` Documentation Loading Issues on Windows
 
 > Comprehensive strategies to restore access to Zig standard library docs when the bundled server opens but browsers show a blank page, endless spinner, or connection errors.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -28,6 +28,22 @@ navigation:
     url: "/generated/DEFINITIONS_REFERENCE"
   - title: "Code Index"
     url: "/generated/CODE_API_INDEX"
+  - title: "Production Deployment"
+    url: "/production-deployment/"
+  - title: "Testing Strategy"
+    url: "/testing-strategy/"
+  - title: "Module Organization"
+    url: "/module-organization/"
+  - title: "GPU AI Acceleration"
+    url: "/gpu-ai-acceleration/"
+  - title: "Manual API Reference"
+    url: "/manual-api-reference/"
+  - title: "zig std Windows Fix"
+    url: "/zig-std-windows-fix/"
+  - title: "Windows zig std Docs Pipeline"
+    url: "/windows-zig-std-docs-fix/"
+  - title: "zig std Windows Regression"
+    url: "/zig-std-windows-bug/"
 
 # SEO and metadata
 lang: en

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -8,12 +8,12 @@ Welcome to the comprehensive API documentation for the ABI AI Framework.
 
 - [**AI & Agents**](ai.md) — `abi.features.ai.*` personas, enhanced pipelines, and training utilities
 - [**Vector Database**](database.md) — `abi.features.database.*` storage engine, configuration, and HTTP/CLI front-ends
-- [**GPU Tooling**](../GPU_AI_ACCELERATION.md) — `abi.features.gpu.*` compute kernels, backends, and profiling suites
+- [**GPU Tooling**]({{ '/gpu-ai-acceleration/' | relative_url }}) — `abi.features.gpu.*` compute kernels, backends, and profiling suites
 - [**Web & Connectors**](http_client.md) — `abi.features.web.*` networking clients/servers plus connector bridges
 
 ### Framework & Shared Layers
 
-- [**Framework Runtime**](../MODULE_ORGANIZATION.md#-module-architecture) — `abi.framework.*` feature toggles, lifecycle, plugin coordination
+- [**Framework Runtime**]({{ '/module-organization/' | relative_url }}#-module-architecture) — `abi.framework.*` feature toggles, lifecycle, plugin coordination
 - [**Plugin System**](plugins.md) — `abi.shared.*` registries, loaders, and interfaces used by the runtime
 - [**SIMD & Utilities**](simd.md) — `abi.simd` helpers alongside `abi.utils`/`abi.platform`
 - [**WDBX Utilities**](wdbx.md) — Operational helpers layered on top of the database feature

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,3 +1,10 @@
+---
+layout: documentation
+title: "Manual API Reference"
+description: "Hand-authored ABI API notes that complement the generated reference materials."
+permalink: /manual-api-reference/
+---
+
 # API Reference
 
 Comprehensive API documentation for the Abi AI Framework with usage examples.

--- a/docs/zig_std_windows_bug.md
+++ b/docs/zig_std_windows_bug.md
@@ -1,3 +1,10 @@
+---
+layout: documentation
+title: "zig std Windows Regression"
+description: "Impact analysis of the Zig 0.15.x Windows documentation regression and mitigation tactics."
+permalink: /zig-std-windows-bug/
+---
+
 # Zig `zig std` Windows Regression (0.15.x)
 
 ## Issue Summary and Manifestation


### PR DESCRIPTION
## Summary
- add Jekyll front matter with permalinks to the hand-written documentation guides so they use the shared documentation layout
- surface the new guides in the documentation navigation and update the Windows troubleshooting link to the canonical permalink

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d03e0365508331be4607b50fce364a