### PR TITLE
Fix broken documentation links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -325,8 +325,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔗 **Links**
 
-- **[Unreleased]**: [Compare v0.1.0-alpha...HEAD](https://github.com/yourusername/abi/compare/v0.1.0-alpha...HEAD)
-- **[0.1.0-alpha]**: [Release v0.1.0-alpha](https://github.com/yourusername/abi/releases/tag/v0.1.0-alpha)
+- **[Unreleased]**: [Compare v0.1.0-alpha...HEAD](https://github.com/donaldfilimon/abi/compare/v0.1.0-alpha...HEAD)
+- **[0.1.0-alpha]**: [Release v0.1.0-alpha](https://github.com/donaldfilimon/abi/releases/tag/v0.1.0-alpha)
 
 ---
 
@@ -359,4 +359,4 @@ Each entry should include:
 
 **📋 This changelog is maintained by the Abi AI Framework team**
 
-**🚀 For the latest updates, check our [GitHub releases](https://github.com/yourusername/abi/releases)**
+**🚀 For the latest updates, check our [GitHub releases](https://github.com/donaldfilimon/abi/releases)**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,7 +226,7 @@ Thank you for contributing to Abi AI Framework!
 
 [![Contributions Welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](CONTRIBUTING.md)
 [![Code of Conduct](https://img.shields.io/badge/code%20of%20conduct-1.0.0-ff69b4.svg)](CODE_OF_CONDUCT.md)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/yourusername/abi/pulls)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/donaldfilimon/abi/pulls)
 
 ## 📋 **Table of Contents**
 
@@ -296,14 +296,14 @@ Violations will be addressed by the project maintainers. We reserve the right to
 
 ```bash
 # 1. Fork the repository
-# Go to https://github.com/yourusername/abi and click "Fork"
+# Go to https://github.com/donaldfilimon/abi and click "Fork"
 
 # 2. Clone your fork
-git clone https://github.com/yourusername/abi.git
+git clone https://github.com/donaldfilimon/abi.git
 cd abi
 
 # 3. Add upstream remote
-git remote add upstream https://github.com/original-owner/abi.git
+git remote add upstream https://github.com/donaldfilimon/abi.git
 
 # 4. Install dependencies
 # Zig should be in your PATH

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![Zig Version](https://img.shields.io/badge/Zig-0.16.0--dev.254%2B6dd0270a1-orange.svg)](https://ziglang.org/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Platform](https://img.shields.io/badge/Platform-Cross--platform-green.svg)]()
+[![Platform](https://img.shields.io/badge/Platform-Cross--platform-green.svg)](#platform-support)
 
 ## 🚀 Features
 
@@ -205,10 +205,10 @@ MIT License - see [LICENSE](LICENSE)
 
 [![Zig Version](https://img.shields.io/badge/Zig-0.16.0--dev.254%2B6dd0270a1-orange.svg)](https://ziglang.org/) • [Docs](https://donaldfilimon.github.io/abi/) • [CI: Pages](.github/workflows/deploy_docs.yml)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Platform](https://img.shields.io/badge/Platform-Cross--platform-green.svg)](https://github.com/yourusername/abi)
-[![Build Status](https://img.shields.io/badge/Build-Passing-brightgreen.svg)]()
-[![Tests](https://img.shields.io/badge/Tests-Passing-brightgreen.svg)]()
-[![Performance](https://img.shields.io/badge/Performance-2,777+%20ops%2Fsec-brightgreen.svg)]()
+[![Platform](https://img.shields.io/badge/Platform-Cross--platform-green.svg)](https://github.com/donaldfilimon/abi)
+[![Build Status](https://img.shields.io/badge/Build-Passing-brightgreen.svg)](.github/workflows/ci.yml)
+[![Tests](https://img.shields.io/badge/Tests-Passing-brightgreen.svg)](tests/)
+[![Performance](https://img.shields.io/badge/Performance-2,777+%20ops%2Fsec-brightgreen.svg)](benchmarks/)
 
 ## ✅ **Key Improvements**
 - **Performance**: SIMD optimizations, arena allocators, statistical analysis
@@ -640,7 +640,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## 🆘 **Support**
 
 - **📖 Documentation**: [docs/](docs/)
-- **🐛 Issues**: [GitHub Issues](https://github.com/yourusername/abi/issues)
+- **🐛 Issues**: [GitHub Issues](https://github.com/donaldfilimon/abi/issues)
 - **💬 Discord**: [Join our server](https://discord.gg/yourinvite)
 - **📧 Email**: support@abi-framework.org
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,22 +13,22 @@ Welcome to the comprehensive documentation for ABI, a high-performance vector da
 
 <div class="quick-nav">
   <div class="nav-card">
-    <h3><a href="{{ '/generated/API_REFERENCE/' | relative_url }}">📘 API Reference</a></h3>
+    <h3><a href="generated/API_REFERENCE.md">📘 API Reference</a></h3>
     <p>Complete API documentation with examples and detailed function signatures.</p>
   </div>
 
   <div class="nav-card">
-    <h3><a href="{{ '/generated/EXAMPLES/' | relative_url }}">💡 Examples</a></h3>
+    <h3><a href="generated/EXAMPLES.md">💡 Examples</a></h3>
     <p>Practical examples and tutorials to get you started quickly.</p>
   </div>
 
   <div class="nav-card">
-    <h3><a href="{{ '/generated/MODULE_REFERENCE/' | relative_url }}">📦 Module Reference</a></h3>
+    <h3><a href="generated/MODULE_REFERENCE.md">📦 Module Reference</a></h3>
     <p>Detailed module documentation and architecture overview.</p>
   </div>
 
   <div class="nav-card">
-    <h3><a href="{{ '/generated/PERFORMANCE_GUIDE/' | relative_url }}">⚡ Performance Guide</a></h3>
+    <h3><a href="generated/PERFORMANCE_GUIDE.md">⚡ Performance Guide</a></h3>
     <p>Optimization tips, benchmarks, and performance best practices.</p>
   </div>
 </div>
@@ -36,17 +36,17 @@ Welcome to the comprehensive documentation for ABI, a high-performance vector da
 ## 📖 What's Inside
 
 ### Core Documentation
-- **[API Reference]({{ '/generated/API_REFERENCE/' | relative_url }})** - Complete function and type documentation
-- **[Module Reference]({{ '/generated/MODULE_REFERENCE/' | relative_url }})** - Module structure and relationships
-- **[Examples]({{ '/generated/EXAMPLES/' | relative_url }})** - Practical usage examples and tutorials
-- **[Performance Guide]({{ '/generated/PERFORMANCE_GUIDE/' | relative_url }})** - Optimization and benchmarking
-- **[Definitions]({{ '/generated/DEFINITIONS_REFERENCE/' | relative_url }})** - Comprehensive glossary and concepts
+- **[API Reference](generated/API_REFERENCE.md)** - Complete function and type documentation
+- **[Module Reference](generated/MODULE_REFERENCE.md)** - Module structure and relationships
+- **[Examples](generated/EXAMPLES.md)** - Practical usage examples and tutorials
+- **[Performance Guide](generated/PERFORMANCE_GUIDE.md)** - Optimization and benchmarking
+- **[Definitions](generated/DEFINITIONS_REFERENCE.md)** - Comprehensive glossary and concepts
 
 ### Developer Resources
-- **[Code Index]({{ '/generated/CODE_API_INDEX/' | relative_url }})** - Auto-generated API index from source
-- **[Native Docs]({{ '/zig-docs/' | relative_url }})** - Zig compiler-generated documentation
-- **[Windows Zig std Troubleshooting]({{ '/docs/ZIG_STD_WINDOWS_FIX.html' | relative_url }})** - Workarounds when the stdlib docs fail to load on Windows
-- **[Search]({{ '/index.html' | relative_url }})** - Interactive documentation browser
+- **[Code Index](generated/CODE_API_INDEX.md)** - Auto-generated API index from source
+- **[Native Docs](zig-docs/)** - Zig compiler-generated documentation
+- **[Windows Zig std Troubleshooting](ZIG_STD_WINDOWS_FIX.md)** - Workarounds when the stdlib docs fail to load on Windows
+- **[Search](index.html)** - Interactive documentation browser
 
 ## 🔍 Features
 
@@ -58,10 +58,10 @@ Welcome to the comprehensive documentation for ABI, a high-performance vector da
 
 ## 🛠️ Getting Started
 
-1. **Installation**: Check the [Examples]({{ '/generated/EXAMPLES/' | relative_url }}) for setup instructions
-2. **Quick Start**: Follow the [basic usage examples]({{ '/generated/EXAMPLES/' | relative_url }}#quick-start)
-3. **API Learning**: Explore the [API Reference]({{ '/generated/API_REFERENCE/' | relative_url }}) for detailed function documentation
-4. **Optimization**: Read the [Performance Guide]({{ '/generated/PERFORMANCE_GUIDE/' | relative_url }}) for best practices
+1. **Installation**: Check the [Examples](generated/EXAMPLES.md) for setup instructions
+2. **Quick Start**: Follow the [basic usage examples](generated/EXAMPLES.md#quick-start)
+3. **API Learning**: Explore the [API Reference](generated/API_REFERENCE.md) for detailed function documentation
+4. **Optimization**: Read the [Performance Guide](generated/PERFORMANCE_GUIDE.md) for best practices
 
 ## 📚 Documentation Types
 
@@ -83,7 +83,7 @@ This documentation is generated using multiple approaches:
 
 - **[GitHub Repository](https://github.com/donaldfilimon/abi/)** - Source code and issues
 - **[Zig Language](https://ziglang.org/)** - Learn about the Zig programming language
-- **[Vector Databases]({{ '/generated/DEFINITIONS_REFERENCE/' | relative_url }}#vector-database)** - Learn about vector database concepts
+- **[Vector Databases](generated/DEFINITIONS_REFERENCE.md#vector-database)** - Learn about vector database concepts
 
 ## 📧 Support
 


### PR DESCRIPTION
## Summary
- point README badges to working anchors, workflows, and directories
- update docs/README navigation to use valid relative links in the repo
- replace placeholder GitHub URLs across docs with the canonical repository links

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d03fef8a44833189d39b9ffdbe90ed