### PR TITLE
docs: rebalance readme overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,69 +2,122 @@
 > Ultra-high-performance AI framework with GPU acceleration, lock-free concurrency, and platform-optimized implementations.
 
 [![Zig Version](https://img.shields.io/badge/Zig-0.16.0--dev.254%2B6dd0270a1-orange.svg)](https://ziglang.org/)
+[![Docs](https://img.shields.io/badge/Docs-Latest-blue.svg)](https://donaldfilimon.github.io/abi/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Platform](https://img.shields.io/badge/Platform-Cross--platform-green.svg)]()
 
-## 🚀 Features
+Abi couples a high-throughput runtime, GPU-accelerated AI primitives, and a production-ready vector database into a cohesive
+toolkit for building latency-sensitive agents, analytics pipelines, and services that must scale from embedded targets to
+cloud fleets.
 
-### Core Capabilities
-- **GPU Acceleration**: WebGPU with platform-specific fallbacks
-- **SIMD Optimizations**: 3GB/s+ throughput with alignment safety
-- **Lock-free Concurrency**: Wait-free data structures
-- **Vector Database**: Custom WDBX-AI format for embeddings
-- **Neural Networks**: SIMD-accelerated operations
-- **Plugin System**: Cross-platform dynamic loading
-- **Production Servers**: HTTP/TCP with fault tolerance
+---
+
+## Table of Contents
+- [Overview](#overview)
+- [Key Capabilities](#key-capabilities)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Project Layout](#project-layout)
+- [Usage Examples](#usage-examples)
+- [Vector Database](#vector-database)
+- [Build & Configuration](#build--configuration)
+- [Performance & Benchmarking](#performance--benchmarking)
+- [Testing](#testing)
+- [Documentation & Resources](#documentation--resources)
+- [Contributing](#contributing)
+- [License](#license)
+
+---
+
+## Overview
+Abi is organized into three collaborating planes:
+- **Runtime Plane** – Schedules workloads, manages lock-free concurrency primitives, and bridges CPU/GPU execution paths.
+- **AI & Data Plane** – Hosts persona-driven agents, neural network training, and the WDBX vector database for embeddings.
+- **Operations Plane** – Exposes CLI tooling, HTTP/WebSocket services, and observability pipelines for production readiness.
+
+Each plane is implemented in Zig modules under `src/` and can be embedded into existing Zig applications or driven through the
+bundled CLI.
+
+---
+
+## Key Capabilities
+### Core Framework
+- GPU acceleration via WebGPU with platform-specific fallbacks.
+- SIMD-optimized text processing (3 GB/s+ throughput) and neural network primitives.
+- Lock-free queues, wait-free messaging, and zero-copy allocators for low-latency pipelines.
+- Production-grade HTTP/TCP servers with adaptive load-balancing and fault tolerance.
+
+### AI & Tooling
+- Multi-persona chat agents with OpenAI integration and persona presets.
+- Complete neural network training stack (FFN, CNN, RNN, Transformer) supporting distributed execution modes.
+- Plugin system for cross-platform dynamic loading (`.dll`/`.so`/`.dylib`) with type-safe Zig wrappers.
+- Observability hooks: Prometheus metrics, performance profiling, memory tracking, and debug tooling.
 
 ### Platform Support
-- **Cross-platform**: Windows, Linux, macOS, iOS
-- **Platform Optimizations**: OS-specific enhancements
-- **Discord Integration**: Bot framework with gateway support
+- Cross-platform support for Linux, macOS, Windows, and embedded targets.
+- Deployment recipes covering Docker, Kubernetes, and standalone binaries.
+- Legacy Zig 0.15.x notes are retained for teams maintaining older deployments.
+
+---
 
 ## Installation
-
 ### Prerequisites
-- **Zig 0.16.0-dev.254+6dd0270a1** (see `.zigversion` and verify with `zig version`)
-- GPU drivers (optional, for acceleration)
-- OpenAI API key (for AI features)
+- **Zig 0.16.0-dev.254+6dd0270a1** (see `.zigversion` to match the toolchain).
+- GPU drivers (optional, required for CUDA/WebGPU backends).
+- OpenAI API key (for hosted LLM/persona integrations).
 
-### Compatibility
-
-- **Current Toolchain**: Zig 0.16.0-dev.254+6dd0270a1. This repository's `.zigversion` file is the authoritative reference—match it exactly when installing Zig.
-- **Legacy Notes**: Historical guidance for Zig 0.15.x (including CI setups using `mlugg/setup-zig@v2` with Zig 0.15.0) remains in older sections below for teams maintaining legacy deployments. These paths are not part of the active test matrix.
-
-### Quick Start
+### Clone & Build
 ```bash
 git clone https://github.com/donaldfilimon/abi.git
 cd abi
 zig build -Doptimize=ReleaseFast
-zig build test
-./zig-out/bin/abi --help
 ```
 
-## 📁 Project Structure
+### Compatibility Notes
+- `.zigversion` pins the supported compiler. Align CI and local toolchains with that version.
+- Historical instructions for Zig 0.15.x live in legacy documentation. They are not part of the active CI matrix but may be
+  useful for long-lived branches.
 
-```
-abi/
-├── src/                          # Source code
-│   ├── core/                     # Core utilities
-│   ├── framework/                # Runtime orchestration and lifecycle
-│   ├── ai/                       # AI/ML components
-│   ├── database/                 # Vector database
-│   ├── net/                      # Networking
-│   ├── perf/                     # Performance monitoring
-│   ├── gpu/                      # GPU acceleration
-│   ├── ml/                       # ML algorithms
-│   ├── simd/                     # SIMD operations
-│   └── wdbx/                     # CLI interface
-├── tests/                        # Test suite
-├── docs/                         # Documentation
-├── examples/                     # Usage examples
-└── tools/                        # Development tools
+---
 
 ## Quick Start
+```bash
+# Run tests registered in build.zig
+zig build test
 
-### Basic Usage
+# Launch the default executable
+zig build run
+
+# Inspect the CLI helper
+./zig-out/bin/abi --help
+
+# Generate docs and benchmarks
+zig build docs
+zig build bench-all
+```
+
+Additional targets:
+- `zig build bench-simd` – SIMD micro-benchmarks.
+- `zig build cross-platform` – Build the supported target matrix.
+- `zig build -Denable_heavy_tests=true test` – Include long-running suites.
+
+---
+
+## Project Layout
+```text
+abi/
+├── src/                # Core framework, AI modules, GPU backends
+├── tests/              # Unit, integration, and platform-specific suites
+├── docs/               # Manual + generated documentation portal
+├── examples/           # Minimal runnable samples
+├── tools/              # Developer utilities and automation helpers
+└── zig-out/            # Build artifacts (generated)
+```
+
+---
+
+## Usage Examples
+### Bootstrap the Framework
 ```zig
 const std = @import("std");
 const abi = @import("abi");
@@ -72,586 +125,129 @@ const abi = @import("abi");
 pub fn main() !void {
     const allocator = std.heap.page_allocator;
 
-    // Create AI agent using the exported AgentConfig
     var agent = try abi.features.ai.agent.Agent.init(allocator, .{ .name = "QuickStart" });
     defer agent.deinit();
 
-    // Process a message
     const response = try agent.process("Hello!", allocator);
     defer allocator.free(@constCast(response));
 }
 ```
 
-> `Agent.process` duplicates its reply into the allocator you provide, so callers must free the returned buffer once they're
-> done with it.
+### CLI Commands
+```bash
+abi help                         # Overview of available subcommands
+abi chat --persona creative      # Interactive chat session
+abi llm train data.csv           # Model training pipeline
+abi wdbx http --host 0.0.0.0     # Start HTTP server for the vector DB
+abi benchmark --memory-track     # Performance + memory benchmarks
+```
 
-### Vector Database
+### REST & WebSocket Endpoints
+- `GET /health` – Service health probe.
+- `GET /api/status` – Framework status snapshot.
+- `POST /api/agent/query` – AI agent request (JSON payload).
+- `POST /api/database/search` – Vector similarity search.
+- `WebSocket /ws` – Bi-directional chat stream.
+
+---
+
+## Vector Database
+The WDBX storage engine powers embeddings and similarity search while preserving allocator safety.
+
+**Highlights**
+- SIMD-accelerated insert/search paths validated at **2,777+ ops/sec**.
+- K-nearest neighbor queries via CLI, HTTP REST, and WebSocket APIs.
+- Metadata lifecycle helpers (e.g., `Db.freeResults`) for deterministic resource cleanup.
+
+**Example**
 ```zig
-// Open database
+const std = @import("std");
+const abi = @import("abi");
+
 var db = try abi.features.database.database.Db.open("vectors.wdbx", true);
 defer db.close();
 
-// Add and search vectors
-const embedding = [_]f32{0.1, 0.2, 0.3};
-const results = try db.search(&embedding, 10, allocator);
+const allocator = std.heap.page_allocator;
+const embedding = [_]f32{ 0.1, 0.2, 0.3 };
+const matches = try db.search(&embedding, 10, allocator);
+defer abi.features.database.database.Db.freeResults(matches, allocator);
 ```
 
-### WDBX CLI
+---
 
-```bash
-# Inspect available subcommands
-./zig-out/bin/abi wdbx help
+## Build & Configuration
+Tune features with Zig build options:
+- `-Denable_cuda=true|false` – Toggle CUDA acceleration (default: true).
+- `-Denable_spirv=true|false` – Compile Vulkan/SPIR-V shaders (default: true).
+- `-Denable_wasm=true|false` – Emit WebAssembly artifacts (default: true).
+- `-Dtarget=<triple>` – Cross-compile (e.g., `x86_64-linux-gnu`, `aarch64-macos`).
+- `-Doptimize=Debug|ReleaseSafe|ReleaseFast|ReleaseSmall` – Build profile selection.
+- `-Denable_heavy_tests=true` – Include long-running performance and HNSW suites.
 
-# Launch the lightweight HTTP API (Ctrl+C to stop)
-./zig-out/bin/abi wdbx http --host 0.0.0.0 --port 8080
+Compile-time settings surface through the `options` module:
+```zig
+const options = @import("options");
+std.log.info("CUDA enabled? {}", .{ options.enable_cuda });
 ```
 
-> If you install `abi` into your `PATH`, you can drop the `./zig-out/bin/` prefix and run commands like `abi wdbx http …` directly.
+---
 
-## Modules
+## Performance & Benchmarking
+| Component            | Performance Target           | Notes                                      |
+|----------------------|------------------------------|--------------------------------------------|
+| Text processing      | ≥3.2 GB/s SIMD throughput    | Alignment-safe, zero-copy message passing. |
+| Vector operations    | ≥2,777 ops/sec               | Validated via WDBX micro-benchmarks.       |
+| Neural inference     | <1 ms for 32×32 networks     | SIMD + GPU acceleration where available.   |
+| Lock-free queue      | 10M ops/sec                  | Single producer/consumer benchmark.        |
 
-- **`core/`**: Core utilities and framework foundation
-- **`framework/`**: Runtime orchestrator that wires features and plugins together
-- **`ai/`**: AI agents and machine learning components
-- **`database/`**: WDBX-AI vector database with HNSW indexing
-- **`net/`**: HTTP/TCP servers and client libraries
-- **`simd/`**: SIMD-accelerated operations
-- **`perf/`**: Performance monitoring and profiling
-- **`gpu/`**: GPU acceleration and rendering
-- **`ml/`**: Machine learning algorithms
+Common workflows:
+- `zig build bench-all` – Run the full benchmark suite.
+- `zig build bench-simd` – Stress text/vector SIMD kernels.
+- `abi benchmark --memory-track` – Runtime profiling with memory tracking enabled.
 
-## CLI
-
-The current executable boots the framework and prints a bootstrap summary. Run it with Zig's
-build system:
-
-```bash
-abi help                    # Show commands
-abi chat                    # AI chat session
-abi train <data>           # Train neural network
-./zig-out/bin/abi wdbx http --host 0.0.0.0 --port 8080   # Start HTTP server
-abi benchmark              # Performance tests
-abi analyze <file>         # Text analysis
-
-# With options
-abi --memory-track --gpu benchmark
-abi --verbose --debug chat
-```
-
-## API
-
-```bash
-abi web                    # Start web server
-```
-
-**Endpoints:**
-- `GET /health` - Health check
-- `POST /api/agent/query` - AI queries
-- `POST /api/database/search` - Vector search
-
-## Performance
-
-**Benchmarks:**
-- **Text Processing**: 3.2 GB/s SIMD throughput
-- **Vector Operations**: 15 GFLOPS
-- **Neural Networks**: <1ms inference
-- **Memory Tracking**: <1% overhead
-
-```bash
-abi benchmark --memory-track    # Run benchmarks
-abi --memory-track --gpu        # Monitor performance
-```
+---
 
 ## Testing
-
 ```bash
-# Run all tests registered in build.zig (currently exercises src/main.zig)
+# Run all tests registered in build.zig
 zig build test
 
-# Targeted test files
-zig test tests/test_create.zig
+# Target specific suites
+zig test tests/test_memory_management.zig
+zig test tests/test_cli_integration.zig
 zig test tests/cross-platform/linux.zig
 zig test tests/cross-platform/macos.zig
 zig test tests/cross-platform/windows.zig
 ```
 
-The cross-platform tests gracefully skip when run on unsupported operating systems, so it's
-safe to invoke the full list from any development environment.
-
-**Quality Metrics:**
-- Memory Safety: Zero leaks
-- Performance: <5% regression tolerance
-- Test Coverage: 95%+
-- Build Success: 99%+
-
-## Contributing
-
-1. Fork and create feature branch
-2. Run tests: `zig build test`
-3. Check memory: `zig build test-memory`
-4. Submit PR with tests
-
-## License
-
-MIT License - see [LICENSE](LICENSE)
-
-## Links
-
-- [Documentation](docs/)
-- [Issues](https://github.com/donaldfilimon/abi/issues)
-# 🚀 Abi AI Framework
-
-> **Ultra-high-performance AI framework with GPU acceleration, lock-free concurrency, advanced monitoring, and platform-optimized implementations for Zig development.**
-
-[![Zig Version](https://img.shields.io/badge/Zig-0.16.0--dev.254%2B6dd0270a1-orange.svg)](https://ziglang.org/) • [Docs](https://donaldfilimon.github.io/abi/) • [CI: Pages](.github/workflows/deploy_docs.yml)
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Platform](https://img.shields.io/badge/Platform-Cross--platform-green.svg)](https://github.com/yourusername/abi)
-[![Build Status](https://img.shields.io/badge/Build-Passing-brightgreen.svg)]()
-[![Tests](https://img.shields.io/badge/Tests-Passing-brightgreen.svg)]()
-[![Performance](https://img.shields.io/badge/Performance-2,777+%20ops%2Fsec-brightgreen.svg)]()
-
-## ✅ **Key Improvements**
-- **Performance**: SIMD optimizations, arena allocators, statistical analysis
-- **Reliability**: Enhanced error handling, memory leak detection, thread safety
-- **Monitoring**: Real-time metrics, adaptive load balancing, confidence scoring
-- **Reporting**: Multiple output formats, detailed analytics, optimization recommendations
-- **Security**: Vulnerability detection, secure random generation, input validation
-- **Platform Support**: Windows-specific optimizations, cross-platform compatibility
-- **Chat Integration**: Complete AI chat functionality with multiple personas and backends
-- **Model Training**: Full neural network training pipeline with CLI interface
-- **Web API**: RESTful endpoints and WebSocket support for AI interactions
-
-## ✨ **Key Features**
-
-### 🚀 **Performance & Acceleration**
-- **GPU Acceleration**: WebGPU support with fallback to platform-specific APIs
-- **SIMD Optimizations**: 3GB/s+ text processing throughput with alignment safety
-- **Lock-free Concurrency**: Wait-free data structures for minimal contention
-- **Zero-copy Architecture**: Efficient memory management throughout
-- **Performance Monitoring**: Real-time profiling with sub-microsecond precision
-
-### 🤖 **AI & Machine Learning**
-- **Multi-persona AI Agents**: 8 distinct personalities with OpenAI integration
-- **Interactive Chat System**: CLI-based chat with persona selection and backend support
-- **Advanced Neural Networks**: Feed-forward, CNN, RNN, and Transformer architectures
-- **Reinforcement Learning**: DQN, Policy Gradient, and Actor-Critic implementations
-- **Model Training Pipeline**: Complete training infrastructure with CSV data support
-- **Distributed Training**: Multi-GPU and multi-node training with parameter servers
-- **Vector Database**: Custom ABI format for high-dimensional embeddings
-- **Advanced ML Algorithms**: Transformer models, federated learning, online learning
-- **Model Serialization**: Full model save/load with versioning and compression
-
-### 🛡️ **Production-Ready Infrastructure**
-- **Production-Grade Servers**: Enterprise-ready HTTP/TCP servers with 99.98% uptime
-- **Network Error Recovery**: Graceful handling of connection failures and errors
-- **Fault Tolerance**: Servers continue operating even when individual connections fail
-- **Enhanced Monitoring**: Comprehensive observability with Prometheus + Grafana
-- **Production Deployment**: Docker containers, Kubernetes manifests, and cloud deployment
-- **Distributed Systems**: Multi-node deployment with load balancing and service discovery
-- **GPU Orchestration**: Kubernetes GPU resource management and scheduling
-
-### 🔌 **Extensible Plugin System**
-- **Cross-Platform Loading**: Windows (.dll), Linux (.so), macOS (.dylib)
-- **Type-Safe Interfaces**: C-compatible with safe Zig wrappers
-- **Dependency Management**: Automatic plugin loading and dependency resolution
-- **Event-Driven Architecture**: Inter-plugin messaging and service discovery
-
-## 🚀 **Quick Start**
-
-### **Prerequisites**
-- **Zig 0.16.0-dev.254+6dd0270a1** (GitHub Actions uses `mlugg/setup-zig@v2` pinned to this version)
-- GPU drivers (optional, for acceleration)
-- OpenAI API key (for AI agent features)
-
-### **Installation**
-
-```bash
-# Clone the repository
-git clone https://github.com/donaldfilimon/abi.git
-cd abi
-
-# Build
-zig build
-
-# Run tests
-zig build test
-
-# Docs (GitHub Pages)
-zig build docs
-
-# Benchmarks
-zig build bench-all
-
-# Run CLI
-zig build run
-
-# Run SIMD micro-benchmark
-zig build bench-simd
-```
-
-### **Basic Usage**
-
-```zig
-const std = @import("std");
-const abi = @import("abi");
-
-pub fn main() !void {
-    // Initialize framework with monitoring
-    var framework = try abi.init(std.heap.page_allocator, .{
-        .enable_gpu = true,
-        .enable_simd = true,
-        .enable_memory_tracking = true,
-        .enable_performance_profiling = true,
-    });
-    defer framework.deinit();
-
-    // Create AI agent
-    var agent = try abi.ai.Agent.init(std.heap.page_allocator, .creative);
-    defer agent.deinit();
-
-    // Generate response
-    const response = try agent.generate("Hello, how can you help me?", .{});
-    defer std.heap.page_allocator.free(response.content);
-
-    std.debug.print("🤖 Agent: {s}\n", .{response.content});
-}
-```
-
-### **Vector Database Example**
-
-```zig
-// Create vector database
-var db = try abi.database.Db.open("vectors.wdbx", true);
-defer db.close();
-
-try db.init(384); // 384-dimensional vectors
-
-// Add embeddings
-const embedding = [_]f32{0.1, 0.2, 0.3, /* ... */};
-const row_id = try db.addEmbedding(&embedding);
-
-// Search for similar vectors
-const query = [_]f32{0.15, 0.25, 0.35, /* ... */};
-const matches = try db.search(&query, 10, allocator);
-defer abi.features.database.database.Db.freeResults(matches, allocator);
-```
-
-> **Note:** Always release search metadata with `Db.freeResults(matches, allocator)` when you're done so allocator-backed metadata gets reclaimed.
-
-### **WDBX Vector Database Features**
-
-The ABI vector database provides enterprise-grade performance with:
-
-- **High Performance**: SIMD-optimized vector operations and efficient file I/O
-- **Vector Operations**: Add, query, and k-nearest neighbor search
-- **Multiple APIs**: Command-line interface, HTTP REST API, TCP binary protocol, WebSocket
-- **Security**: JWT authentication and rate limiting
-- **Monitoring**: Comprehensive statistics and performance metrics
-- **Production Ready**: Error handling, graceful degradation, and comprehensive testing
-
-#### **Command Line Usage**
-
-```bash
-# Query k-nearest neighbors
-./zig-out/bin/abi wdbx knn "1.1,2.1,3.1,4.1,5.1,6.1,7.1,8.1" 5
-
-# Query nearest neighbor
-./zig-out/bin/abi wdbx query "1.1,2.1,3.1,4.1,5.1,6.1,7.1,8.1"
-
-# Add vector to database
-./zig-out/bin/abi wdbx add "1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0"
-
-# Start HTTP REST API server
-./zig-out/bin/abi wdbx http --port 8080
-```
-
-#### **HTTP REST API**
-
-Start the server and access endpoints:
-
-```bash
-./zig-out/bin/abi wdbx http --port 8080
-```
-
-**API Endpoints:**
-- `GET /health` - Health check
-- `GET /stats` - Database statistics
-- `POST /add` - Add vector (requires admin token)
-- `GET /query?vec=1.0,2.0,3.0` - Query nearest neighbor
-- `GET /knn?vec=1.0,2.0,3.0&k=5` - Query k-nearest neighbors
-
-## 📊 **Performance Benchmarks**
-
-| Component | Performance | Hardware |
-|-----------|-------------|----------|
-| **Text Processing** | 3.2 GB/s | SIMD-accelerated with alignment safety |
-| **Vector Operations** | 15 GFLOPS | SIMD dot product with memory tracking |
-| **Neural Networks** | <1ms inference | 32x32 network with memory safety |
-| **LSP Completions** | <10ms response | Sub-10ms completion responses |
-| **GPU Rendering** | 500+ FPS | Terminal UI with GPU acceleration |
-| **Lock-free Queue** | 10M ops/sec | Single producer, minimal contention |
-| **WDBX Database** | 2,777+ ops/sec | Production-validated performance |
-
-## 🛠️ **Command Line Interface**
-
-```bash
-# AI Chat (Interactive)
-abi chat --persona creative --backend openai --interactive
-
-# AI Chat (Single Message)
-abi chat "Hello, how can you help me?" --persona analytical
-
-# Model Training
-abi llm train --data training_data.csv --output model.bin --epochs 100 --lr 0.001
-
-# Model Training with GPU
-abi llm train --data data.csv --gpu --threads 8 --batch-size 64
-
-# Vector Database Operations
-abi llm embed --db vectors.wdbx --text "Sample text for embedding"
-abi llm query --db vectors.wdbx --text "Query text" --k 5
-
-# Web Server
-abi web --port 8080
-
-# Performance Benchmarking
-abi benchmark --iterations 1000 --memory-track
-
-# Memory Profiling
-abi --memory-profile benchmark
-```
-
-## ⚙️ **Build Options**
-
-Configure features and targets via command-line flags:
-
-### **GPU & Acceleration**
-- `-Denable_cuda=true|false` (default: true) - Enable NVIDIA CUDA support
-- `-Denable_spirv=true|false` (default: true) - Enable Vulkan/SPIRV compilation
-- `-Denable_wasm=true|false` (default: true) - Enable WebAssembly compilation
-
-### **Optimization & Targets**
-- `-Dtarget=<triple>` - Cross-compilation target (e.g., `x86_64-linux-gnu`, `aarch64-macos`)
-- `-Doptimize=Debug|ReleaseSafe|ReleaseFast|ReleaseSmall` (default: Debug)
-
-### **Development Features**
-- `-Denable_cross_compilation=true|false` (default: true) - Enable cross-compilation support
-- `-Denable_heavy_tests=true|false` (default: false) - Run heavy database/HNSW tests
-
-### **Examples**
-
-```bash
-# Production build with CUDA acceleration
-zig build -Dtarget=x86_64-linux-gnu -Doptimize=ReleaseFast -Denable_cuda=true
-
-# Cross-compile for ARM64 macOS
-zig build -Dtarget=aarch64-macos -Doptimize=ReleaseSmall
-
-# Run with all tests including heavy ones
-zig build test-all -Denable_heavy_tests=true
-
-# Minimal build without GPU support
-zig build -Denable_cuda=false -Denable_spirv=false
-```
-
-### **Runtime Configuration**
-
-Build options are available at compile-time via the `options` module:
-
-```zig
-const options = @import("options");
-
-pub fn main() void {
-    std.log.info("CUDA: {}, SPIRV: {}", .{ options.enable_cuda, options.enable_spirv });
-    std.log.info("Target: {}", .{ options.target });
-}
-```
-
-## 🏗️ **Architecture Overview**
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│                    Abi AI Framework                        │
-├─────────────────────────────────────────────────────────────┤
-│  🤖 AI Agents    🧠 Neural Nets    🗄️ Vector Database    │
-├─────────────────────────────────────────────────────────────┤
-│  🚀 SIMD Ops     🔒 Lock-free      🌐 Network Servers    │
-├─────────────────────────────────────────────────────────────┤
-│  📊 Monitoring   🔍 Profiling      🧪 Testing Suite      │
-├─────────────────────────────────────────────────────────────┤
-│  🔌 Plugin Sys   📱 CLI Interface  🌍 Platform Ops      │
-└─────────────────────────────────────────────────────────────┘
-```
-
-## 📚 **Further Reading**
-
-- **[Documentation Portal](docs/README.md)** - Landing page that links to generated and manual guides
-- **[Module Organization](docs/MODULE_ORGANIZATION.md)** - Current source tree and dependency overview
-- **[Architecture & Feature Reference](docs/generated/MODULE_REFERENCE.md)** - Generated inventory of feature modules wired through `src/mod.zig`
-- **[Vector Database Guide](docs/api/database.md)** - WDBX storage engine configuration, sharding, and HTTP surfaces
-- **[AI Agent Guide](docs/api/ai.md)** - Agent personas, enhanced pipelines, and training utilities
-- **[GPU Acceleration Guide](docs/GPU_AI_ACCELERATION.md)** - Feature deep dive for GPU-backed workloads
-- **[Testing Strategy](docs/TESTING_STRATEGY.md)** - Quality gates, coverage expectations, and tooling
-- **[Production Deployment](docs/PRODUCTION_DEPLOYMENT.md)** - Deployment runbooks and environment guidance
-- **[API Reference](docs/api_reference.md)** - Hand-authored API summary with links to generated docs
-- **[Generated Documentation](docs/generated/)** - Auto-generated API, module, and example references
-
-## 🧪 **Testing & Quality**
-
-### Quick commands
-- Build: `zig build`
-- Test: `zig build test`
-- Bench: `zig build bench-all`
-- Docs: `zig build docs`
-- Static analysis: `zig build analyze`
-- Cross-platform: `zig build cross-platform`
-
-### **Comprehensive Test Suite**
-```bash
-# Run all tests
-zig build test
-
-# Memory management tests
-zig test tests/test_memory_management.zig
-
-# Performance regression tests
-zig test tests/test_performance_regression.zig
-
-# CLI integration tests
-zig test tests/test_cli_integration.zig
-```
-
-### **Quality Metrics**
-- **Memory Safety**: Zero memory leaks with comprehensive tracking
-- **Performance Stability**: <5% performance regression tolerance
-- **Test Coverage**: 95%+ code coverage with memory and performance tests
-- **Build Success Rate**: 99%+ successful builds across all platforms
-
-### **Test Categories**
-- **Memory Management**: Memory safety and leak detection (100% coverage)
-- **Performance Regression**: Performance stability monitoring (95% coverage)
-- **CLI Integration**: Command-line interface validation (90% coverage)
-- **Database Operations**: Vector database functionality (95% coverage)
-- **SIMD Operations**: SIMD acceleration validation (90% coverage)
-- **Network Infrastructure**: Server stability and error handling (95% coverage)
-
-## 🌐 **Web API**
-
-Start the web server and access REST endpoints:
-
-```bash
-abi web --port 8080
-```
-
-**Available Endpoints:**
-- `GET /health` - Health check
-- `GET /api/status` - System status
-- `POST /api/agent/query` - Query AI agent (JSON: `{"message": "your question"}`)
-- `POST /api/database/search` - Search vectors
-- `GET /api/database/info` - Database information
-- `WebSocket /ws` - Real-time chat with AI agent
-
-## 🔌 **Plugin Development**
-
-Create custom plugins for the framework:
-
-```zig
-// Example plugin
-pub const ExamplePlugin = struct {
-    pub const name = "example_plugin";
-    pub const version = "1.0.0";
-    
-    pub fn init(allocator: std.mem.Allocator) !*@This() {
-        // Plugin initialization
-    }
-    
-    pub fn deinit(self: *@This()) void {
-        // Plugin cleanup
-    }
-};
-```
-
-See the [Module Organization guide](docs/MODULE_ORGANIZATION.md) and generated module reference for plugin entry points.
-
-## 🚀 **Production Deployment**
-
-The framework includes production-ready deployment configurations:
-
-- **Kubernetes Manifests**: Complete staging and production deployments
-- **Monitoring Stack**: Prometheus + Grafana with validated thresholds
-- **Performance Validation**: 2,777+ ops/sec with 99.98% uptime
-- **Automated Scripts**: Windows (PowerShell) and Linux deployment scripts
-
-See [Production Deployment Guide](docs/PRODUCTION_DEPLOYMENT.md) for complete deployment instructions.
-
-## 🌍 **Cross-Platform Guide (Zig 0.16.0-dev.254+6dd0270a1)**
-
-### **Targets**
-```bash
-# Examples
-zig build -Dtarget=x86_64-linux-gnu
-zig build -Dtarget=aarch64-linux-gnu
-zig build -Dtarget=x86_64-macos
-zig build -Dtarget=aarch64-macos
-zig build -Dtarget=wasm32-wasi
-```
-
-### **Conditional Compilation**
-```zig
-const builtin = @import("builtin");
-
-pub fn main() void {
-    if (comptime builtin.os.tag == .windows) {
-        // Windows-specific code
-    } else if (comptime builtin.os.tag == .linux) {
-        // Linux-specific code
-    } else if (comptime builtin.os.tag == .macos) {
-        // macOS-specific code
-    }
-}
-```
-
-### **Cross-Platform Build Step**
-```bash
-zig build cross-platform   # builds CLI for multiple targets into zig-out/cross/
-```
-
-### **Windows Networking Notes**
-- Windows networking paths use Winsock on Windows to avoid ReadFile edge cases
-- Diagnostic tool: `zig build test-network` (Windows only)
-- PowerShell fixes: `fix_windows_networking.ps1`
-
-## 🤝 **Contributing**
-
-We welcome contributions! Please read our [Contributing Guide](CONTRIBUTING.md) for details.
-
-### **Development Workflow**
-1. **Fork and Clone**: Create a feature branch
-2. **Run Tests**: Ensure all tests pass with monitoring
-3. **Memory Safety**: Verify no leaks in your changes
-4. **Performance**: Run performance tests to ensure no regressions
-5. **Documentation**: Update docs for new features
-6. **Submit PR**: Create pull request with comprehensive coverage
-
-## 📄 **License**
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## 🆘 **Support**
-
-- **📖 Documentation**: [docs/](docs/)
-- **🐛 Issues**: [GitHub Issues](https://github.com/yourusername/abi/issues)
-- **💬 Discord**: [Join our server](https://discord.gg/yourinvite)
-- **📧 Email**: support@abi-framework.org
-
-## 🙏 **Acknowledgments**
-
-- [Zig programming language](https://ziglang.org/) team
-- [WebGPU specification](https://www.w3.org/TR/webgpu/) contributors
-- Open source community contributors
+Cross-platform suites gracefully skip on unsupported hosts. Debug builds enable leak detection by default; aim to keep
+performance regressions under 5% across releases.
 
 ---
 
-**⭐ Star this repository if you find it useful!**
+## Documentation & Resources
+- [`docs/`](docs/) – Landing page for manuals, deployment guides, and generated references.
+- [`DEPLOYMENT_GUIDE.md`](DEPLOYMENT_GUIDE.md) – Production rollout checklist.
+- [`CROSS_PLATFORM_TESTING_GUIDE.md`](CROSS_PLATFORM_TESTING_GUIDE.md) – Supported matrix and CI configuration.
+- [`UTILITIES_IMPLEMENTATION_SUMMARY.md`](UTILITIES_IMPLEMENTATION_SUMMARY.md) – Overview of developer tooling.
+- [`MIGRATION_REPORT.md`](MIGRATION_REPORT.md) – Upgrade notes across releases.
 
-**🚀 Ready to build the future of AI with Zig? Get started with Abi AI Framework today!**
+---
+
+## Contributing
+1. Fork the repository and create a feature branch.
+2. Run `zig build`, `zig build test`, and relevant benchmarks before submitting changes.
+3. Update documentation when modifying public APIs or behavior.
+4. Open a pull request with a clear summary, reproduction steps for fixes, and benchmark deltas when relevant.
+
+**Need help?**
+- Documentation portal: [`docs/`](docs/)
+- GitHub Issues: <https://github.com/donaldfilimon/abi/issues>
+- Community channels (Discord/email): see the documentation landing page.
+
+---
+
+## License
+This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
+
+⭐ **Star the project if Abi helps accelerate your AI workloads!**


### PR DESCRIPTION
## Summary
- restore a balanced README structure with badges, overview, and clarified capability groupings
- reintroduce installation, quick start, and usage workflows while keeping commands concise and scannable
- reorganize performance, testing, and resource references into dedicated sections with tables and curated links

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d03e2272548331a6fada1e53a185f5