### PR TITLE
docs: align readme with available bootstrap api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Abi AI Framework
-> Ultra-high-performance AI framework with GPU acceleration, lock-free concurrency, and platform-optimized implementations.
+> Modular Zig framework for composing ABI feature sets and managing plugin lifecycles.
 
 [![Zig Version](https://img.shields.io/badge/Zig-0.16.0--dev.254%2B6dd0270a1-orange.svg)](https://ziglang.org/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -8,30 +8,25 @@
 ## 🚀 Features
 
 ### Core Capabilities
-- **GPU Acceleration**: WebGPU with platform-specific fallbacks
-- **SIMD Optimizations**: 3GB/s+ throughput with alignment safety
-- **Lock-free Concurrency**: Wait-free data structures
-- **Vector Database**: Custom WDBX-AI format for embeddings
-- **Neural Networks**: SIMD-accelerated operations
-- **Plugin System**: Cross-platform dynamic loading
-- **Production Servers**: HTTP/TCP with fault tolerance
+- **Framework bootstrap**: The `abi` executable initialises the framework and prints a runtime summary.
+- **Feature toggles**: `abi.Framework` exposes bitset-backed toggles for major feature groups.
+- **Plugin registry**: Shared plugin registry helpers handle discovery, loading and lifecycle calls.
+- **Module re-exports**: `@import("abi")` surfaces organised submodules under `abi.features`, `abi.framework`, and `abi.shared`.
 
 ### Platform Support
-- **Cross-platform**: Windows, Linux, macOS, iOS
-- **Platform Optimizations**: OS-specific enhancements
-- **Discord Integration**: Bot framework with gateway support
+- **Cross-platform**: Builds on Linux, macOS, and Windows with the Zig toolchain.
+- **CLI-first**: Ships as a bootstrap executable; additional services are built on top of the API surface.
 
 ## Installation
 
 ### Prerequisites
 - **Zig 0.16.0-dev.254+6dd0270a1** (see `.zigversion` and verify with `zig version`)
-- GPU drivers (optional, for acceleration)
-- OpenAI API key (for AI features)
+- Optional GPU drivers if you plan to explore the GPU feature modules.
 
 ### Compatibility
 
 - **Current Toolchain**: Zig 0.16.0-dev.254+6dd0270a1. This repository's `.zigversion` file is the authoritative reference—match it exactly when installing Zig.
-- **Legacy Notes**: Historical guidance for Zig 0.15.x (including CI setups using `mlugg/setup-zig@v2` with Zig 0.15.0) remains in older sections below for teams maintaining legacy deployments. These paths are not part of the active test matrix.
+- **Legacy Notes**: Earlier Zig 0.15.x instructions are available in the Git history for teams maintaining older deployments.
 
 ### Quick Start
 ```bash
@@ -39,28 +34,25 @@ git clone https://github.com/donaldfilimon/abi.git
 cd abi
 zig build -Doptimize=ReleaseFast
 zig build test
-./zig-out/bin/abi --help
+zig build run
 ```
 
 ## 📁 Project Structure
 
 ```
 abi/
-├── src/                          # Source code
-│   ├── core/                     # Core utilities
-│   ├── framework/                # Runtime orchestration and lifecycle
-│   ├── ai/                       # AI/ML components
-│   ├── database/                 # Vector database
-│   ├── net/                      # Networking
-│   ├── perf/                     # Performance monitoring
-│   ├── gpu/                      # GPU acceleration
-│   ├── ml/                       # ML algorithms
-│   ├── simd/                     # SIMD operations
-│   └── wdbx/                     # CLI interface
-├── tests/                        # Test suite
-├── docs/                         # Documentation
-├── examples/                     # Usage examples
-└── tools/                        # Development tools
+├── src/
+│   ├── features/      # Feature families re-exported under `abi.features`
+│   ├── framework/     # Framework configuration, runtime, and feature toggles
+│   ├── shared/        # Common utilities (logging, platform helpers, registry)
+│   ├── examples/      # Library usage snippets
+│   ├── tools/         # Internal utilities and maintenance commands
+│   ├── main.zig       # Bootstrap executable entry point
+│   └── mod.zig        # Public module surface
+├── tests/             # Additional top-level tests
+├── docs/              # Project documentation
+├── benchmarks/        # Benchmark harnesses
+└── scripts/           # Development scripts
 
 ## Quick Start
 
@@ -72,95 +64,95 @@ const abi = @import("abi");
 pub fn main() !void {
     const allocator = std.heap.page_allocator;
 
-    // Create AI agent using the exported AgentConfig
-    var agent = try abi.features.ai.agent.Agent.init(allocator, .{ .name = "QuickStart" });
-    defer agent.deinit();
+    var framework = try abi.init(allocator, .{});
+    defer framework.deinit();
 
-    // Process a message
-    const response = try agent.process("Hello!", allocator);
-    defer allocator.free(@constCast(response));
+    // Write the bootstrap summary to stdout
+    try framework.writeSummary(std.io.getStdOut().writer());
 }
 ```
 
-> `Agent.process` duplicates its reply into the allocator you provide, so callers must free the returned buffer once they're
-> done with it.
+> `abi.init` allocates internal bookkeeping structures; always pair it with `Framework.deinit` (or `abi.shutdown`).
 
 ### Vector Database
 ```zig
-// Open database
-var db = try abi.features.database.database.Db.open("vectors.wdbx", true);
-defer db.close();
+const std = @import("std");
+const abi = @import("abi");
 
-// Add and search vectors
-const embedding = [_]f32{0.1, 0.2, 0.3};
-const results = try db.search(&embedding, 10, allocator);
+// Access the database feature module through the re-exported API.
+const Database = abi.features.database;
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+
+    var db = try Database.database.Db.open("vectors.wdbx", true);
+    defer db.close();
+
+    const embedding = [_]f32{ 0.1, 0.2, 0.3 };
+    try db.init(embedding.len);
+
+    const results = try db.search(&embedding, 10, gpa.allocator());
+    defer gpa.allocator().free(results);
+}
 ```
-
-### WDBX CLI
-
-```bash
-# Inspect available subcommands
-./zig-out/bin/abi wdbx help
-
-# Launch the lightweight HTTP API (Ctrl+C to stop)
-./zig-out/bin/abi wdbx http --host 0.0.0.0 --port 8080
-```
-
-> If you install `abi` into your `PATH`, you can drop the `./zig-out/bin/` prefix and run commands like `abi wdbx http …` directly.
 
 ## Modules
 
-- **`core/`**: Core utilities and framework foundation
-- **`framework/`**: Runtime orchestrator that wires features and plugins together
-- **`ai/`**: AI agents and machine learning components
-- **`database/`**: WDBX-AI vector database with HNSW indexing
-- **`net/`**: HTTP/TCP servers and client libraries
-- **`simd/`**: SIMD-accelerated operations
-- **`perf/`**: Performance monitoring and profiling
-- **`gpu/`**: GPU acceleration and rendering
-- **`ml/`**: Machine learning algorithms
+- **`abi.framework`**: High-level configuration, runtime orchestration, and feature toggles.
+- **`abi.features.ai`**: AI-focused modules including agent pipelines and neural helpers.
+- **`abi.features.database`**: WDBX storage engine, search helpers, and CLI bindings.
+- **`abi.features.web`**: HTTP scaffolding and routing utilities exposed via the framework.
+- **`abi.features.monitoring`**: Telemetry and instrumentation primitives.
+- **`abi.features.gpu`**: GPU-oriented abstractions and compute helpers.
+- **`abi.features.connectors`**: Integrations for external services and adapters.
+- **`abi.shared`**: Common logging, platform, and plugin registry utilities.
 
 ## CLI
 
-The current executable boots the framework and prints a bootstrap summary. Run it with Zig's
-build system:
+The bundled executable initialises the framework and prints a runtime summary. It is
+primarily a bootstrap tool for validating feature toggles and plugin discovery logic.
 
 ```bash
-abi help                    # Show commands
-abi chat                    # AI chat session
-abi train <data>           # Train neural network
-./zig-out/bin/abi wdbx http --host 0.0.0.0 --port 8080   # Start HTTP server
-abi benchmark              # Performance tests
-abi analyze <file>         # Text analysis
+# Build and run the bootstrap executable
+zig build run
 
-# With options
-abi --memory-track --gpu benchmark
-abi --verbose --debug chat
+# Or invoke the binary directly after building
+./zig-out/bin/abi
 ```
 
-## API
+Sample output:
 
-```bash
-abi web                    # Start web server
+```
+ABI Framework bootstrap complete
+Features enabled (5):
+  - AI/Agents: Conversation agents, training loops, and inference helpers
+  - Vector Database: High-performance embedding and vector persistence layer
+  - Web Services: HTTP servers, clients, and gateway orchestration
+  - Monitoring: Instrumentation, telemetry, and health checks
+  - SIMD Runtime: Runtime SIMD utilities and fast math operations
+Plugin search paths: none configured
+Registered plugins: 0
+Discovered plugins awaiting load: 0
 ```
 
-**Endpoints:**
-- `GET /health` - Health check
-- `POST /api/agent/query` - AI queries
-- `POST /api/database/search` - Vector search
+Use the executable as a reference implementation for invoking `abi.init` and interacting with
+`abi.Framework`; custom applications are expected to build on the library API directly.
 
-## Performance
+## API Surface
 
-**Benchmarks:**
-- **Text Processing**: 3.2 GB/s SIMD throughput
-- **Vector Operations**: 15 GFLOPS
-- **Neural Networks**: <1ms inference
-- **Memory Tracking**: <1% overhead
+The `abi` module provides a curated export of framework primitives:
 
-```bash
-abi benchmark --memory-track    # Run benchmarks
-abi --memory-track --gpu        # Monitor performance
-```
+- `abi.init(allocator, options)` and `abi.shutdown` manage the primary `Framework` lifecycle.
+- `abi.Framework` exposes feature toggles, plugin path helpers (`setPluginPaths`, `refreshPlugins`),
+  and summary writers (`writeSummary`).
+- `abi.framework` re-exports the full framework configuration and runtime modules when you need
+  lower-level access.
+- `abi.features.*` namespaces organise feature code such as `abi.features.ai`,
+  `abi.features.database`, and `abi.features.monitoring`.
+
+Refer to `src/mod.zig` for the complete list of re-exports and `src/framework/runtime.zig` for
+runtime semantics.
 
 ## Testing
 
@@ -178,11 +170,10 @@ zig test tests/cross-platform/windows.zig
 The cross-platform tests gracefully skip when run on unsupported operating systems, so it's
 safe to invoke the full list from any development environment.
 
-**Quality Metrics:**
-- Memory Safety: Zero leaks
-- Performance: <5% regression tolerance
-- Test Coverage: 95%+
-- Build Success: 99%+
+**Quality Goals:**
+- Maintain leak-free operation under `zig build test`.
+- Keep feature and plugin API changes documented in `CHANGELOG.md`.
+- Ensure new modules include unit tests or examples illustrating usage.
 
 ## Contributing
 
@@ -199,459 +190,3 @@ MIT License - see [LICENSE](LICENSE)
 
 - [Documentation](docs/)
 - [Issues](https://github.com/donaldfilimon/abi/issues)
-# 🚀 Abi AI Framework
-
-> **Ultra-high-performance AI framework with GPU acceleration, lock-free concurrency, advanced monitoring, and platform-optimized implementations for Zig development.**
-
-[![Zig Version](https://img.shields.io/badge/Zig-0.16.0--dev.254%2B6dd0270a1-orange.svg)](https://ziglang.org/) • [Docs](https://donaldfilimon.github.io/abi/) • [CI: Pages](.github/workflows/deploy_docs.yml)
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Platform](https://img.shields.io/badge/Platform-Cross--platform-green.svg)](https://github.com/yourusername/abi)
-[![Build Status](https://img.shields.io/badge/Build-Passing-brightgreen.svg)]()
-[![Tests](https://img.shields.io/badge/Tests-Passing-brightgreen.svg)]()
-[![Performance](https://img.shields.io/badge/Performance-2,777+%20ops%2Fsec-brightgreen.svg)]()
-
-## ✅ **Key Improvements**
-- **Performance**: SIMD optimizations, arena allocators, statistical analysis
-- **Reliability**: Enhanced error handling, memory leak detection, thread safety
-- **Monitoring**: Real-time metrics, adaptive load balancing, confidence scoring
-- **Reporting**: Multiple output formats, detailed analytics, optimization recommendations
-- **Security**: Vulnerability detection, secure random generation, input validation
-- **Platform Support**: Windows-specific optimizations, cross-platform compatibility
-- **Chat Integration**: Complete AI chat functionality with multiple personas and backends
-- **Model Training**: Full neural network training pipeline with CLI interface
-- **Web API**: RESTful endpoints and WebSocket support for AI interactions
-
-## ✨ **Key Features**
-
-### 🚀 **Performance & Acceleration**
-- **GPU Acceleration**: WebGPU support with fallback to platform-specific APIs
-- **SIMD Optimizations**: 3GB/s+ text processing throughput with alignment safety
-- **Lock-free Concurrency**: Wait-free data structures for minimal contention
-- **Zero-copy Architecture**: Efficient memory management throughout
-- **Performance Monitoring**: Real-time profiling with sub-microsecond precision
-
-### 🤖 **AI & Machine Learning**
-- **Multi-persona AI Agents**: 8 distinct personalities with OpenAI integration
-- **Interactive Chat System**: CLI-based chat with persona selection and backend support
-- **Advanced Neural Networks**: Feed-forward, CNN, RNN, and Transformer architectures
-- **Reinforcement Learning**: DQN, Policy Gradient, and Actor-Critic implementations
-- **Model Training Pipeline**: Complete training infrastructure with CSV data support
-- **Distributed Training**: Multi-GPU and multi-node training with parameter servers
-- **Vector Database**: Custom ABI format for high-dimensional embeddings
-- **Advanced ML Algorithms**: Transformer models, federated learning, online learning
-- **Model Serialization**: Full model save/load with versioning and compression
-
-### 🛡️ **Production-Ready Infrastructure**
-- **Production-Grade Servers**: Enterprise-ready HTTP/TCP servers with 99.98% uptime
-- **Network Error Recovery**: Graceful handling of connection failures and errors
-- **Fault Tolerance**: Servers continue operating even when individual connections fail
-- **Enhanced Monitoring**: Comprehensive observability with Prometheus + Grafana
-- **Production Deployment**: Docker containers, Kubernetes manifests, and cloud deployment
-- **Distributed Systems**: Multi-node deployment with load balancing and service discovery
-- **GPU Orchestration**: Kubernetes GPU resource management and scheduling
-
-### 🔌 **Extensible Plugin System**
-- **Cross-Platform Loading**: Windows (.dll), Linux (.so), macOS (.dylib)
-- **Type-Safe Interfaces**: C-compatible with safe Zig wrappers
-- **Dependency Management**: Automatic plugin loading and dependency resolution
-- **Event-Driven Architecture**: Inter-plugin messaging and service discovery
-
-## 🚀 **Quick Start**
-
-### **Prerequisites**
-- **Zig 0.16.0-dev.254+6dd0270a1** (GitHub Actions uses `mlugg/setup-zig@v2` pinned to this version)
-- GPU drivers (optional, for acceleration)
-- OpenAI API key (for AI agent features)
-
-### **Installation**
-
-```bash
-# Clone the repository
-git clone https://github.com/donaldfilimon/abi.git
-cd abi
-
-# Build
-zig build
-
-# Run tests
-zig build test
-
-# Docs (GitHub Pages)
-zig build docs
-
-# Benchmarks
-zig build bench-all
-
-# Run CLI
-zig build run
-
-# Run SIMD micro-benchmark
-zig build bench-simd
-```
-
-### **Basic Usage**
-
-```zig
-const std = @import("std");
-const abi = @import("abi");
-
-pub fn main() !void {
-    // Initialize framework with monitoring
-    var framework = try abi.init(std.heap.page_allocator, .{
-        .enable_gpu = true,
-        .enable_simd = true,
-        .enable_memory_tracking = true,
-        .enable_performance_profiling = true,
-    });
-    defer framework.deinit();
-
-    // Create AI agent
-    var agent = try abi.ai.Agent.init(std.heap.page_allocator, .creative);
-    defer agent.deinit();
-
-    // Generate response
-    const response = try agent.generate("Hello, how can you help me?", .{});
-    defer std.heap.page_allocator.free(response.content);
-
-    std.debug.print("🤖 Agent: {s}\n", .{response.content});
-}
-```
-
-### **Vector Database Example**
-
-```zig
-// Create vector database
-var db = try abi.database.Db.open("vectors.wdbx", true);
-defer db.close();
-
-try db.init(384); // 384-dimensional vectors
-
-// Add embeddings
-const embedding = [_]f32{0.1, 0.2, 0.3, /* ... */};
-const row_id = try db.addEmbedding(&embedding);
-
-// Search for similar vectors
-const query = [_]f32{0.15, 0.25, 0.35, /* ... */};
-const matches = try db.search(&query, 10, allocator);
-defer abi.features.database.database.Db.freeResults(matches, allocator);
-```
-
-> **Note:** Always release search metadata with `Db.freeResults(matches, allocator)` when you're done so allocator-backed metadata gets reclaimed.
-
-### **WDBX Vector Database Features**
-
-The ABI vector database provides enterprise-grade performance with:
-
-- **High Performance**: SIMD-optimized vector operations and efficient file I/O
-- **Vector Operations**: Add, query, and k-nearest neighbor search
-- **Multiple APIs**: Command-line interface, HTTP REST API, TCP binary protocol, WebSocket
-- **Security**: JWT authentication and rate limiting
-- **Monitoring**: Comprehensive statistics and performance metrics
-- **Production Ready**: Error handling, graceful degradation, and comprehensive testing
-
-#### **Command Line Usage**
-
-```bash
-# Query k-nearest neighbors
-./zig-out/bin/abi wdbx knn "1.1,2.1,3.1,4.1,5.1,6.1,7.1,8.1" 5
-
-# Query nearest neighbor
-./zig-out/bin/abi wdbx query "1.1,2.1,3.1,4.1,5.1,6.1,7.1,8.1"
-
-# Add vector to database
-./zig-out/bin/abi wdbx add "1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0"
-
-# Start HTTP REST API server
-./zig-out/bin/abi wdbx http --port 8080
-```
-
-#### **HTTP REST API**
-
-Start the server and access endpoints:
-
-```bash
-./zig-out/bin/abi wdbx http --port 8080
-```
-
-**API Endpoints:**
-- `GET /health` - Health check
-- `GET /stats` - Database statistics
-- `POST /add` - Add vector (requires admin token)
-- `GET /query?vec=1.0,2.0,3.0` - Query nearest neighbor
-- `GET /knn?vec=1.0,2.0,3.0&k=5` - Query k-nearest neighbors
-
-## 📊 **Performance Benchmarks**
-
-| Component | Performance | Hardware |
-|-----------|-------------|----------|
-| **Text Processing** | 3.2 GB/s | SIMD-accelerated with alignment safety |
-| **Vector Operations** | 15 GFLOPS | SIMD dot product with memory tracking |
-| **Neural Networks** | <1ms inference | 32x32 network with memory safety |
-| **LSP Completions** | <10ms response | Sub-10ms completion responses |
-| **GPU Rendering** | 500+ FPS | Terminal UI with GPU acceleration |
-| **Lock-free Queue** | 10M ops/sec | Single producer, minimal contention |
-| **WDBX Database** | 2,777+ ops/sec | Production-validated performance |
-
-## 🛠️ **Command Line Interface**
-
-```bash
-# AI Chat (Interactive)
-abi chat --persona creative --backend openai --interactive
-
-# AI Chat (Single Message)
-abi chat "Hello, how can you help me?" --persona analytical
-
-# Model Training
-abi llm train --data training_data.csv --output model.bin --epochs 100 --lr 0.001
-
-# Model Training with GPU
-abi llm train --data data.csv --gpu --threads 8 --batch-size 64
-
-# Vector Database Operations
-abi llm embed --db vectors.wdbx --text "Sample text for embedding"
-abi llm query --db vectors.wdbx --text "Query text" --k 5
-
-# Web Server
-abi web --port 8080
-
-# Performance Benchmarking
-abi benchmark --iterations 1000 --memory-track
-
-# Memory Profiling
-abi --memory-profile benchmark
-```
-
-## ⚙️ **Build Options**
-
-Configure features and targets via command-line flags:
-
-### **GPU & Acceleration**
-- `-Denable_cuda=true|false` (default: true) - Enable NVIDIA CUDA support
-- `-Denable_spirv=true|false` (default: true) - Enable Vulkan/SPIRV compilation
-- `-Denable_wasm=true|false` (default: true) - Enable WebAssembly compilation
-
-### **Optimization & Targets**
-- `-Dtarget=<triple>` - Cross-compilation target (e.g., `x86_64-linux-gnu`, `aarch64-macos`)
-- `-Doptimize=Debug|ReleaseSafe|ReleaseFast|ReleaseSmall` (default: Debug)
-
-### **Development Features**
-- `-Denable_cross_compilation=true|false` (default: true) - Enable cross-compilation support
-- `-Denable_heavy_tests=true|false` (default: false) - Run heavy database/HNSW tests
-
-### **Examples**
-
-```bash
-# Production build with CUDA acceleration
-zig build -Dtarget=x86_64-linux-gnu -Doptimize=ReleaseFast -Denable_cuda=true
-
-# Cross-compile for ARM64 macOS
-zig build -Dtarget=aarch64-macos -Doptimize=ReleaseSmall
-
-# Run with all tests including heavy ones
-zig build test-all -Denable_heavy_tests=true
-
-# Minimal build without GPU support
-zig build -Denable_cuda=false -Denable_spirv=false
-```
-
-### **Runtime Configuration**
-
-Build options are available at compile-time via the `options` module:
-
-```zig
-const options = @import("options");
-
-pub fn main() void {
-    std.log.info("CUDA: {}, SPIRV: {}", .{ options.enable_cuda, options.enable_spirv });
-    std.log.info("Target: {}", .{ options.target });
-}
-```
-
-## 🏗️ **Architecture Overview**
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│                    Abi AI Framework                        │
-├─────────────────────────────────────────────────────────────┤
-│  🤖 AI Agents    🧠 Neural Nets    🗄️ Vector Database    │
-├─────────────────────────────────────────────────────────────┤
-│  🚀 SIMD Ops     🔒 Lock-free      🌐 Network Servers    │
-├─────────────────────────────────────────────────────────────┤
-│  📊 Monitoring   🔍 Profiling      🧪 Testing Suite      │
-├─────────────────────────────────────────────────────────────┤
-│  🔌 Plugin Sys   📱 CLI Interface  🌍 Platform Ops      │
-└─────────────────────────────────────────────────────────────┘
-```
-
-## 📚 **Further Reading**
-
-- **[Documentation Portal](docs/README.md)** - Landing page that links to generated and manual guides
-- **[Module Organization](docs/MODULE_ORGANIZATION.md)** - Current source tree and dependency overview
-- **[Architecture & Feature Reference](docs/generated/MODULE_REFERENCE.md)** - Generated inventory of feature modules wired through `src/mod.zig`
-- **[Vector Database Guide](docs/api/database.md)** - WDBX storage engine configuration, sharding, and HTTP surfaces
-- **[AI Agent Guide](docs/api/ai.md)** - Agent personas, enhanced pipelines, and training utilities
-- **[GPU Acceleration Guide](docs/GPU_AI_ACCELERATION.md)** - Feature deep dive for GPU-backed workloads
-- **[Testing Strategy](docs/TESTING_STRATEGY.md)** - Quality gates, coverage expectations, and tooling
-- **[Production Deployment](docs/PRODUCTION_DEPLOYMENT.md)** - Deployment runbooks and environment guidance
-- **[API Reference](docs/api_reference.md)** - Hand-authored API summary with links to generated docs
-- **[Generated Documentation](docs/generated/)** - Auto-generated API, module, and example references
-
-## 🧪 **Testing & Quality**
-
-### Quick commands
-- Build: `zig build`
-- Test: `zig build test`
-- Bench: `zig build bench-all`
-- Docs: `zig build docs`
-- Static analysis: `zig build analyze`
-- Cross-platform: `zig build cross-platform`
-
-### **Comprehensive Test Suite**
-```bash
-# Run all tests
-zig build test
-
-# Memory management tests
-zig test tests/test_memory_management.zig
-
-# Performance regression tests
-zig test tests/test_performance_regression.zig
-
-# CLI integration tests
-zig test tests/test_cli_integration.zig
-```
-
-### **Quality Metrics**
-- **Memory Safety**: Zero memory leaks with comprehensive tracking
-- **Performance Stability**: <5% performance regression tolerance
-- **Test Coverage**: 95%+ code coverage with memory and performance tests
-- **Build Success Rate**: 99%+ successful builds across all platforms
-
-### **Test Categories**
-- **Memory Management**: Memory safety and leak detection (100% coverage)
-- **Performance Regression**: Performance stability monitoring (95% coverage)
-- **CLI Integration**: Command-line interface validation (90% coverage)
-- **Database Operations**: Vector database functionality (95% coverage)
-- **SIMD Operations**: SIMD acceleration validation (90% coverage)
-- **Network Infrastructure**: Server stability and error handling (95% coverage)
-
-## 🌐 **Web API**
-
-Start the web server and access REST endpoints:
-
-```bash
-abi web --port 8080
-```
-
-**Available Endpoints:**
-- `GET /health` - Health check
-- `GET /api/status` - System status
-- `POST /api/agent/query` - Query AI agent (JSON: `{"message": "your question"}`)
-- `POST /api/database/search` - Search vectors
-- `GET /api/database/info` - Database information
-- `WebSocket /ws` - Real-time chat with AI agent
-
-## 🔌 **Plugin Development**
-
-Create custom plugins for the framework:
-
-```zig
-// Example plugin
-pub const ExamplePlugin = struct {
-    pub const name = "example_plugin";
-    pub const version = "1.0.0";
-    
-    pub fn init(allocator: std.mem.Allocator) !*@This() {
-        // Plugin initialization
-    }
-    
-    pub fn deinit(self: *@This()) void {
-        // Plugin cleanup
-    }
-};
-```
-
-See the [Module Organization guide](docs/MODULE_ORGANIZATION.md) and generated module reference for plugin entry points.
-
-## 🚀 **Production Deployment**
-
-The framework includes production-ready deployment configurations:
-
-- **Kubernetes Manifests**: Complete staging and production deployments
-- **Monitoring Stack**: Prometheus + Grafana with validated thresholds
-- **Performance Validation**: 2,777+ ops/sec with 99.98% uptime
-- **Automated Scripts**: Windows (PowerShell) and Linux deployment scripts
-
-See [Production Deployment Guide](docs/PRODUCTION_DEPLOYMENT.md) for complete deployment instructions.
-
-## 🌍 **Cross-Platform Guide (Zig 0.16.0-dev.254+6dd0270a1)**
-
-### **Targets**
-```bash
-# Examples
-zig build -Dtarget=x86_64-linux-gnu
-zig build -Dtarget=aarch64-linux-gnu
-zig build -Dtarget=x86_64-macos
-zig build -Dtarget=aarch64-macos
-zig build -Dtarget=wasm32-wasi
-```
-
-### **Conditional Compilation**
-```zig
-const builtin = @import("builtin");
-
-pub fn main() void {
-    if (comptime builtin.os.tag == .windows) {
-        // Windows-specific code
-    } else if (comptime builtin.os.tag == .linux) {
-        // Linux-specific code
-    } else if (comptime builtin.os.tag == .macos) {
-        // macOS-specific code
-    }
-}
-```
-
-### **Cross-Platform Build Step**
-```bash
-zig build cross-platform   # builds CLI for multiple targets into zig-out/cross/
-```
-
-### **Windows Networking Notes**
-- Windows networking paths use Winsock on Windows to avoid ReadFile edge cases
-- Diagnostic tool: `zig build test-network` (Windows only)
-- PowerShell fixes: `fix_windows_networking.ps1`
-
-## 🤝 **Contributing**
-
-We welcome contributions! Please read our [Contributing Guide](CONTRIBUTING.md) for details.
-
-### **Development Workflow**
-1. **Fork and Clone**: Create a feature branch
-2. **Run Tests**: Ensure all tests pass with monitoring
-3. **Memory Safety**: Verify no leaks in your changes
-4. **Performance**: Run performance tests to ensure no regressions
-5. **Documentation**: Update docs for new features
-6. **Submit PR**: Create pull request with comprehensive coverage
-
-## 📄 **License**
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## 🆘 **Support**
-
-- **📖 Documentation**: [docs/](docs/)
-- **🐛 Issues**: [GitHub Issues](https://github.com/yourusername/abi/issues)
-- **💬 Discord**: [Join our server](https://discord.gg/yourinvite)
-- **📧 Email**: support@abi-framework.org
-
-## 🙏 **Acknowledgments**
-
-- [Zig programming language](https://ziglang.org/) team
-- [WebGPU specification](https://www.w3.org/TR/webgpu/) contributors
-- Open source community contributors
-
----
-
-**⭐ Star this repository if you find it useful!**
-
-**🚀 Ready to build the future of AI with Zig? Get started with Abi AI Framework today!**


### PR DESCRIPTION
## Summary
- replace inaccurate CLI, REST, and benchmark claims in the README with a truthful description of the bootstrap executable
- refresh usage examples to demonstrate the `abi.*` module re-exports and clean up the project structure overview
- trim obsolete promotional sections and point readers to the curated API surface and support links

## Testing
- `zig build test` *(fails: command not found: zig)*

------
https://chatgpt.com/codex/tasks/task_e_68d041e2155c8331be46b93d88f28155