### PR TITLE
Prepare 0.1.0a changelog and update release tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,23 @@
 
 All notable changes to the Abi AI Framework.
 
-## [1.0.0] - 2025-01-18
+<a id="010a"></a>
+
+## [0.1.0a] - 2025-09-21
+
+### Added
+- **Framework bootstrap API**: `abi.init` now constructs the `Framework` orchestration layer with sensible defaults and exposes lifecycle helpers such as `shutdown()` for orderly teardown.
+- **Feature toggle system**: `FrameworkOptions` and `FeatureToggles` allow callers to enable/disable AI, database, web, monitoring, SIMD, and GPU functionality at runtime.
+- **Plugin registry**: Dynamic plugin discovery, registration, and lifecycle management via `PluginRegistry`, including dependency tracking and safe unload/deinit handling.
+- **Operational summary output**: `Framework.writeSummary` produces a human-readable snapshot of enabled features, plugin search paths, and registry state for CLI tools.
+
+### Tooling
+- Release automation via `scripts/release.(sh|ps1)` builds, tests, and packages the framework with consistent fallback metadata.
+
+<a id="100-planned"></a>
+
+## [1.0.0] - 2025-01-18 *(Planned – not yet released)*
+> **Status:** Roadmap goals for a future stable milestone. The features below describe intent and remain unreleased.
 
 ### 🎉 Production-Ready Release
 
@@ -40,7 +56,10 @@ All notable changes to the Abi AI Framework.
 - Network: 99.98% success rate
 - Memory: 4.096KB per vector, zero leaks
 
-## [1.0.0-alpha] - 2024-01-01
+<a id="100-alpha-planned"></a>
+
+## [1.0.0-alpha] - 2024-01-01 *(Planned – not yet released)*
+> **Status:** Early roadmap concepts for 1.x development; these capabilities are aspirational and still under construction.
 - Initial release with core AI functionality
 - Basic vector database and CLI
 - Foundation for cross-platform support
@@ -54,7 +73,7 @@ All notable changes to the Abi AI Framework.
 
 > **All notable changes to the Abi AI Framework will be documented in this file**
 
-[![Version](https://img.shields.io/badge/version-0.1.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.1.0a-blue.svg)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -62,13 +81,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 📋 **Table of Contents**
 
-- [Unreleased](#unreleased)
+- [0.1.0a](#010a)
+- [1.0.0 (planned)](#100-planned)
+- [1.0.0-alpha (planned)](#100-alpha-planned)
+- [Unreleased roadmap](#unreleased-roadmap)
 - [0.1.0-alpha](#010-alpha)
 - [Roadmap](#roadmap)
 
 ---
 
+<a id="unreleased-roadmap"></a>
+
 ## 🚀 **[Unreleased]**
+
+> **Status:** Work in progress. The items below map to planned 1.x milestones and are not yet available in a released build.
 
 > **Latest development version with cutting-edge features - Major Refactoring Complete!**
 
@@ -251,6 +277,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🗺️ **Roadmap**
 
+> **Status:** Long-term planning for future 1.x and beyond releases; completion states reflect aspirations rather than shipped functionality.
+
 ### **Version 1.0.0 (Target: Q3 2025)**
 
 #### **🎯 Core Objectives**
@@ -325,7 +353,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔗 **Links**
 
-- **[Unreleased]**: [Compare v0.1.0-alpha...HEAD](https://github.com/yourusername/abi/compare/v0.1.0-alpha...HEAD)
+- **[Unreleased]**: [Compare v0.1.0a...HEAD](https://github.com/yourusername/abi/compare/v0.1.0a...HEAD)
+- **[0.1.0a]**: [Release v0.1.0a](https://github.com/yourusername/abi/releases/tag/v0.1.0a)
 - **[0.1.0-alpha]**: [Release v0.1.0-alpha](https://github.com/yourusername/abi/releases/tag/v0.1.0-alpha)
 
 ---

--- a/README.md
+++ b/README.md
@@ -559,7 +559,7 @@ Create custom plugins for the framework:
 // Example plugin
 pub const ExamplePlugin = struct {
     pub const name = "example_plugin";
-    pub const version = "1.0.0";
+    pub const version = "0.1.0a";
     
     pub fn init(allocator: std.mem.Allocator) !*@This() {
         // Plugin initialization

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -144,9 +144,9 @@ function New-ReleaseArchive {
 
     try {
         $version = & git describe --tags --abbrev=0 2>$null
-        if ($LASTEXITCODE -ne 0) { $version = "v1.0.0" }
+        if ($LASTEXITCODE -ne 0) { $version = "v0.1.0a" }
     } catch {
-        $version = "v1.0.0"
+        $version = "v0.1.0a"
     }
 
     $archiveName = "abi-framework-$($version -replace '^v')-windows-$($env:PROCESSOR_ARCHITECTURE.ToLower())"
@@ -182,9 +182,9 @@ function New-ReleaseArchive {
 function Show-ReleaseInfo {
     try {
         $version = & git describe --tags --abbrev=0 2>$null
-        if ($LASTEXITCODE -ne 0) { $version = "v1.0.0" }
+        if ($LASTEXITCODE -ne 0) { $version = "v0.1.0a" }
     } catch {
-        $version = "v1.0.0"
+        $version = "v0.1.0a"
     }
 
     Write-Host ""

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -104,7 +104,7 @@ generate_docs() {
 
 # Create release archive
 create_archive() {
-    local version=$(git describe --tags --abbrev=0 2>/dev/null || echo "v1.0.0")
+    local version=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.1.0a")
     local archive_name="abi-framework-${version#v}-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)"
 
     print_status "Creating release archive: $archive_name.tar.gz"
@@ -137,7 +137,7 @@ create_archive() {
 
 # Show release information
 show_release_info() {
-    local version=$(git describe --tags --abbrev=0 2>/dev/null || echo "v1.0.0")
+    local version=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.1.0a")
 
     echo
     echo "🎉 Release Build Complete!"


### PR DESCRIPTION
## Summary
- add a 0.1.0a release section with accurate highlights and mark the 1.x notes as planned roadmap content
- refresh documentation references to show the 0.1.0a plugin version
- align release scripts with a v0.1.0a fallback so archives and status output match the new tag

## Testing
- bash scripts/release.sh *(fails: Zig is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d041b3b24c83319e399291dffe8f97