### PR TITLE
core: bump version to 0.1.0a

### DIFF
--- a/src/features/database/cli.zig
+++ b/src/features/database/cli.zig
@@ -242,7 +242,7 @@ pub const WdbxCLI = struct {
     }
 
     fn showVersion(self: *Self) !void {
-        try self.logger.info("ABI Vector Database v1.0.0", .{});
+        try self.logger.info("ABI Vector Database v0.1.0a", .{});
     }
 
     fn addVectors(self: *Self) !void {

--- a/src/features/database/core.zig
+++ b/src/features/database/core.zig
@@ -290,13 +290,13 @@ pub const ErrorCodes = struct {
 
 /// WDBX version information
 pub const VERSION = struct {
-    pub const MAJOR = 1;
-    pub const MINOR = 0;
+    pub const MAJOR = 0;
+    pub const MINOR = 1;
     pub const PATCH = 0;
-    pub const PRE_RELEASE = "alpha";
+    pub const PRE_RELEASE = "0.1.0a";
 
     pub fn string() []const u8 {
-        return "1.0.0-alpha";
+        return "0.1.0a";
     }
 
     pub fn isCompatible(major: u32, minor: u32) bool {

--- a/src/features/database/unified.zig
+++ b/src/features/database/unified.zig
@@ -96,9 +96,9 @@ test "WDBX module initialization" {
 }
 
 test "Version information" {
-    try std.testing.expectEqualStrings("1.0.0-alpha", version);
-    try std.testing.expectEqual(@as(u32, 1), version_major);
-    try std.testing.expectEqual(@as(u32, 0), version_minor);
+    try std.testing.expectEqualStrings("0.1.0a", version);
+    try std.testing.expectEqual(@as(u32, 0), version_major);
+    try std.testing.expectEqual(@as(u32, 1), version_minor);
     try std.testing.expectEqual(@as(u32, 0), version_patch);
 }
 

--- a/src/mod.zig
+++ b/src/mod.zig
@@ -5,8 +5,8 @@
 //! coordinates feature toggles, plugin discovery, and lifecycle management.
 
 const std = @import("std");
-const framework = @import("framework/mod.zig");
-const core = @import("shared/core/core.zig");
+const framework_mod = @import("framework/mod.zig");
+const core_internal = @import("shared/core/core.zig");
 const lifecycle_mod = @import("shared/core/lifecycle.zig");
 
 // =============================================================================
@@ -35,14 +35,14 @@ pub const root = @import("root.zig");
 // PUBLIC API
 // =============================================================================
 
-pub const Feature = framework.Feature;
-pub const Framework = framework.Framework;
-pub const FrameworkOptions = framework.FrameworkOptions;
+pub const Feature = framework_mod.Feature;
+pub const Framework = framework_mod.Framework;
+pub const FrameworkOptions = framework_mod.FrameworkOptions;
 
 /// Initialise the ABI framework and return the orchestration handle. Call
 /// `Framework.deinit` (or `abi.shutdown`) when finished.
 pub fn init(allocator: std.mem.Allocator, options: FrameworkOptions) !Framework {
-    return try framework.runtime.Framework.init(allocator, options);
+    return try framework_mod.runtime.Framework.init(allocator, options);
 }
 
 /// Convenience wrapper around `Framework.deinit` for callers that prefer the
@@ -53,7 +53,7 @@ pub fn shutdown(instance: *Framework) void {
 
 /// Get framework version information.
 pub fn version() []const u8 {
-    return "1.0.0-alpha";
+    return "0.1.0a";
 }
 
 test {

--- a/src/shared/mod.zig
+++ b/src/shared/mod.zig
@@ -35,12 +35,13 @@ pub fn init(allocator: std.mem.Allocator) !PluginRegistry {
 
 /// Plugin system version
 pub const VERSION = struct {
-    pub const MAJOR = 1;
-    pub const MINOR = 0;
+    pub const MAJOR = 0;
+    pub const MINOR = 1;
     pub const PATCH = 0;
+    pub const PRE_RELEASE = "0.1.0a";
 
     pub fn string() []const u8 {
-        return "1.0.0";
+        return "0.1.0a";
     }
 
     pub fn isCompatible(major: u32, minor: u32) bool {

--- a/src/shared/utils/utils.zig
+++ b/src/shared/utils/utils.zig
@@ -36,15 +36,18 @@ const std = @import("std");
 
 /// Project version information
 pub const VERSION = .{
-    .major = 1,
-    .minor = 0,
+    .major = 0,
+    .minor = 1,
     .patch = 0,
-    .pre_release = "alpha",
+    .pre_release = "0.1.0a",
 };
 
 /// Render version as semantic version string: "major.minor.patch[-pre]"
 pub fn versionString(allocator: std.mem.Allocator) ![]u8 {
     if (VERSION.pre_release.len > 0) {
+        if (std.ascii.isDigit(VERSION.pre_release[0])) {
+            return std.fmt.allocPrint(allocator, "{s}", .{VERSION.pre_release});
+        }
         return std.fmt.allocPrint(allocator, "{d}.{d}.{d}-{s}", .{ VERSION.major, VERSION.minor, VERSION.patch, VERSION.pre_release });
     }
     return std.fmt.allocPrint(allocator, "{d}.{d}.{d}", .{ VERSION.major, VERSION.minor, VERSION.patch });
@@ -134,7 +137,7 @@ test "Utilities module integration" {
     // Test version functionality
     const version_str = try versionString(testing.allocator);
     defer testing.allocator.free(version_str);
-    try testing.expect(std.mem.indexOf(u8, version_str, "1.0.0") != null);
+    try testing.expect(std.mem.indexOf(u8, version_str, "0.1.0a") != null);
 
     // Test config
     const config = Config.init("test");

--- a/src/tools/main.zig
+++ b/src/tools/main.zig
@@ -9,7 +9,7 @@ const services = @import("services");
 const connectors = @import("connectors");
 const plugins = @import("plugins");
 
-const CLI_VERSION = "1.0.0-alpha";
+const CLI_VERSION = "0.1.0a";
 const CLI_NAME = "ABI Framework CLI";
 
 pub fn main() !void {


### PR DESCRIPTION
## Summary
- update the framework and shared version constants to report 0.1.0a
- refresh the utilities formatter and downstream database/CLI references for the new label

## Testing
- zig fmt src/mod.zig src/shared/mod.zig src/shared/utils/utils.zig src/features/database/unified.zig src/features/database/cli.zig src/tools/main.zig src/features/database/core.zig
- zig build test *(fails: module `src/mod.zig` is simultaneously part of `root` and `abi` when invoked via `zig build test`)*

------
https://chatgpt.com/codex/tasks/task_e_68d041b2b4688331b500fd98d7e6cd01