### PR TITLE
docs: update generated api index version

### DIFF
--- a/docs/generated/CODE_API_INDEX.md
+++ b/docs/generated/CODE_API_INDEX.md
@@ -7039,13 +7039,13 @@ pub const VERSION = struct {
 - const `MAJOR`
 
 ```zig
-pub const MAJOR = 1;
+pub const MAJOR = 0;
 ```
 
 - const `MINOR`
 
 ```zig
-pub const MINOR = 0;
+pub const MINOR = 1;
 ```
 
 - const `PATCH`
@@ -7057,7 +7057,7 @@ pub const PATCH = 0;
 - const `PRE_RELEASE`
 
 ```zig
-pub const PRE_RELEASE = "alpha";
+pub const PRE_RELEASE = "a";
 ```
 
 - fn `string`
@@ -20899,13 +20899,13 @@ pub const VERSION = struct {
 - const `MAJOR`
 
 ```zig
-pub const MAJOR = 1;
+pub const MAJOR = 0;
 ```
 
 - const `MINOR`
 
 ```zig
-pub const MINOR = 0;
+pub const MINOR = 1;
 ```
 
 - const `PATCH`


### PR DESCRIPTION
## Summary
- update the generated documentation index to reflect the 0.1.0a semantic version values
- ensure MAJOR, MINOR, PATCH, and PRE_RELEASE constants in the docs align with the latest code definitions

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d051e140948331aa6b96553832911a