### PR TITLE
build: export package version to abi module

### DIFF
--- a/src/mod.zig
+++ b/src/mod.zig
@@ -5,6 +5,7 @@
 //! coordinates feature toggles, plugin discovery, and lifecycle management.
 
 const std = @import("std");
+const build_options = @import("build_options");
 
 // =============================================================================
 // FEATURE AND FRAMEWORK MODULES
@@ -57,9 +58,13 @@ pub fn shutdown(instance: *Framework) void {
 
 /// Get framework version information.
 pub fn version() []const u8 {
-    return "1.0.0-alpha";
+    return build_options.package_version;
 }
 
 test {
     std.testing.refAllDecls(@This());
+}
+
+test "abi.version returns build package version" {
+    try std.testing.expectEqualStrings(build_options.package_version, version());
 }


### PR DESCRIPTION
## Summary
- add a build helper that parses the package version from build.zig.zon and shares it through build options
- expose the parsed version to src/mod.zig so abi.version() always reflects the package metadata and gains a regression test

## Testing
- zig fmt . *(fails: zig not installed in container)*
- zig build test *(fails: zig not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0563cec388331b0d12d034aea2e10