### PR TITLE
enforce zig 0.15 toolchain

### DIFF
--- a/src/compat.zig
+++ b/src/compat.zig
@@ -1,0 +1,13 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+comptime {
+    if (builtin.zig_version.major != 0 or builtin.zig_version.minor != 15) {
+        @compileError("This code requires Zig 0.15.x; current compiler is " ++
+            std.fmt.comptimePrint("{d}.{d}.{d}", .{
+                builtin.zig_version.major,
+                builtin.zig_version.minor,
+                builtin.zig_version.patch,
+            }));
+    }
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
 const abi = @import("abi");
+// Ensure the repository is built with Zig 0.15.x
+_ = @import("compat");
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};


### PR DESCRIPTION
## Summary
- add a compile-time guard that rejects Zig versions other than 0.15.x
- import the guard in the main entrypoint to ensure every build triggers the check

## Testing
- zig fmt src/compat.zig src/main.zig *(fails: `zig` executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d077d7436883319866a9faf61a5e3e