### PR TITLE
Add compile-time Zig 0.15 compatibility guard

### DIFF
--- a/src/compat.zig
+++ b/src/compat.zig
@@ -1,0 +1,18 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+/// Ensures the repository is compiled with Zig 0.15.x toolchains.
+///
+/// Emits a compile error if the detected compiler version is not 0.15.x.
+pub fn ensureZig015x() void {
+    comptime {
+        if (builtin.zig_version.major != 0 or builtin.zig_version.minor != 15) {
+            @compileError("This codebase requires Zig 0.15.x; detected " ++
+                std.fmt.comptimePrint("{d}.{d}.{d}", .{
+                    builtin.zig_version.major,
+                    builtin.zig_version.minor,
+                    builtin.zig_version.patch,
+                }));
+        }
+    }
+}

--- a/src/mod.zig
+++ b/src/mod.zig
@@ -6,6 +6,11 @@
 
 const std = @import("std");
 const build_options = @import("build_options");
+const compat = @import("compat.zig");
+
+comptime {
+    compat.ensureZig015x();
+}
 
 // =============================================================================
 // FEATURE AND FRAMEWORK MODULES


### PR DESCRIPTION
## Summary
- add a `compat` module that emits a compile-time error when the compiler is not Zig 0.15.x
- import the compat guard from the main module so every consumer triggers the version check

## Testing
- not run (zig toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d079a6427c83319eede4e1e000f37c