### PR TITLE
Add documentation build pipeline

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -79,6 +79,14 @@ This documentation is generated using multiple approaches:
 - Type information and signatures
 - Cross-references and relationships
 
+```bash
+zig build docs
+```
+
+Run the command above to regenerate the complete documentation portal, including the Zig-native
+reference and the markdown API catalog, ensuring the published site always reflects the current
+source tree.
+
 ## 🔗 External Resources
 
 - **[GitHub Repository](https://github.com/donaldfilimon/abi/)** - Source code and issues

--- a/src/tools/docs_generator.zig
+++ b/src/tools/docs_generator.zig
@@ -449,13 +449,45 @@ fn generateSEOMetadata(_: std.mem.Allocator) !void {
 
 /// Generate native Zig documentation using built-in tools
 fn generateZigNativeDocs() !void {
-    // Create directory for native docs
-    try std.fs.cwd().makePath("docs/zig-docs");
-    // In a CI environment, you could run: zig build docs
-    // Here we create a placeholder index to avoid empty directory
+    const docs_dir = "docs/zig-docs";
+    try std.fs.cwd().makePath(docs_dir);
+
+    const run_result = std.process.Child.run(.{
+        .allocator = std.heap.page_allocator,
+        .argv = &[_][]const u8{
+            "zig",
+            "doc",
+            "src/mod.zig",
+            "--output-dir",
+            docs_dir,
+        },
+    }) catch |err| {
+        std.log.warn("failed to invoke 'zig doc': {s}", .{@errorName(err)});
+        return writeZigDocFallback();
+    };
+    defer std.heap.page_allocator.free(run_result.stdout);
+    defer std.heap.page_allocator.free(run_result.stderr);
+
+    if (run_result.term == .Exited and run_result.term.Exited == 0) {
+        std.log.info("Generated Zig native docs at {s}", .{docs_dir});
+        return;
+    }
+
+    const trimmed_stderr = std.mem.trim(u8, run_result.stderr, " \n\r\t");
+    if (trimmed_stderr.len != 0) {
+        std.log.warn("zig doc stderr: {s}", .{trimmed_stderr});
+    }
+
+    try writeZigDocFallback();
+}
+
+fn writeZigDocFallback() !void {
+    std.log.warn("writing placeholder Zig native docs because generation failed", .{});
     var out = try std.fs.cwd().createFile("docs/zig-docs/index.html", .{ .truncate = true });
     defer out.close();
-    try out.writeAll("<html><body><h1>Zig Native Docs</h1><p>Generated offline.</p></body></html>");
+    try out.writeAll(
+        "<html><body><h1>Zig Native Docs</h1><p>Documentation generation failed; placeholder created.</p></body></html>",
+    );
 }
 
 /// Generate README redirect for GitHub


### PR DESCRIPTION
## Summary
- add a `docs` build step that drives the docs generator and API catalog tools
- enhance the docs generator to invoke `zig doc` and fall back to a placeholder when unavailable
- document the `zig build docs` command in the documentation portal README

## Testing
- not run (zig toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d077cd060083319a7315631bec5d15