### PR TITLE
enforce zig 0.15 toolchain

### DIFF
--- a/src/compat.zig
+++ b/src/compat.zig
@@ -1,0 +1,13 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+comptime {
+    if (builtin.zig_version.major != 0 or builtin.zig_version.minor != 15) {
+        @compileError("This project requires Zig 0.15.x; current compiler is " ++
+            std.fmt.comptimePrint("{d}.{d}.{d}", .{
+                builtin.zig_version.major,
+                builtin.zig_version.minor,
+                builtin.zig_version.patch,
+            }));
+    }
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,5 +1,10 @@
 const std = @import("std");
 const abi = @import("abi");
+const compat = @import("compat.zig");
+
+comptime {
+    _ = compat;
+}
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};

--- a/src/mod.zig
+++ b/src/mod.zig
@@ -6,6 +6,11 @@
 
 const std = @import("std");
 const build_options = @import("build_options");
+const compat = @import("compat.zig");
+
+comptime {
+    _ = compat;
+}
 
 // =============================================================================
 // FEATURE AND FRAMEWORK MODULES


### PR DESCRIPTION
## Summary
- add a compile-time compatibility module that enforces using Zig 0.15.x
- import the compatibility guard from the binary and library entry points so every build triggers it

## Testing
- Not run (zig toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d079a6427c83319eede4e1e000f37c