### PR TITLE
Add compile-time Zig 0.15 guard

### DIFF
--- a/src/compat.zig
+++ b/src/compat.zig
@@ -1,0 +1,13 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+comptime {
+    if (builtin.zig_version.major != 0 or builtin.zig_version.minor != 15) {
+        @compileError("This code requires Zig 0.15.x; current compiler is " ++
+            std.fmt.comptimePrint("{d}.{d}.{d}", .{
+                builtin.zig_version.major,
+                builtin.zig_version.minor,
+                builtin.zig_version.patch,
+            }));
+    }
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
 const abi = @import("abi");
+// Ensure the repository is built with Zig 0.15.x
+const _ = @import("compat");
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};


### PR DESCRIPTION
## Summary
- add a compat module that enforces compiling with Zig 0.15.x
- import the compat module from main so the check runs during every build

## Testing
- zig fmt --check . *(fails: zig not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0795cc6008331ae793fe8324eb56d