### PR TITLE
chore: tighten Zig 0.16.0-dev guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Added
 - Nothing yet.
 
+### Changed
+- Hardened the Zig 0.16.0-dev toolchain guard with semantic version enforcement and library-wide import coverage.
+
 ## [0.1.0a] - 2025-09-20
 
 ### Added

--- a/src/compat.zig
+++ b/src/compat.zig
@@ -1,0 +1,15 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+const minimum_version = std.SemanticVersion.parse("0.16.0-dev.254+6dd0270a1") catch @panic("invalid version");
+
+comptime {
+    if (builtin.zig_version.order(minimum_version) == .lt) {
+        @compileError("This code requires Zig 0.16.0-dev.254+6dd0270a1 or newer; current compiler is " ++
+            std.fmt.comptimePrint("{d}.{d}.{d}", .{
+                builtin.zig_version.major,
+                builtin.zig_version.minor,
+                builtin.zig_version.patch,
+            }));
+    }
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const abi = @import("abi");
+_ = @import("compat"); // Enforce Zig 0.16.0-dev+ toolchain at compile time.
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};

--- a/src/mod.zig
+++ b/src/mod.zig
@@ -6,6 +6,7 @@
 
 const std = @import("std");
 const build_options = @import("build_options");
+_ = @import("compat"); // Enforce Zig toolchain compatibility for library consumers.
 
 // =============================================================================
 // FEATURE AND FRAMEWORK MODULES


### PR DESCRIPTION
## Summary
- reinforced the compile-time guard to require Zig 0.16.0-dev.254+6dd0270a1 using semantic-version comparison
- imported the compat module from `src/mod.zig` so dependent packages encounter the toolchain enforcement
- documented the hardened guard in the changelog entry

## Testing
- zig fmt src/compat.zig src/mod.zig *(fails: `zig`: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d077d7436883319866a9faf61a5e3e