### PR TITLE
Restore Detailed Status Documentation

### DIFF
--- a/docs/reports/cross_platform_testing.md
+++ b/docs/reports/cross_platform_testing.md
@@ -1,44 +1,179 @@
 # Cross-Platform Testing Reference
 
-This page captures the consolidated matrix, workflows, and follow-up tasks for the project's cross-platform guarantees. It merges the previous testing guide and enhancement summary into a single home.
+Generated on: 2025-09-28 06:25:31 UTC
 
-## Test Matrix
-- **Operating systems**: Windows Server 2019/2022, macOS 13/14, Ubuntu 18.04/20.04/22.04.
-- **Architectures**: x86_64 everywhere, plus Apple Silicon (aarch64) coverage on macOS and Linux.
-- **Zig toolchains**: 0.16.0-dev (baseline), 0.16.0 release, and nightly master builds.
+This reference merges the retired cross-platform testing guide and enhancement summary so every team can rely on the same coverage matrix, workflows, and follow-up plan.
 
-## Platform-Specific Notes
+## Coverage Matrix
+
+| Dimension | Current Scope | Notes |
+| --- | --- | --- |
+| Operating systems | Windows Server 2019/2022, macOS 13/14, Ubuntu 18.04/20.04/22.04 | Mirrors CI runners and staging fleet |
+| Architectures | x86_64 (all platforms), aarch64 (macOS Apple Silicon, Linux ARM64) | Capture Rosetta + native binaries |
+| Zig toolchains | 0.16.0-dev baseline, 0.16.0 release, nightly `master` | Nightly protects against upstream regressions |
+| Test types | Unit, integration, performance, security, GPU smoke, container smoke | Driven by `tests/cross-platform/*.zig` |
+| CI combinations | ~48+ (7 OS targets × 2 architectures × 3 Zig versions) | 4× increase over prior matrix |
+
+### Operating Systems
+- **Windows**: Windows Server 2019 and 2022 runners with validated PowerShell deployment scripts.
+- **macOS**: macOS 13 (Ventura) and macOS 14 (Sonoma) on Intel and Apple Silicon hardware.
+- **Linux**: Ubuntu 18.04, 20.04, and 22.04 images covering glibc and musl libc variants.
+
+### Architectures
+- **x86_64**: Primary architecture for CI, staging, and production workloads.
+- **aarch64**: Required for Apple Silicon and ARM server validation; binaries run natively and under Rosetta.
+
+### Zig Toolchains
+- `0.16.0-dev` pin (repository baseline).
+- Latest 0.16.0 release candidate for stability checks.
+- Nightly `master` builds to surface upstream breakage early.
+
+---
+
+## CI Automation & Artifacts
+- `.github/workflows/ci.yml` provisions matrix builds across OS, architecture, and toolchain combinations with cache tuning per runner.
+- Automation scripts generate `/tmp/ci_analysis.md` and `/tmp/enhanced_matrix.md` snapshots when evaluating coverage.
+- Container smoke tests build Docker images (e.g., `ubuntu:22.04`) and publish artifacts for downstream validation.
+- Platform-specific suites live in `tests/cross-platform/{windows,macos,linux}.zig` and skip gracefully on other OS targets.
+
+---
+
+## Platform Playbooks
+
 ### Windows
-- Prefer Winsock2 networking and handle path casing/ACL semantics.
-- Exercise service management, registry interactions, and file locking behavior.
+- Prefer Winsock2 networking and ensure file path comparisons honor case preservation and ACL semantics.
+- Validate service management flows, registry interactions, and file locking across Server 2019/2022 images.
+- Exercise deployment scripts (`deploy/scripts/deploy-staging.ps1`) and ensure NTFS permission adjustments succeed.
 
 ### macOS
-- Validate kqueue-powered event loops and both Intel/Apple Silicon binaries.
-- Track framework entitlements when invoking Foundation/CoreFoundation APIs.
+- Exercise kqueue-driven event loops on both Intel and Apple Silicon hardware, verifying event delivery parity.
+- Track entitlements whenever invoking Foundation/CoreFoundation APIs and document signing requirements.
+- Validate universal binaries and Rosetta fallbacks, especially for GPU toolchains.
 
 ### Linux
-- Use epoll for scalable I/O and test against multiple libc variants (glibc, musl).
-- Account for containerized environments where `/proc` and cgroup limits may differ.
+- Use epoll for scalable I/O and test on both glibc and musl images.
+- Account for containerized environments where `/proc` access or cgroup limits may differ; add guards for missing filesystems.
+- Validate shell scripts (`deploy/scripts/deploy-staging.sh`) under bash and dash to ensure portability.
 
-## Best Practices
-- Gate platform logic with `builtin.os.tag` checks and centralize conditional compilation.
-- Use `std.fs.path` helpers for filesystem joins and normalization.
-- Exercise both IPv4/IPv6 sockets and TLS pathways during regression runs.
-- Capture environment fingerprints (OS, architecture, Zig version) in test logs for traceability.
+---
 
-## CI & Automation
-- GitHub Actions matrix runs the full suite across all OS/architecture/Zig combinations with caching tuned per runner.
-- Dedicated test files exist in `tests/cross-platform/{windows,macos,linux}.zig`, each guarding platform-only features and failure modes.
-- Container builds validate Linux deployments via Docker and publish artifacts for downstream smoke tests.
+## Best Practices & Snippets
 
-## Troubleshooting Checklist
-1. Confirm platform detection and feature flags before diving into failure logs.
-2. Re-run isolated suites (`zig build test-windows`, `zig build test-macos`, `zig build test-linux`) to reproduce deterministically.
-3. Inspect permissions/path handling issues; normalize separators and encoding where needed.
-4. Monitor CI artifacts for system metadata, panic traces, and performance regressions.
+### Conditional Compilation
+```zig
+const builtin = @import("builtin");
+
+if (builtin.os.tag == .windows) {
+    // Windows-specific code paths
+} else if (builtin.os.tag == .macos) {
+    // macOS-specific code paths
+} else if (builtin.os.tag == .linux) {
+    // Linux-specific code paths
+}
+```
+
+### Platform Detection Helpers
+```zig
+const is_windows = builtin.os.tag == .windows;
+const is_macos = builtin.os.tag == .macos;
+const is_linux = builtin.os.tag == .linux;
+```
+
+### Cross-Platform Paths
+```zig
+const path = try std.fs.path.join(allocator, &[_][]const u8{"dir", "file.txt"});
+```
+
+### Network Coverage
+```zig
+const address4 = try std.net.Address.parseIp4("127.0.0.1", 8080);
+const address6 = try std.net.Address.parseIp6("::1", 8080);
+```
+
+### Environment Fingerprint
+```zig
+const stdout = std.io.getStdOut().writer();
+try stdout.print("platform={s} arch={s} zig={s}\n", .{
+    @tagName(builtin.os.tag),
+    @tagName(builtin.cpu.arch),
+    builtin.zig_version_string,
+});
+```
+
+---
+
+## Running the Matrix
+```bash
+# Run entire suite
+zig build test
+
+# Focused cross-platform aggregator
+zig build test-cross-platform
+
+# OS-specific runs
+zig build test-windows
+zig build test-macos
+zig build test-linux
+```
+
+---
+
+## Troubleshooting & Debugging
+1. Confirm `builtin.os.tag` and feature flags match expectations before triaging failures.
+2. Re-run isolated suites (`zig build test-windows`, etc.) to reproduce deterministically.
+3. Inspect file path normalization and permission handling; normalize separators/encodings as needed.
+4. Review CI artifacts for system metadata, panic traces, and performance regressions.
+5. Capture environment fingerprints in logs to accelerate cross-team debugging.
+
+---
+
+## Container Guidance
+```dockerfile
+FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y curl xz-utils
+# Install Zig toolchain and run tests
+```
+- Validate container images with both glibc and musl bases when possible.
+- Ensure `/proc` reads guard against restricted environments; skip tests gracefully when resources are unavailable.
+
+---
 
 ## Enhancement Summary
-- Expanded the CI matrix to 48+ combinations covering OS, architecture, and compiler deltas.
-- Added platform-focused regression suites and container smoke coverage.
-- Produced this merged reference so future updates live in one maintained location.
-- Next steps: monitor nightly regressions, expand hardware diversity, and feed learnings back into developer onboarding materials.
+
+### Completed
+- Updated CI workflow with the expanded Zig/OS matrix and architecture coverage.
+- Created platform-specific regression suites under `tests/cross-platform/` with allocator-aware skips.
+- Generated this consolidated reference that merges the historical guide and automation summary.
+
+### Coverage Improvements
+| Category | Before | After | Improvement |
+| --- | --- | --- | --- |
+| OS Versions | 3 | 7 | +133% |
+| Zig Versions | 3 | 4 | +33% |
+| Architectures | 1 | 2 | +100% |
+| Total Combinations | ~12 | ~48+ | +300% |
+
+### Next Steps
+1. Monitor CI runs across all platforms and investigate regressions promptly.
+2. Extend performance benchmarking to stress platform-specific hot paths (IOCP, kqueue, epoll).
+3. Keep this reference updated as new OS/Zig releases land or hardware diversity grows.
+
+### Files Created / Updated by Automation
+- `.github/workflows/ci.yml`
+- `tests/cross-platform/windows.zig`
+- `tests/cross-platform/macos.zig`
+- `tests/cross-platform/linux.zig`
+- `docs/reports/cross_platform_testing.md`
+
+### Benefits
+- Improved reliability via proactive coverage.
+- Earlier detection of OS/toolchain regressions in CI.
+- Reduced support burden thanks to consistent behavior across environments.
+
+---
+
+## Automation Notes
+- Generated by `scripts/enhance_cross_platform_testing.sh`.
+- CI matrix recommendations recorded in `/tmp/enhanced_matrix.md`.
+- Regenerated platform-specific regression suites under `tests/cross-platform/`.
+- Review GitHub Actions workflow changes before merging automated edits.

--- a/docs/reports/engineering_status.md
+++ b/docs/reports/engineering_status.md
@@ -1,37 +1,194 @@
 # Engineering Status Overview
 
-This document consolidates the high-level engineering reports that previously lived at the root of the repository. It provides a single entry point for release readiness, platform coverage, benchmarking, and migration status.
+This consolidated report merges the retired status documents into a single location so product, infrastructure, and quality teams can review the same source of truth. It preserves the detailed metrics, playbooks, and ownership data from the original codebase improvement, utilities, benchmarking, deployment, and migration reports.
+
+## Snapshot Metrics
+
+| Metric | Value | Source |
+| --- | --- | --- |
+| Lines of Zig code | 51,140 | Static analysis (`tools/basic_code_analyzer.zig`) |
+| Functions / Structs | 2,028 functions, 456 structs | Static analysis |
+| Comment lines | 6,225 | Static analysis |
+| Complexity score | 3,969 | Static analysis |
+| Test coverage | 89 / 89 suites passing | Comprehensive test suite |
+| Benchmark exports | Console, JSON, CSV, Markdown | Unified benchmark runner |
+| Deployment throughput | 2,777–2,790 ops/sec | Staging validation |
+| Deployment latency | 783–885 µs average | Staging validation |
+| Deployment success rate | 99.98% | Staging validation |
+| Production readiness | ✅ Complete | Deployment readiness report |
+
+---
 
 ## Codebase Quality & Tooling
-- Adopted comprehensive linting and formatting rules across the Zig workspace to enforce consistent style and module structure.
-- Added static-analysis helpers (including `tools/basic_code_analyzer.zig`) to surface API drift, dependency issues, and dead code before landing changes.
-- Expanded the regression suite with scenario coverage for runtime, GPU integration, concurrency primitives, and failure-injection harnesses.
-- Hardened CI with quality gates, artifact retention, and reusable workflows so new features inherit the same review baseline.
 
-## Utility Library Completion
-- Closed out all high/medium priority utilities: memory tracking helpers, JSON/URL codecs, Base64, validation pipelines, random data sources, and math helpers.
-- Standardized error handling and cleanup patterns through shared utility modules to prevent allocator leaks or inconsistent diagnostics.
-- Documented usage snippets for each utility domain to speed up adoption during feature work.
+### Coding Standards & Cleanup
+- Resolved 11 linter findings (shadowing, unused discards, error handling) in `src/server/enhanced_web_server.zig` to establish a clean baseline for the enforcement bots.
+- Adopted 4-space indentation, 100-character line length, and consistent naming conventions (snake_case modules, PascalCase types, UPPER_SNAKE constants) across the workspace.
+- Documented the preferred file layout—imports, constants, types, functions, tests—so new modules follow the same scaffolding.
+
+### Static Analysis & Quality Configuration
+- `tools/basic_code_analyzer.zig` now surfaces line counts, complexity, and declaration inventory as part of `zig build code-analyze`.
+- `.code-quality-config.json` tracks security scans, performance anti-patterns, and maintainability rules that gate CI.
+- Quality checks run automatically in CI with structured reports archived for release engineering.
+
+### Comprehensive Testing Framework
+- `tests/comprehensive_test_suite.zig` covers unit, integration, performance, security, and plugin validations.
+- Dedicated suites exist for AI agents, neural networks, vector databases, GPU backends, web server surfaces, and plugin execution with allocator hygiene checks.
+- Build system exposes task shorthands: `zig build test-comprehensive`, `zig build test-performance`, `zig build test-security`, and more for targeted runs.
+
+### Enhanced CI/CD Pipeline
+- `.github/workflows/enhanced-ci-cd.yml` runs on Ubuntu, Windows, and macOS with architecture expansion and Zig version pinning for determinism.
+- Quality gates enforce formatting, static analysis, security scanning, benchmark baselines, and leak detection prior to merge.
+- Automation integrates pre-commit hooks, regression dashboards, and alert routing so owners react to drift quickly.
+
+### Documentation & Developer Experience
+- `docs/DEVELOPMENT_WORKFLOW.md` centralizes environment setup, quality standards, testing workflow, performance optimization, security practices, and troubleshooting steps.
+- API documentation includes function-level usage notes, parameter tables, and error contracts to speed onboarding.
+
+### Performance Optimization & Security Hardening
+- Memory utilities introduced bounded buffers, allocator tracking, leak detection, and safe cleanup patterns.
+- SIMD vectorization, cache-friendly data structures, and GPU backends (CUDA, Vulkan, Metal, DirectX, OpenGL, WebGPU) contribute to performance uplift.
+- Validation suites enforce secure input handling, buffer safety, retry/backoff primitives, and telemetry-friendly error propagation.
+
+---
+
+## Utility Library Rollout
+
+All high and medium priority utilities live in `src/utils.zig` with 100% test coverage and allocator-safe APIs.
+
+- **Memory Management**: Managed buffers, batch deallocation helpers, and consistent `deinit` usage eliminate leak regressions.
+- **JSON Utilities**: Parse/serialize into `JsonValue`, hydrate typed structs with `parseInto`, and emit canonical strings with `stringifyFrom` while handling cleanup automatically.
+- **URL Utilities**: Encode/decode internationalized URLs, parse individual components, and rebuild query strings safely.
+- **Base64 Utilities**: Provide standard and URL-safe encoding/decoding built on the Zig standard library primitives.
+- **File System Helpers**: Support recursive directory creation, file copying, metadata inspection, and directory enumeration.
+- **Validation Suite**: RFC-compliant email and UUID checks, password and phone validation, and generic bounds checking utilities.
+- **Random Utilities**: Cryptographically secure bytes, custom random strings, UUID v4 generation, Fisher–Yates shuffling, and slice sampling.
+- **Math Utilities**: Clamp, interpolate, compute statistics (mean/median/stddev), evaluate GCD/LCM, and calculate 2D/3D distances.
+- **Memory & Error Helpers**: Logging allocators, retry/backoff wrappers, result types with source tracking, and guard utilities for strings and slices.
+
+---
 
 ## Benchmark & Performance Suite
-- Rebuilt the benchmark framework to emit statistical summaries (mean, median, deviation, confidence intervals) along with JSON/CSV/Markdown exports for CI ingestion.
-- Unified benchmark runners for AI workloads, database access, SIMD micro-benchmarks, and foundational primitives with shared configuration knobs.
-- Instrumented performance harnesses with memory tracking and platform metadata so regressions can be triaged quickly across OS/architecture pairs.
 
-## Cross-Platform Coverage
-- Codified the OS/architecture/Zig matrix (Windows Server 2019/2022, macOS 13/14 Intel & Apple Silicon, Ubuntu 18.04/20.04/22.04 on x86_64/aarch64).
-- Provisioned dedicated test targets (`tests/cross-platform/{windows,macos,linux}.zig`) with environment-specific checks for filesystems, networking, and event loops.
-- Published an evergreen testing guide that captures CI settings, troubleshooting steps, and best practices for conditional compilation (`docs/reports/cross_platform_testing.md`).
+The benchmarking overhaul standardizes frameworks, statistical rigor, and reporting across all performance workstreams.
+
+### Framework Enhancements
+- `benchmark_framework.zig` introduces configurable warmup/measurement loops, `BenchmarkStats` analytics, and exports to console, JSON, CSV, and Markdown.
+- Unified runner (`benchmarks/main.zig`) selects suites (`neural`, `database`, `performance`, `simd`, `all`) and supports `--export` / `--format` / `--output` flags.
+- Benchmarks record OS, architecture, Zig version, throughput, memory peaks, and confidence intervals for reproducible comparisons.
+
+### Domain Suites
+- **Neural Network**: Activation function timing, batch forward-pass simulation, and convergence instrumentation.
+- **Database**: Vector dimensions (64–512), dataset sizes (100–50K), top-K queries, insertion throughput, and memory growth tracking.
+- **SIMD Micro-benchmarks**: Euclidean distance, cosine similarity, trigonometric functions, and matrix multiplies from 32×32 to 256×256 with SIMD-vs-scalar ratios.
+- **Performance Suite**: Lock-free primitives, text processing, allocator stress tests, and vector similarity workloads with throughput metrics.
+- **Simple Benchmarks**: Lightweight allocation, initialization, summation, and math operations for quick CI validation.
+
+### Usage Reference
+```
+zig run benchmarks/main.zig -- all
+zig run benchmarks/main.zig -- --export --format=json database
+zig run benchmarks/performance_suite.zig
+```
+
+---
 
 ## Deployment Readiness
-- Curated production deployment workflows covering single-server, container, and Kubernetes strategies with environment variables, feature flags, and artifact outputs.
-- Verified staging performance (≈2.8K ops/sec, sub-millisecond latency, 99.98% success rate) and established validation gates before production rollout.
-- Bundled monitoring assets (Prometheus, Grafana dashboards) plus rollback and incident-response procedures to maintain high availability.
+
+### Validated Metrics
+| Metric | Result | Target |
+| --- | --- | --- |
+| Throughput | 2,777–2,790 ops/sec | ≥ 2,500 ops/sec |
+| Latency | 783–885 µs average | < 1 ms |
+| Success rate | 99.98% | > 99% |
+| Concurrent connections | 5,000+ | ≥ 4,000 |
+| Memory | 0 leaks detected | Zero tolerance |
+| Network errors | None under load | Zero tolerance |
+
+### Execution Playbook
+1. **Deploy Staging**
+   - Linux/macOS: `./deploy/scripts/deploy-staging.sh`
+   - Windows: `./deploy/scripts/deploy-staging.ps1`
+   - Manual fallback: create namespace and apply `deploy/staging/wdbx-staging.yaml`.
+2. **Validate Health & Performance**
+   - `kubectl get pods -n wdbx-staging`
+   - `curl http://<staging-ip>:8081/health`
+3. **Monitor**
+   - Grafana (`http://<grafana-ip>:3000`, admin/admin123)
+   - Prometheus (`http://<prometheus-ip>:9090`)
+4. **Promote to Production**
+   - Follow `deploy/PRODUCTION_ROLLOUT_PLAN.md` four-phase canary.
+5. **Rollback / Mitigate**
+   - `kubectl rollout undo deployment/wdbx-staging -n wdbx-staging`
+   - `kubectl scale deployment wdbx-staging --replicas=0 -n wdbx-staging`
+
+### Assets & Monitoring
+```
+deploy/
+├── staging/wdbx-staging.yaml
+├── scripts/deploy-staging.sh
+├── scripts/deploy-staging.ps1
+└── PRODUCTION_ROLLOUT_PLAN.md
+monitoring/
+├── prometheus/{prometheus.yaml,wdbx-alerts.yml}
+└── grafana/wdbx-dashboard.json
+```
+- Alerts, dashboards, and health probes remain active post-rollout to preserve high availability.
+
+---
 
 ## Zig 0.16 Migration Playbook
-- Documented strategic objectives for the Zig 0.16-dev upgrade, including maintaining feature parity and unlocking GPU backends (Vulkan, Metal, CUDA).
-- Broke migration into governable waves with ownership, risk registers, and reviewer exit criteria to keep progress measurable.
-- Captured stdlib/build-system deltas, allocator policies, observability requirements, and security considerations to streamline future upgrades.
+
+### Strategy & Governance
+- Objectives: maintain feature parity, unlock GPU backends (Vulkan, Metal, CUDA), lay neural-network foundations, and codify observability/security guardrails.
+- Principles: wave-based execution, clear DRIs with deputies, fail-fast validation, and documentation-first workflows.
+- Cadence: weekly steering sync, daily async standup in `#zig-migration`, and heightened change control for high-risk areas.
+
+### Milestones & Owners
+| Milestone | Target | Success Criteria | Owner / Deputy |
+| --- | --- | --- | --- |
+| Toolchain pin & build graph audit | 2025-09-22 | `zig build` / `zig build test` green on Linux/macOS/Windows | Dev Infra (A. Singh) / Release Eng (S. Walker) |
+| Allocator & stdlib refactor | 2025-10-01 | Allocator policy tests pass; ≤1% diagnostics regression | Runtime (L. Gomez) / Dev Infra (E. Chen) |
+| GPU backend enablement | 2025-10-12 | Vulkan/Metal/CUDA smoke + perf tests green; shader toolchain refreshed | GPU (M. Ito) / ML Systems (R. Chen) |
+| Neural-network kernel uplift | 2025-10-20 | Tensor-core matmul ≥1.8× speedup; convergence parity | ML Systems (R. Chen) / Runtime (J. Patel) |
+| Observability & security sign-off | 2025-10-25 | Dashboards live; tracing checklist complete; SBOM updated | SRE/Security (K. Patel) / Dev Infra (A. Singh) |
+| Final migration review | 2025-10-27 | Reviewer checklist cleared; rollback plan rehearsed | Release Eng (S. Walker) / Program Mgmt (T. Rivera) |
+
+### Module Ownership Snapshot
+| Domain | Key Artifacts | Team Focus |
+| --- | --- | --- |
+| Core Runtime | `src/runtime/{allocator,context,async}.zig` | Align async primitives with new `std.Channel`; surface allocator telemetry. |
+| Build System | `build.zig`, `build.zig.zon`, `.zigversion`, `scripts/toolchain/*` | Pin toolchain, modernize build graph, mirror dependencies. |
+| GPU Backends | `src/gpu/{vulkan,metal,cuda}/*`, `assets/shaders/*`, `tools/shaderc/*` | Refresh shader pipelines, driver validation, backend toggles. |
+| Neural Network Stack | `src/nn/{tensor,ops,train}.zig`, `benchmarks/nn/*`, `tests/nn/*` | Tensor-core kernels, fused ops, convergence benchmarks. |
+| Observability | `src/telemetry/*`, `tools/metrics/*`, dashboards | Ensure metrics/logging/tracing parity. |
+| Security & Release | `tools/security/*`, `deploy/*`, `.github/workflows/*` | SBOM diffs, container hardening, canary promotion scripts. |
+
+### Key Risks & Mitigations
+- **Upstream Zig churn** (Medium): track nightly releases, mirror binaries, revert to last known good within 24h on regression.
+- **GPU driver mismatch** (High): maintain driver matrix, pre-warm CI AMIs, provide software rasterizer fallback.
+- **Allocator regressions** (Medium): expand leak detectors, nightly fuzzing, freeze allocator merges on detection.
+- **Tensor-core under-utilization** (Medium): profile with Nsight/Metal HUD, escalate to vendor if uplift <1.5×.
+- **Observability gaps** (Low): enforce tracing spans, synthetic monitors, and alert reviews before rollout.
+- **Security regressions** (Low): automated SBOM diff scans, secure review gates, hotfix SLA within 48h.
+
+### Technical Workstreams
+- **Build-System Deltas**: adopt new build APIs, refactor module registration, regenerate `build.zig.zon`, and document graph topology.
+- **Stdlib & API Updates**: migrate time APIs, JSON parsing, async channels, meta reflection helpers, and update tests.
+- **Allocator Policies**: introduce logging allocators, guard-page monitoring, and soak tests (`zig build allocator-soak`).
+- **GPU Enablement**: implement `-Dgpu-backend` option, refresh Vulkan/Metal/CUDA integrations, and document driver prerequisites.
+- **Neural-Network Foundations**: detect tensor-core capabilities, refactor operator library, modernize training loop, and benchmark convergence.
+- **CI & Benchmarks**: expand matrix across OS/architecture, add GPU runners, enforce regression thresholds, and route alerts to #zig-migration.
+- **Observability & Security**: structured logging, OpenTelemetry spans, migration dashboards, SBOM regeneration, and container hardening.
+- **Reviewer Checklist**: verify toolchain pins, build graph modernization, allocator telemetry, GPU smoke tests, benchmark baselines, and dashboard updates before sign-off.
+
+---
+
+## Release Confidence Snapshot
+- ✅ Comprehensive regression and performance suites cover platform, GPU, allocator, and neural-network scenarios.
+- ✅ Deployment automation, monitoring, and rollback procedures validated with production-equivalent loads.
+- ✅ Migration governance, risk tracking, and documentation ensure visibility across teams.
+- ✅ Utility, benchmarking, and infrastructure upgrades are centralized for onboarding and ongoing maintenance.
 
 ## Quick Links
 - Cross-platform testing reference: [`docs/reports/cross_platform_testing.md`](./cross_platform_testing.md)

--- a/scripts/enhance_cross_platform_testing.sh
+++ b/scripts/enhance_cross_platform_testing.sh
@@ -19,6 +19,7 @@ NC='\033[0m' # No Color
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CI_WORKFLOW_FILE="$PROJECT_ROOT/.github/workflows/ci.yml"
 REPORTS_DIR="$PROJECT_ROOT/docs/reports"
+CURRENT_DATE="$(date -u +"%Y-%m-%d %H:%M:%S UTC")"
 
 print_status() {
     echo -e "${BLUE}[INFO]${NC} $1"
@@ -246,51 +247,186 @@ generate_testing_guide() {
 
     mkdir -p "$REPORTS_DIR"
 
-    cat > "$REPORTS_DIR/cross_platform_testing.md" << 'EOF'
+    cat > "$REPORTS_DIR/cross_platform_testing.md" << EOF
 # Cross-Platform Testing Reference
 
-This page captures the consolidated matrix, workflows, and follow-up tasks for the project's cross-platform guarantees. It merges the previous testing guide and enhancement summary into a single home.
+Generated on: ${CURRENT_DATE}
 
-## Test Matrix
-- **Operating systems**: Windows Server 2019/2022, macOS 13/14, Ubuntu 18.04/20.04/22.04.
-- **Architectures**: x86_64 everywhere, plus Apple Silicon (aarch64) coverage on macOS and Linux.
-- **Zig toolchains**: 0.16.0-dev (baseline), 0.16.0 release, and nightly master builds.
+This reference merges the retired cross-platform testing guide and enhancement summary so every team can rely on the same coverage matrix, workflows, and follow-up plan.
 
-## Platform-Specific Notes
+## Coverage Matrix
+
+| Dimension | Current Scope | Notes |
+| --- | --- | --- |
+| Operating systems | Windows Server 2019/2022, macOS 13/14, Ubuntu 18.04/20.04/22.04 | Mirrors CI runners and staging fleet |
+| Architectures | x86_64 (all platforms), aarch64 (macOS Apple Silicon, Linux ARM64) | Capture Rosetta + native binaries |
+| Zig toolchains | 0.16.0-dev baseline, 0.16.0 release, nightly `master` | Nightly protects against upstream regressions |
+| Test types | Unit, integration, performance, security, GPU smoke, container smoke | Driven by `tests/cross-platform/*.zig` |
+| CI combinations | ~48+ (7 OS targets × 2 architectures × 3 Zig versions) | 4× increase over prior matrix |
+
+### Operating Systems
+- **Windows**: Windows Server 2019 and 2022 runners with validated PowerShell deployment scripts.
+- **macOS**: macOS 13 (Ventura) and macOS 14 (Sonoma) on Intel and Apple Silicon hardware.
+- **Linux**: Ubuntu 18.04, 20.04, and 22.04 images covering glibc and musl libc variants.
+
+### Architectures
+- **x86_64**: Primary architecture for CI, staging, and production workloads.
+- **aarch64**: Required for Apple Silicon and ARM server validation; binaries run natively and under Rosetta.
+
+### Zig Toolchains
+- `0.16.0-dev` pin (repository baseline).
+- Latest 0.16.0 release candidate for stability checks.
+- Nightly `master` builds to surface upstream breakage early.
+
+---
+
+## CI Automation & Artifacts
+- `.github/workflows/ci.yml` provisions matrix builds across OS, architecture, and toolchain combinations with cache tuning per runner.
+- Automation scripts generate `/tmp/ci_analysis.md` and `/tmp/enhanced_matrix.md` snapshots when evaluating coverage.
+- Container smoke tests build Docker images (e.g., `ubuntu:22.04`) and publish artifacts for downstream validation.
+- Platform-specific suites live in `tests/cross-platform/{windows,macos,linux}.zig` and skip gracefully on other OS targets.
+
+---
+
+## Platform Playbooks
+
 ### Windows
-- Prefer Winsock2 networking and handle path casing/ACL semantics.
-- Exercise service management, registry interactions, and file locking behavior.
+- Prefer Winsock2 networking and ensure file path comparisons honor case preservation and ACL semantics.
+- Validate service management flows, registry interactions, and file locking across Server 2019/2022 images.
+- Exercise deployment scripts (`deploy/scripts/deploy-staging.ps1`) and ensure NTFS permission adjustments succeed.
 
 ### macOS
-- Validate kqueue-powered event loops and both Intel/Apple Silicon binaries.
-- Track framework entitlements when invoking Foundation/CoreFoundation APIs.
+- Exercise kqueue-driven event loops on both Intel and Apple Silicon hardware, verifying event delivery parity.
+- Track entitlements whenever invoking Foundation/CoreFoundation APIs and document signing requirements.
+- Validate universal binaries and Rosetta fallbacks, especially for GPU toolchains.
 
 ### Linux
-- Use epoll for scalable I/O and test against multiple libc variants (glibc, musl).
-- Account for containerized environments where `/proc` and cgroup limits may differ.
+- Use epoll for scalable I/O and test on both glibc and musl images.
+- Account for containerized environments where `/proc` access or cgroup limits may differ; add guards for missing filesystems.
+- Validate shell scripts (`deploy/scripts/deploy-staging.sh`) under bash and dash to ensure portability.
 
-## Best Practices
-- Gate platform logic with `builtin.os.tag` checks and centralize conditional compilation.
-- Use `std.fs.path` helpers for filesystem joins and normalization.
-- Exercise both IPv4/IPv6 sockets and TLS pathways during regression runs.
-- Capture environment fingerprints (OS, architecture, Zig version) in test logs for traceability.
+---
 
-## CI & Automation
-- GitHub Actions matrix runs the full suite across all OS/architecture/Zig combinations with caching tuned per runner.
-- Dedicated test files exist in `tests/cross-platform/{windows,macos,linux}.zig`, each guarding platform-only features and failure modes.
-- Container builds validate Linux deployments via Docker and publish artifacts for downstream smoke tests.
+## Best Practices & Snippets
 
-## Troubleshooting Checklist
-1. Confirm platform detection and feature flags before diving into failure logs.
-2. Re-run isolated suites (`zig build test-windows`, `zig build test-macos`, `zig build test-linux`) to reproduce deterministically.
-3. Inspect permissions/path handling issues; normalize separators and encoding where needed.
-4. Monitor CI artifacts for system metadata, panic traces, and performance regressions.
+### Conditional Compilation
+```zig
+const builtin = @import("builtin");
+
+if (builtin.os.tag == .windows) {
+    // Windows-specific code paths
+} else if (builtin.os.tag == .macos) {
+    // macOS-specific code paths
+} else if (builtin.os.tag == .linux) {
+    // Linux-specific code paths
+}
+```
+
+### Platform Detection Helpers
+```zig
+const is_windows = builtin.os.tag == .windows;
+const is_macos = builtin.os.tag == .macos;
+const is_linux = builtin.os.tag == .linux;
+```
+
+### Cross-Platform Paths
+```zig
+const path = try std.fs.path.join(allocator, &[_][]const u8{"dir", "file.txt"});
+```
+
+### Network Coverage
+```zig
+const address4 = try std.net.Address.parseIp4("127.0.0.1", 8080);
+const address6 = try std.net.Address.parseIp6("::1", 8080);
+```
+
+### Environment Fingerprint
+```zig
+const stdout = std.io.getStdOut().writer();
+try stdout.print("platform={s} arch={s} zig={s}\n", .{
+    @tagName(builtin.os.tag),
+    @tagName(builtin.cpu.arch),
+    builtin.zig_version_string,
+});
+```
+
+---
+
+## Running the Matrix
+```bash
+# Run entire suite
+zig build test
+
+# Focused cross-platform aggregator
+zig build test-cross-platform
+
+# OS-specific runs
+zig build test-windows
+zig build test-macos
+zig build test-linux
+```
+
+---
+
+## Troubleshooting & Debugging
+1. Confirm `builtin.os.tag` and feature flags match expectations before triaging failures.
+2. Re-run isolated suites (`zig build test-windows`, etc.) to reproduce deterministically.
+3. Inspect file path normalization and permission handling; normalize separators/encodings as needed.
+4. Review CI artifacts for system metadata, panic traces, and performance regressions.
+5. Capture environment fingerprints in logs to accelerate cross-team debugging.
+
+---
+
+## Container Guidance
+```dockerfile
+FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y curl xz-utils
+# Install Zig toolchain and run tests
+```
+- Validate container images with both glibc and musl bases when possible.
+- Ensure `/proc` reads guard against restricted environments; skip tests gracefully when resources are unavailable.
+
+---
 
 ## Enhancement Summary
-- Expanded the CI matrix to 48+ combinations covering OS, architecture, and compiler deltas.
-- Added platform-focused regression suites and container smoke coverage.
-- Produced this merged reference so future updates live in one maintained location.
-- Next steps: monitor nightly regressions, expand hardware diversity, and feed learnings back into developer onboarding materials.
+
+### Completed
+- Updated CI workflow with the expanded Zig/OS matrix and architecture coverage.
+- Created platform-specific regression suites under `tests/cross-platform/` with allocator-aware skips.
+- Generated this consolidated reference that merges the historical guide and automation summary.
+
+### Coverage Improvements
+| Category | Before | After | Improvement |
+| --- | --- | --- | --- |
+| OS Versions | 3 | 7 | +133% |
+| Zig Versions | 3 | 4 | +33% |
+| Architectures | 1 | 2 | +100% |
+| Total Combinations | ~12 | ~48+ | +300% |
+
+### Next Steps
+1. Monitor CI runs across all platforms and investigate regressions promptly.
+2. Extend performance benchmarking to stress platform-specific hot paths (IOCP, kqueue, epoll).
+3. Keep this reference updated as new OS/Zig releases land or hardware diversity grows.
+
+### Files Created / Updated by Automation
+- `.github/workflows/ci.yml`
+- `tests/cross-platform/windows.zig`
+- `tests/cross-platform/macos.zig`
+- `tests/cross-platform/linux.zig`
+- `docs/reports/cross_platform_testing.md`
+
+### Benefits
+- Improved reliability via proactive coverage.
+- Earlier detection of OS/toolchain regressions in CI.
+- Reduced support burden thanks to consistent behavior across environments.
+
+---
+
+## Automation Notes
+- Generated by `scripts/enhance_cross_platform_testing.sh`.
+- CI matrix recommendations recorded in `/tmp/enhanced_matrix.md`.
+- Regenerated platform-specific regression suites under `tests/cross-platform/`.
+- Review GitHub Actions workflow changes before merging automated edits.
 EOF
 
     print_success "Cross-platform testing reference generated"
@@ -298,7 +434,12 @@ EOF
 
 # Create summary report
 create_summary_report() {
-    print_status "Appending automation notes to cross-platform reference..."
+    print_status "Recording automation metadata for cross-platform reference..."
+
+    if grep -q "## Automation Notes" "$REPORTS_DIR/cross_platform_testing.md"; then
+        print_status "Automation notes already captured; skipping append"
+        return
+    fi
 
     cat >> "$REPORTS_DIR/cross_platform_testing.md" << EOF
 


### PR DESCRIPTION
## Summary
- restore the retired status content in `docs/reports/engineering_status.md`, preserving metrics, deployment procedures, and the Zig 0.16 migration playbook in one reference
- rebuild `docs/reports/cross_platform_testing.md` to merge the original guide and enhancement summary while removing the literal `$(date)` placeholder
- update `scripts/enhance_cross_platform_testing.sh` to generate the richer documentation with an actual timestamp and unchanged automation notes

## Testing
- not run (documentation and script generation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68d8d07b551083318b814e9b9f1ce362