### PR TITLE
Fix stdout writer usage for Zig 0.16

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -10,8 +10,7 @@ pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
 
-    var stdout_adapter = std.io.getStdOut().writer().adaptToNewApi(&.{});
-    const stdout_writer = stdout_adapter.new_interface;
+    const stdout = std.io.getStdOut().writer();
 
     var framework = try abi.init(gpa.allocator(), .{});
     defer framework.deinit();
@@ -21,5 +20,5 @@ pub fn main() !void {
     try framework.writeSummary(stream.writer());
 
     const summary = stream.getWritten();
-    try stdout_writer.print("ABI Framework bootstrap complete\n{s}\n", .{summary});
+    try stdout.print("ABI Framework bootstrap complete\n{s}\n", .{summary});
 }


### PR DESCRIPTION
## Summary
- replace the temporary stdout adapter with the standard std.io writer API
- ensure the CLI bootstrap prints via Zig 0.16's std.io.getStdOut writer

## Testing
- not run (zig is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d8dbef5ddc833190b9bf7cb13bbfc2