### PR TITLE
Refactor CLI registry into typed modules

### DIFF
--- a/src/tools/cli/chat.zig
+++ b/src/tools/cli/chat.zig
@@ -4,6 +4,7 @@ const common = @import("common.zig");
 const persona_manifest = abi.ai.persona_manifest;
 
 pub const command = common.Command{
+    .id = .chat,
     .name = "chat",
     .summary = "Interact with the ABI conversational agent",
     .usage = "abi chat [--persona <type>] [--backend <provider>] [--model <name>] [--persona-manifest <path>] [--profile <name>] [--interactive] [message]",

--- a/src/tools/cli/common.zig
+++ b/src/tools/cli/common.zig
@@ -3,11 +3,25 @@ const std = @import("std");
 pub const CLI_NAME = "ABI Framework CLI";
 pub const CLI_VERSION = "0.1.0a";
 
+pub const CommandId = enum {
+    gpu,
+    db,
+    config,
+    neural,
+    simd,
+    plugin,
+    server,
+    weather,
+    llm,
+    chat,
+};
+
 pub const Context = struct {
     allocator: std.mem.Allocator,
 };
 
 pub const Command = struct {
+    id: CommandId,
     name: []const u8,
     aliases: []const []const u8 = &.{},
     summary: []const u8,

--- a/src/tools/cli/config.zig
+++ b/src/tools/cli/config.zig
@@ -3,6 +3,7 @@ const wdbx = @import("wdbx");
 const common = @import("common.zig");
 
 pub const command = common.Command{
+    .id = .config,
     .name = "config",
     .summary = "Inspect and modify ABI configuration files",
     .usage = "abi config [set|get|list|validate|show] [options]",

--- a/src/tools/cli/db.zig
+++ b/src/tools/cli/db.zig
@@ -3,6 +3,7 @@ const wdbx = @import("wdbx");
 const common = @import("common.zig");
 
 pub const command = common.Command{
+    .id = .db,
     .name = "db",
     .aliases = &.{"wdbx"},
     .summary = "Manage vector databases",

--- a/src/tools/cli/gpu.zig
+++ b/src/tools/cli/gpu.zig
@@ -3,6 +3,7 @@ const gpu = @import("gpu");
 const common = @import("common.zig");
 
 pub const command = common.Command{
+    .id = .gpu,
     .name = "gpu",
     .summary = "GPU diagnostics and vector utilities",
     .usage = "abi gpu <info|run-examples|dot|search|benchmark> [options]",

--- a/src/tools/cli/llm.zig
+++ b/src/tools/cli/llm.zig
@@ -6,6 +6,7 @@ const common = @import("common.zig");
 const ml = @import("ml_support.zig");
 
 pub const command = common.Command{
+    .id = .llm,
     .name = "llm",
     .summary = "Work with language model embeddings and training",
     .usage = "abi llm <embed|query|train> [flags]",

--- a/src/tools/cli/neural.zig
+++ b/src/tools/cli/neural.zig
@@ -4,6 +4,7 @@ const common = @import("common.zig");
 const ml = @import("ml_support.zig");
 
 pub const command = common.Command{
+    .id = .neural,
     .name = "neural",
     .summary = "Train and inspect neural network models",
     .usage = "abi neural <train|predict|info|benchmark> [options]",

--- a/src/tools/cli/plugin.zig
+++ b/src/tools/cli/plugin.zig
@@ -3,6 +3,7 @@ const plugins = @import("plugins");
 const common = @import("common.zig");
 
 pub const command = common.Command{
+    .id = .plugin,
     .name = "plugin",
     .summary = "Manage ABI plugin registry",
     .usage = "abi plugin <list|load|info|call> [args...]",

--- a/src/tools/cli/registry.zig
+++ b/src/tools/cli/registry.zig
@@ -12,44 +12,100 @@ const weather = @import("weather.zig");
 const llm = @import("llm.zig");
 const chat = @import("chat.zig");
 
-pub const commands = [_]common.Command{
-    gpu.command,
-    db.command,
-    config.command,
-    neural.command,
-    simd.command,
-    plugin.command,
-    server.command,
-    weather.command,
-    llm.command,
-    chat.command,
-};
+pub const CommandRegistry = struct {
+    pub const Entry = struct {
+        id: common.CommandId,
+        command: *const common.Command,
+    };
 
-pub fn all() []const common.Command {
-    return commands[0..];
-}
+    entries: []const Entry,
 
-pub fn find(name: []const u8) ?*const common.Command {
-    for (&commands) |*cmd| {
-        if (std.mem.eql(u8, name, cmd.name)) return cmd;
-        for (cmd.aliases) |alias| {
-            if (std.mem.eql(u8, name, alias)) return cmd;
+    pub inline fn init(comptime entries: []const Entry) CommandRegistry {
+        comptime {
+            const all_ids = std.meta.fields(common.CommandId);
+            var seen = [_]bool{false} ** all_ids.len;
+            inline for (entries) |entry| {
+                const idx = @intFromEnum(entry.id);
+                if (idx >= seen.len) {
+                    @compileError("Command id out of range");
+                }
+                if (seen[idx]) {
+                    @compileError("Duplicate command id registered: " ++ all_ids[idx].name);
+                }
+                if (entry.command.id != entry.id) {
+                    @compileError("Command id mismatch for " ++ entry.command.name);
+                }
+                seen[idx] = true;
+            }
+
+            inline for (seen, 0..) |was_seen, idx| {
+                if (!was_seen) {
+                    const field = all_ids[idx];
+                    @compileError("Command registry missing entry for " ++ field.name);
+                }
+            }
+        }
+
+        return .{ .entries = entries };
+    }
+
+    pub inline fn iter(self: CommandRegistry) []const Entry {
+        return self.entries;
+    }
+
+    pub inline fn find(self: CommandRegistry, name: []const u8) ?*const common.Command {
+        for (self.entries) |entry| {
+            const cmd = entry.command;
+            if (std.mem.eql(u8, name, cmd.name)) return cmd;
+            for (cmd.aliases) |alias| {
+                if (std.mem.eql(u8, name, alias)) return cmd;
+            }
+        }
+        return null;
+    }
+
+    pub inline fn byId(self: CommandRegistry, id: common.CommandId) *const common.Command {
+        for (self.entries) |entry| {
+            if (entry.id == id) return entry.command;
+        }
+        @panic("Command id not registered");
+    }
+
+    pub inline fn formatSummary(self: CommandRegistry, writer: anytype) !void {
+        for (self.entries) |entry| {
+            const cmd = entry.command;
+            try writer.print("  {s}  {s}\n", .{ cmd.name, cmd.summary });
         }
     }
-    return null;
+};
+
+const entries = [_]CommandRegistry.Entry{
+    .{ .id = .gpu, .command = &gpu.command },
+    .{ .id = .db, .command = &db.command },
+    .{ .id = .config, .command = &config.command },
+    .{ .id = .neural, .command = &neural.command },
+    .{ .id = .simd, .command = &simd.command },
+    .{ .id = .plugin, .command = &plugin.command },
+    .{ .id = .server, .command = &server.command },
+    .{ .id = .weather, .command = &weather.command },
+    .{ .id = .llm, .command = &llm.command },
+    .{ .id = .chat, .command = &chat.command },
+};
+
+pub const global = CommandRegistry.init(entries);
+
+pub fn find(name: []const u8) ?*const common.Command {
+    return global.find(name);
+}
+
+pub fn iter() []const CommandRegistry.Entry {
+    return global.iter();
 }
 
 pub fn formatSummary(writer: anytype) !void {
-    const entries = commands[0..];
-    var longest: usize = 0;
-    for (entries) |cmd| {
-        longest = @max(longest, cmd.name.len);
-        for (cmd.aliases) |alias| {
-            longest = @max(longest, alias.len);
-        }
-    }
+    try global.formatSummary(writer);
+}
 
-    for (entries) |cmd| {
-        try writer.print("  {s}  {s}\n", .{ cmd.name, cmd.summary });
-    }
+pub fn byId(id: common.CommandId) *const common.Command {
+    return global.byId(id);
 }

--- a/src/tools/cli/router.zig
+++ b/src/tools/cli/router.zig
@@ -34,16 +34,9 @@ pub fn printGlobalHelp() !void {
     std.debug.print("Available commands:\n", .{});
 
     // Print commands directly
-    const commands = registry.all();
-    var longest: usize = 0;
-    for (commands) |cmd| {
-        longest = @max(longest, cmd.name.len);
-        for (cmd.aliases) |alias| {
-            longest = @max(longest, alias.len);
-        }
-    }
-
-    for (commands) |cmd| {
+    const entries = registry.iter();
+    for (entries) |entry| {
+        const cmd = entry.command;
         std.debug.print("  {s}  {s}\n", .{ cmd.name, cmd.summary });
     }
 

--- a/src/tools/cli/server.zig
+++ b/src/tools/cli/server.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const common = @import("common.zig");
 
 pub const command = common.Command{
+    .id = .server,
     .name = "server",
     .summary = "Manage the WDBX HTTP server",
     .usage = "abi server <start|stop|status|test> [flags]",

--- a/src/tools/cli/simd.zig
+++ b/src/tools/cli/simd.zig
@@ -3,6 +3,7 @@ const abi = @import("abi");
 const common = @import("common.zig");
 
 pub const command = common.Command{
+    .id = .simd,
     .name = "simd",
     .summary = "CPU SIMD utilities and benchmarks",
     .usage = "abi simd <info|benchmark|dot|matrix> [options]",

--- a/src/tools/cli/weather.zig
+++ b/src/tools/cli/weather.zig
@@ -5,6 +5,7 @@ const wdbx = @import("wdbx");
 const common = @import("common.zig");
 
 pub const command = common.Command{
+    .id = .weather,
     .name = "weather",
     .summary = "Ingest and query weather embeddings",
     .usage = "abi weather <ingest|query> [flags]",

--- a/tests/tools_cli.zig
+++ b/tests/tools_cli.zig
@@ -48,10 +48,15 @@ test "router prints global help" {
 }
 
 test "registry finds commands" {
-    const cmds = registry.all();
-    try std.testing.expect(cmds.len > 0);
-    try std.testing.expect(registry.find("gpu") != null);
-    try std.testing.expect(registry.find("wdbx") != null);
+    const entries = registry.iter();
+    try std.testing.expect(entries.len == std.meta.fields(common.CommandId).len);
+
+    const reg = registry.global;
+    try std.testing.expect(reg.find("gpu") != null);
+    try std.testing.expect(reg.find("wdbx") != null);
+
+    const db_command = registry.byId(.db);
+    try std.testing.expectEqualStrings("db", db_command.name);
 }
 
 test "gpu command displays help" {


### PR DESCRIPTION
## Summary
- add a typed `CommandId` to the shared CLI command descriptor and update each subcommand module
- replace the ad-hoc command array with a `CommandRegistry` that enforces registration and drives router help output
- expand CLI tests to cover the registry metadata and lookups alongside existing subcommand smoke tests

## Testing
- zig test tests/tools_cli.zig *(fails: `zig` is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9aec8c1d88331b5250875ea2e4f32