### PR TITLE
Track SessionDatabase metadata ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ follows [Semantic Versioning](https://semver.org/) while it remains in the `0.y`
 
 ## [Unreleased]
 
+### Fixed
+- Ensure `SessionDatabase.insert` releases duplicated metadata when an append fails so temporary allocations are not leaked.
+- Track metadata ownership for `SessionDatabase` entries so teardown skips freeing slices that were never allocated.
+
 ### Deprecated
 - `shared/core/profiles.zig` is now a legacy shim around `shared/core/profile.zig` and emits a compile-time notice when imported. Downstream users should migrate to the new module before the next release.
 

--- a/src/comprehensive_cli.zig
+++ b/src/comprehensive_cli.zig
@@ -70,7 +70,7 @@ const SessionDatabase = struct {
     const VectorEntry = struct {
         id: u64,
         values: []f32,
-        metadata: []u8,
+        metadata: ?[]u8,
     };
 
     pub const SearchResult = struct {
@@ -96,7 +96,9 @@ const SessionDatabase = struct {
     pub fn deinit(self: *SessionDatabase) void {
         for (self.entries.items) |entry| {
             self.allocator.free(entry.values);
-            self.allocator.free(entry.metadata);
+            if (entry.metadata) |meta| {
+                self.allocator.free(meta);
+            }
         }
         self.entries.deinit();
     }
@@ -113,13 +115,14 @@ const SessionDatabase = struct {
         var stored_needs_free = true;
         errdefer if (stored_needs_free) self.allocator.free(stored);
 
-        var stored_meta: []u8 = &[_]u8{};
+        var stored_meta: ?[]u8 = null;
         var stored_meta_needs_free = false;
         if (metadata) |meta| {
-            stored_meta = try self.allocator.dupe(u8, meta);
+            const duplicated = try self.allocator.dupe(u8, meta);
+            stored_meta = duplicated;
             stored_meta_needs_free = true;
         }
-        errdefer if (stored_meta_needs_free) self.allocator.free(stored_meta);
+        errdefer if (stored_meta_needs_free) self.allocator.free(stored_meta.?);
 
         const id = self.next_id;
         self.next_id += 1;


### PR DESCRIPTION
## Summary
- store SessionDatabase entry metadata as optional and only free it during teardown when it was actually allocated
- document the metadata ownership fix in the changelog

## Testing
- zig test src/comprehensive_cli.zig *(fails: `zig` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbffde16b88331bc9e875d3da5b0c3