### PR TITLE
Fix CLI vector search loop and metadata test string

### DIFF
--- a/src/cli/commands/db.zig
+++ b/src/cli/commands/db.zig
@@ -133,7 +133,7 @@ fn searchHandler(ctx: *modern_cli.Context, args: *modern_cli.ParsedArgs) errors.
             return;
         }
         try stdout.print("Top {d} matches:\n", .{results.len});
-        for (results) |res, idx| {
+        for (results, 0..) |res, idx| {
             try stdout.print(
                 "  {d}) id={d} distance={d:.4}\n",
                 .{ idx + 1, res.id, res.distance },

--- a/src/cli/state.zig
+++ b/src/cli/state.zig
@@ -43,7 +43,7 @@ test "VectorStore insert frees metadata on append failure" {
     defer store.deinit();
 
     const values = [_]f32{ 1.0, 2.0, 3.0 };
-    const metadata = "{"label":"test"}";
+    const metadata = "{\"label\":\"test\"}";
 
     try std.testing.expectError(error.OutOfMemory, store.insert(&values, metadata));
     try std.testing.expectEqual(@as(usize, 0), store.records.items.len);


### PR DESCRIPTION
## Summary
- fix the CLI search loop to use the Zig 0.16 index capture syntax
- escape the JSON metadata literal in the vector store test to restore valid Zig syntax

## Testing
- not run (zig binary unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dcdc6a35e0833184ac3f6e6600339a