### PR TITLE
Redesign zig 0.16 repository structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ git clone https://github.com/donaldfilimon/abi.git
 cd abi
 zig build
 zig build test
+zig build docs   # generate API docs via tools/docs_generator
+zig build tools  # build the aggregated tools CLI (abi-tools)
 ```
 
 The default build produces `zig-out/bin/abi`. This executable now implements a full sub‑command based CLI. Use `abi --help` to view available commands and `abi <subcommand> --help` for detailed usage.
@@ -42,6 +44,13 @@ The default build produces `zig-out/bin/abi`. This executable now implements a f
 
 # Example: list enabled features in JSON mode
 ./zig-out/bin/abi features list --json
+
+# Build and run the tools CLI (aggregates utilities under src/tools)
+zig build tools
+./zig-out/bin/abi-tools --help
+
+# Or run directly through the build system
+zig build tools-run -- --help
 ```
 
 Sample output:

--- a/build.zig
+++ b/build.zig
@@ -57,4 +57,21 @@ pub fn build(b: *std.Build) void {
 
     const docs_step = b.step("docs", "Generate API documentation");
     docs_step.dependOn(&b.addRunArtifact(docs_gen).step);
+
+    // Tools CLI (aggregates utilities under src/tools)
+    const tools_exe = b.addExecutable(.{
+        .name = "abi-tools",
+        .root_source_file = b.path("src/tools/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    tools_exe.root_module.addImport("abi", abi_mod);
+    b.installArtifact(tools_exe);
+
+    const tools_step = b.step("tools", "Build the ABI tools CLI");
+    tools_step.dependOn(&tools_exe.step);
+
+    const run_tools = b.addRunArtifact(tools_exe);
+    const tools_run_step = b.step("tools-run", "Run the ABI tools CLI");
+    tools_run_step.dependOn(&run_tools.step);
 }


### PR DESCRIPTION
Add `abi-tools` CLI and associated build steps to modernize the build system and aggregate utilities.

---
<a href="https://cursor.com/background-agent?bcId=bc-b92d48a2-91ae-4dc8-b7e9-1af8d972c102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b92d48a2-91ae-4dc8-b7e9-1af8d972c102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

