### PR TITLE
Align version test with package version

### DIFF
--- a/lib/mod.zig
+++ b/lib/mod.zig
@@ -116,7 +116,7 @@ test {
 }
 
 test "abi.version returns build package version" {
-    try std.testing.expectEqualStrings("0.1.0a", version());
+    try std.testing.expectEqualStrings("0.2.0", version());
 }
 
 test "framework initialization" {


### PR DESCRIPTION
## Summary
- update the abi.version test to expect the current 0.2.0 package version so it matches build configuration

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69441507bc6c8331b46c240b8fedfba2)