### PR TITLE
Normalize init configuration handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ pub fn main() !void {
     const allocator = gpa.allocator();
 
     // Initialize the framework
-    var framework = try abi.init(allocator, .{});
+    var framework = try abi.init(allocator, abi.FrameworkOptions{});
     defer abi.shutdown(&framework);
 
     // Create an AI agent
@@ -259,7 +259,7 @@ test "AI agent processes input correctly" {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
     
-    var framework = try abi.init(allocator, .{});
+    var framework = try abi.init(allocator, abi.FrameworkOptions{});
     defer abi.shutdown(&framework);
     
     const Agent = abi.ai.agent.Agent;

--- a/docs/guides/GETTING_STARTED.md
+++ b/docs/guides/GETTING_STARTED.md
@@ -67,7 +67,7 @@ pub fn main() !void {
     const allocator = gpa.allocator();
 
     // Initialize the framework
-    var framework = try abi.init(allocator, .{});
+    var framework = try abi.init(allocator, abi.FrameworkOptions{});
     defer abi.shutdown(&framework);
 
     // Print framework version
@@ -104,7 +104,7 @@ pub fn main() !void {
     const allocator = gpa.allocator();
 
     // Initialize framework
-    var framework = try abi.init(allocator, .{});
+    var framework = try abi.init(allocator, abi.FrameworkOptions{});
     defer abi.shutdown(&framework);
 
     // Create an AI agent
@@ -146,7 +146,7 @@ pub fn main() !void {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    var framework = try abi.init(allocator, .{});
+    var framework = try abi.init(allocator, abi.FrameworkOptions{});
     defer abi.shutdown(&framework);
 
     // Create a vector (embedding)
@@ -218,7 +218,7 @@ test "framework initialization" {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    var framework = try abi.init(allocator, .{});
+    var framework = try abi.init(allocator, abi.FrameworkOptions{});
     defer abi.shutdown(&framework);
 
     try testing.expect(framework.state == .initialized);
@@ -229,7 +229,7 @@ test "agent creation and processing" {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    var framework = try abi.init(allocator, .{});
+    var framework = try abi.init(allocator, abi.FrameworkOptions{});
     defer abi.shutdown(&framework);
 
     const Agent = abi.ai.agent.Agent;

--- a/tests/integration/ai_pipeline_test.zig
+++ b/tests/integration/ai_pipeline_test.zig
@@ -8,7 +8,7 @@ test "AI pipeline: agent initialization and processing" {
     const allocator = gpa.allocator();
 
     // Initialize framework
-    var framework = try abi.init(allocator, .{});
+    var framework = try abi.init(allocator, abi.FrameworkOptions{});
     defer abi.shutdown(&framework);
 
     // Create and test agent
@@ -27,7 +27,7 @@ test "AI pipeline: multiple agents coordination" {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    var framework = try abi.init(allocator, .{});
+    var framework = try abi.init(allocator, abi.FrameworkOptions{});
     defer abi.shutdown(&framework);
 
     const Agent = abi.ai.agent.Agent;

--- a/tests/integration/database_ops_test.zig
+++ b/tests/integration/database_ops_test.zig
@@ -7,7 +7,7 @@ test "Database: vector storage and retrieval" {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    var framework = try abi.init(allocator, .{});
+    var framework = try abi.init(allocator, abi.FrameworkOptions{});
     defer abi.shutdown(&framework);
 
     // Test database operations
@@ -31,7 +31,7 @@ test "Database: concurrent operations" {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    var framework = try abi.init(allocator, .{});
+    var framework = try abi.init(allocator, abi.FrameworkOptions{});
     defer abi.shutdown(&framework);
 
     // Test concurrent database access

--- a/tests/integration/framework_lifecycle_test.zig
+++ b/tests/integration/framework_lifecycle_test.zig
@@ -7,7 +7,7 @@ test "Framework: initialization and shutdown" {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    var framework = try abi.init(allocator, .{});
+    var framework = try abi.init(allocator, abi.FrameworkOptions{});
     defer abi.shutdown(&framework);
 
     try testing.expect(framework.state == .initialized);
@@ -20,21 +20,21 @@ test "Framework: multiple init/shutdown cycles" {
 
     // First cycle
     {
-        var framework = try abi.init(allocator, .{});
+        var framework = try abi.init(allocator, abi.FrameworkOptions{});
         defer abi.shutdown(&framework);
         try testing.expect(framework.state == .initialized);
     }
 
     // Second cycle
     {
-        var framework = try abi.init(allocator, .{});
+        var framework = try abi.init(allocator, abi.FrameworkOptions{});
         defer abi.shutdown(&framework);
         try testing.expect(framework.state == .initialized);
     }
 
     // Third cycle
     {
-        var framework = try abi.init(allocator, .{});
+        var framework = try abi.init(allocator, abi.FrameworkOptions{});
         defer abi.shutdown(&framework);
         try testing.expect(framework.state == .initialized);
     }
@@ -45,7 +45,7 @@ test "Framework: feature availability" {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    var framework = try abi.init(allocator, .{});
+    var framework = try abi.init(allocator, abi.FrameworkOptions{});
     defer abi.shutdown(&framework);
 
     // Check that features are available


### PR DESCRIPTION
## Summary
- convert `abi.init` and related helpers to work with `RuntimeConfig` while converting `FrameworkOptions` automatically
- derive runtime feature lists from framework options and map them onto the runtime feature tags
- update integration tests and documentation examples to pass explicit configuration types

## Testing
- Not run (zig executable not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944150681f4833198e7d28e92ce89f3)