### PR TITLE
Add framework feature toggle guardrails

### DIFF
--- a/lib/framework/config.zig
+++ b/lib/framework/config.zig
@@ -186,3 +186,26 @@ test "deriveFeatureToggles respects overrides" {
     try std.testing.expect(!toggles.isEnabled(.gpu));
     try std.testing.expect(!toggles.isEnabled(.database));
 }
+
+test "deriveFeatureToggles maps booleans and applies disabled list" {
+    const options = FrameworkOptions{
+        .enable_ai = false,
+        .enable_database = true,
+        .enable_web = true,
+        .enable_monitoring = false,
+        .enable_gpu = true,
+        .enable_connectors = true,
+        .enable_simd = false,
+        .disabled_features = &.{ .web, .gpu },
+    };
+    const toggles = deriveFeatureToggles(options);
+
+    try std.testing.expect(!toggles.isEnabled(.ai));
+    try std.testing.expect(toggles.isEnabled(.database));
+    try std.testing.expect(!toggles.isEnabled(.web));
+    try std.testing.expect(!toggles.isEnabled(.gpu));
+    try std.testing.expect(!toggles.isEnabled(.monitoring));
+    try std.testing.expect(toggles.isEnabled(.connectors));
+    try std.testing.expect(!toggles.isEnabled(.simd));
+    try std.testing.expectEqual(@as(usize, 2), toggles.count());
+}

--- a/lib/framework/runtime.zig
+++ b/lib/framework/runtime.zig
@@ -332,3 +332,36 @@ test "framework - feature configuration" {
     try testing.expect(!framework.isFeatureEnabled(.gpu)); // Disabled overrides enabled
     try testing.expect(!framework.isFeatureEnabled(.database));
 }
+
+test "runtime feature bitset stays aligned with feature flags mapping" {
+    const testing = std.testing;
+    const all_features = [_]features.FeatureTag{
+        .ai,
+        .gpu,
+        .database,
+        .web,
+        .monitoring,
+        .connectors,
+    };
+
+    var framework = try createFramework(
+        testing.allocator,
+        .{ .enabled_features = &all_features },
+    );
+    defer framework.deinit();
+
+    const expected_flags = features.config.createFlags(&all_features);
+    const bit_length = expected_flags.bit_length;
+    var idx: usize = 0;
+    while (idx < bit_length) : (idx += 1) {
+        try testing.expectEqual(
+            expected_flags.isSet(idx),
+            framework.enabled_features.isSet(idx),
+        );
+    }
+
+    framework.disableFeature(.web);
+    try testing.expect(!framework.isFeatureEnabled(.web));
+    framework.enableFeature(.web);
+    try testing.expect(framework.isFeatureEnabled(.web));
+}


### PR DESCRIPTION
## Summary
- add coverage for FrameworkOptions boolean toggles and disabled precedence
- assert runtime feature bitsets stay aligned with the shared feature flag mapping and toggling helpers

## Testing
- zig test lib/framework/config.zig *(fails: `zig` binary unavailable in environment)*
- zig test lib/framework/runtime.zig *(fails: `zig` binary unavailable in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694415eea61c833197f2284c5385d603)