### PR TITLE
Align package version with manifest

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -5,7 +5,7 @@ fn createBuildOptions(b: *std.Build) *std.Build.Module {
     const build_options = b.addOptions();
 
     // Package version
-    build_options.addOption([]const u8, "package_version", "0.2.0");
+    build_options.addOption([]const u8, "package_version", "0.1.0");
 
     // Feature flags - all default to true for full functionality
     const enable_gpu = b.option(bool, "enable-gpu", "Enable GPU support") orelse true;

--- a/lib/mod.zig
+++ b/lib/mod.zig
@@ -116,7 +116,7 @@ test {
 }
 
 test "abi.version returns build package version" {
-    try std.testing.expectEqualStrings("0.2.0", version());
+    try std.testing.expectEqualStrings("0.1.0", version());
 }
 
 test "framework initialization" {


### PR DESCRIPTION
## Summary
- align the build options package_version value with the package manifest version
- update the abi.version test to expect the corrected package version

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694415e0b5b88331b3ed28e07d5082d6)