### PR TITLE
Use production RateLimiter in rate-limiting tests and add injectable TimeProvider

### DIFF
--- a/tests/unit/test_rate_limiting.zig
+++ b/tests/unit/test_rate_limiting.zig
@@ -4,115 +4,63 @@
 
 const std = @import("std");
 const testing = std.testing;
+const abi = @import("abi");
+
+const security = abi.utils.security;
+const ai = abi.ai;
+
+const MockClock = struct {
+    now: i64,
+
+    fn provider(self: *MockClock) security.TimeProvider {
+        return .{ .context = self, .now_fn = nowFn };
+    }
+
+    fn nowFn(context: ?*anyopaque) i64 {
+        const clock: *MockClock = @ptrCast(@alignCast(context.?));
+        return clock.now;
+    }
+};
 
 test "basic rate limiting" {
-    // TODO: Implement when HTTP server module is available
-    // This is a placeholder for rate limiting tests
-
-    const RateLimiter = struct {
-        requests: std.AutoHashMap(u32, RequestInfo),
-        allocator: std.mem.Allocator,
-        max_requests: u32,
-        window_ms: u64,
-
-        const RequestInfo = struct {
-            count: u32,
-            first_request_time: i64,
-        };
-
-        fn init(allocator: std.mem.Allocator, max_requests: u32, window_ms: u64) !@This() {
-            return .{
-                .requests = std.AutoHashMap(u32, RequestInfo).init(allocator),
-                .allocator = allocator,
-                .max_requests = max_requests,
-                .window_ms = window_ms,
-            };
-        }
-
-        fn deinit(self: *@This()) void {
-            self.requests.deinit();
-        }
-
-        fn checkLimit(self: *@This(), client_ip: u32) !bool {
-            const now = 0;
-
-            if (self.requests.getPtr(client_ip)) |info| {
-                const elapsed = now - info.first_request_time;
-
-                if (elapsed > self.window_ms) {
-                    // Reset window
-                    info.count = 1;
-                    info.first_request_time = now;
-                    return true;
-                }
-
-                if (info.count >= self.max_requests) {
-                    return false; // Rate limit exceeded
-                }
-
-                info.count += 1;
-                return true;
-            } else {
-                // First request from this IP
-                try self.requests.put(client_ip, .{
-                    .count = 1,
-                    .first_request_time = now,
-                });
-                return true;
-            }
-        }
-    };
-
-    // Test rate limiter
-    var limiter = try RateLimiter.init(testing.allocator, 10, 60000); // 10 requests per minute
+    var clock = MockClock{ .now = 0 };
+    var limiter = security.RateLimiter.initWithTimeProvider(
+        testing.allocator,
+        .{
+            .requests_per_minute = 10,
+            .window_seconds = 60,
+            .max_concurrent = 10,
+        },
+        clock.provider(),
+    );
     defer limiter.deinit();
 
     const test_ip: u32 = 0x7F000001; // 127.0.0.1
 
     // First 10 requests should pass
     for (0..10) |_| {
-        try testing.expect(try limiter.checkLimit(test_ip));
+        try limiter.checkLimit(test_ip);
     }
 
     // 11th request should fail
-    try testing.expect(!try limiter.checkLimit(test_ip));
+    try testing.expectError(security.ValidationError.RateLimitExceeded, limiter.checkLimit(test_ip));
+
+    // After window expires, should allow again
+    clock.now = 61;
+    try limiter.checkLimit(test_ip);
 }
 
 test "rate limiting with multiple IPs" {
-    const RateLimiter = struct {
-        requests: std.AutoHashMap(u32, u32),
-        allocator: std.mem.Allocator,
-        max_requests: u32,
-
-        fn init(allocator: std.mem.Allocator, max_requests: u32) !@This() {
-            return .{
-                .requests = std.AutoHashMap(u32, u32).init(allocator),
-                .allocator = allocator,
-                .max_requests = max_requests,
-            };
-        }
-
-        fn deinit(self: *@This()) void {
-            self.requests.deinit();
-        }
-
-        fn checkAndIncrement(self: *@This(), client_ip: u32) !bool {
-            const result = try self.requests.getOrPut(client_ip);
-            if (!result.found_existing) {
-                result.value_ptr.* = 1;
-                return true;
-            }
-
-            if (result.value_ptr.* >= self.max_requests) {
-                return false;
-            }
-
-            result.value_ptr.* += 1;
-            return true;
-        }
-    };
-
-    var limiter = try RateLimiter.init(testing.allocator, 5);
+    var clock = MockClock{ .now = 0 };
+    var limiter = security.RateLimiter.initWithTimeProvider(
+        testing.allocator,
+        .{
+            .requests_per_minute = 5,
+            .window_seconds = 60,
+            .max_concurrent = 10,
+        },
+        clock.provider(),
+    );
     defer limiter.deinit();
 
     // Test different IPs
@@ -121,113 +69,50 @@ test "rate limiting with multiple IPs" {
 
     // Both IPs should get their own limits
     for (0..5) |_| {
-        try testing.expect(try limiter.checkAndIncrement(ip1));
-        try testing.expect(try limiter.checkAndIncrement(ip2));
+        try limiter.checkLimit(ip1);
+        try limiter.checkLimit(ip2);
     }
 
     // Both should now be rate limited
-    try testing.expect(!try limiter.checkAndIncrement(ip1));
-    try testing.expect(!try limiter.checkAndIncrement(ip2));
+    try testing.expectError(security.ValidationError.RateLimitExceeded, limiter.checkLimit(ip1));
+    try testing.expectError(security.ValidationError.RateLimitExceeded, limiter.checkLimit(ip2));
 }
 
-test "sliding window rate limiting" {
-    // More sophisticated rate limiting with sliding window
-    const SlidingWindowLimiter = struct {
-        requests: std.ArrayList(i64),
-        allocator: std.mem.Allocator,
-        max_requests: u32,
-        window_ms: i64,
-
-        fn init(allocator: std.mem.Allocator, max_requests: u32, window_ms: i64) !@This() {
-            return .{
-                .requests = try std.ArrayList(i64).initCapacity(allocator, 0),
-                .allocator = allocator,
-                .max_requests = max_requests,
-                .window_ms = window_ms,
-            };
-        }
-
-        fn deinit(self: *@This()) void {
-            self.requests.deinit(self.allocator);
-        }
-
-        fn checkLimit(self: *@This(), timestamp: i64) !bool {
-            // Remove old requests outside the window
-            const cutoff = timestamp - self.window_ms;
-            var i: usize = 0;
-            while (i < self.requests.items.len) {
-                if (self.requests.items[i] < cutoff) {
-                    _ = self.requests.orderedRemove(i);
-                } else {
-                    i += 1;
-                }
-            }
-
-            // Check if we can accept this request
-            if (self.requests.items.len >= self.max_requests) {
-                return false;
-            }
-
-            // Add the new request
-            try self.requests.append(self.allocator, timestamp);
-            return true;
-        }
-    };
-
-    var limiter = try SlidingWindowLimiter.init(testing.allocator, 3, 1000);
+test "windowed rate limiting resets after window" {
+    var clock = MockClock{ .now = 0 };
+    var limiter = security.RateLimiter.initWithTimeProvider(
+        testing.allocator,
+        .{
+            .requests_per_minute = 3,
+            .window_seconds = 1,
+            .max_concurrent = 10,
+        },
+        clock.provider(),
+    );
     defer limiter.deinit();
 
     // Test requests at different times
-    try testing.expect(try limiter.checkLimit(0)); // t=0
-    try testing.expect(try limiter.checkLimit(200)); // t=200
-    try testing.expect(try limiter.checkLimit(400)); // t=400
-    try testing.expect(!try limiter.checkLimit(600)); // t=600 (should fail, 3 requests in window)
+    try limiter.checkLimit(0x7F000001); // t=0
+    try limiter.checkLimit(0x7F000001); // t=0
+    try limiter.checkLimit(0x7F000001); // t=0
+    try testing.expectError(
+        security.ValidationError.RateLimitExceeded,
+        limiter.checkLimit(0x7F000001),
+    );
 
     // After window expires, should allow again
-    try testing.expect(try limiter.checkLimit(1100)); // t=1100 (first request expired)
+    clock.now = 2;
+    try limiter.checkLimit(0x7F000001);
 }
 
 test "token bucket rate limiting" {
-    const TokenBucket = struct {
-        tokens: f64,
-        max_tokens: f64,
-        refill_rate: f64, // tokens per millisecond
-        last_refill: i64,
-
-        fn init(max_tokens: f64, refill_rate: f64) @This() {
-            return .{
-                .tokens = max_tokens,
-                .max_tokens = max_tokens,
-                .refill_rate = refill_rate,
-                .last_refill = 0,
-            };
-        }
-
-        fn tryConsume(self: *@This(), tokens: f64, current_time: i64) bool {
-            // Refill tokens based on non-negative elapsed time
-            const delta = current_time - self.last_refill;
-            const elapsed = if (delta > 0) @as(f64, @floatFromInt(delta)) else 0.0;
-            const new_tokens = elapsed * self.refill_rate;
-            self.tokens = @min(self.tokens + new_tokens, self.max_tokens);
-            self.last_refill = current_time;
-
-            // Try to consume tokens
-            if (self.tokens >= tokens) {
-                self.tokens -= tokens;
-                return true;
-            }
-
-            return false;
-        }
-    };
-
-    var bucket = TokenBucket.init(10.0, 0.001); // 10 tokens, 1 token per second
+    var bucket = ai.limiter.TokenBucket.init(10, 1000, 0);
 
     // Should allow initial burst
-    try testing.expect(bucket.tryConsume(5.0, 0));
-    try testing.expect(bucket.tryConsume(5.0, 0));
-    try testing.expect(!bucket.tryConsume(1.0, 0)); // Should fail, no tokens left
+    try testing.expect(bucket.acquire(0, 5));
+    try testing.expect(bucket.acquire(0, 5));
+    try testing.expect(!bucket.acquire(0, 1)); // Should fail, no tokens left
 
     // After 5 seconds, should have 5 new tokens
-    try testing.expect(bucket.tryConsume(5.0, 5000));
+    try testing.expect(bucket.acquire(5000, 5));
 }


### PR DESCRIPTION
### Motivation
- Replace test-local placeholder rate limiter implementations with the real production limiter so unit tests exercise actual behavior.
- Make rate-limiting tests deterministic by allowing injection of a controllable time source (clock) to simulate window expiration reliably.
- Reuse the existing AI `TokenBucket` implementation in tests rather than a duplicated test-only version.

### Description
- Add an injectable `TimeProvider` to `lib/shared/utils/security.zig` with `system()` and `timestamp()` helpers to abstract time measurement for the limiter.
- Update `RateLimiter` in `lib/shared/utils/security.zig` to store a `time_provider`, use `time_provider.timestamp()` in `checkLimit`, and provide `initWithTimeProvider(...)`; `init(...)` now delegates to that with the system provider.
- Replace placeholder limiter types in `tests/unit/test_rate_limiting.zig` with the production `security.RateLimiter` via `security.RateLimiter.initWithTimeProvider(...)` and a `MockClock` to control time in tests.
- Swap the test-local token-bucket with the production API `ai.limiter.TokenBucket` and adapt calls to use `acquire(...)`/`init(...)` signatures.

### Testing
- No automated tests were executed in this environment because `zig` was not available (`zig fmt` attempted and failed).
- Updated unit tests: `tests/unit/test_rate_limiting.zig` — rewritten to use `abi.utils.security.RateLimiter` and a `MockClock` (not yet run).
- To validate locally/CI: run `zig build test` or `zig test tests/unit/test_rate_limiting.zig` (expected to exercise the updated limiter and token-bucket code).
- Formatting check: run `zig fmt --check .` after installing Zig to verify style compliance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945c52e62088331b05eb704d4c84cae)