### PR TITLE
Remove unused placeholder feature tests

### DIFF
--- a/lib/features/connectors/tests/mod.zig
+++ b/lib/features/connectors/tests/mod.zig
@@ -1,5 +1,0 @@
-const std = @import("std");
-
-test "placeholder" {
-    try std.testing.expect(true);
-}

--- a/lib/features/database/tests/mod.zig
+++ b/lib/features/database/tests/mod.zig
@@ -1,5 +1,0 @@
-const std = @import("std");
-
-test "placeholder" {
-    try std.testing.expect(true);
-}

--- a/lib/features/gpu/tests/mod.zig
+++ b/lib/features/gpu/tests/mod.zig
@@ -1,5 +1,0 @@
-const std = @import("std");
-
-test "placeholder" {
-    try std.testing.expect(true);
-}

--- a/lib/features/monitoring/tests/mod.zig
+++ b/lib/features/monitoring/tests/mod.zig
@@ -1,5 +1,0 @@
-const std = @import("std");
-
-test "placeholder" {
-    try std.testing.expect(true);
-}

--- a/lib/features/web/tests/mod.zig
+++ b/lib/features/web/tests/mod.zig
@@ -1,5 +1,0 @@
-const std = @import("std");
-
-test "placeholder" {
-    try std.testing.expect(true);
-}


### PR DESCRIPTION
### Motivation
- Remove repetitive, no-op test stubs that add noise to the repository and test tree.
- Eliminate duplicate placeholder files that do not provide meaningful coverage or behavior.
- Prevent accidental inclusion of unused test modules in future changes.

### Description
- Deleted the identical placeholder test files: `lib/features/connectors/tests/mod.zig`, `lib/features/database/tests/mod.zig`, `lib/features/gpu/tests/mod.zig`, `lib/features/monitoring/tests/mod.zig`, and `lib/features/web/tests/mod.zig`.
- These files only contained a single `test "placeholder"` that asserted `true` and provided no value to the test suite.
- No functional code or public APIs were modified as part of this cleanup.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945ff04da088331b405870999a1faea)