### PR TITLE
Update random utilities for Zig 0.16

### DIFF
--- a/lib/shared/utils_modern.zig
+++ b/lib/shared/utils_modern.zig
@@ -215,13 +215,13 @@ pub const async_utils = struct {
 pub const random = struct {
     /// Seeded random number generator
     pub const RandomGenerator = struct {
-        rng: std.rand.DefaultPrng,
+        rng: std.Random.DefaultPrng,
 
         pub fn init(seed: u64) RandomGenerator {
-            return .{ .rng = std.rand.DefaultPrng.init(seed) };
+            return .{ .rng = std.Random.DefaultPrng.init(seed) };
         }
 
-        pub fn random(self: *RandomGenerator) std.rand.Random {
+        pub fn random(self: *RandomGenerator) std.Random {
             return self.rng.random();
         }
 


### PR DESCRIPTION
### Motivation
- Zig 0.16 changed the random API surface (moved `std.rand` into `std.Random`), which caused compilation errors when using the old identifiers.
- The project had build failures referencing `std.rand.DefaultPrng` and `std.rand.Random` types in modern utilities.

### Description
- Replace `std.rand.DefaultPrng` with `std.Random.DefaultPrng` in `lib/shared/utils_modern.zig`.
- Update `RandomGenerator.init` to call `std.Random.DefaultPrng.init(seed)` and change the `random` method return type to `std.Random`.
- Commit message: `Update random utilities for Zig 0.16` and modified `lib/shared/utils_modern.zig` accordingly.

### Testing
- No automated tests were run as part of this change.
- Manual greps and build error inspection were used to identify the failing references prior to the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694601a72e588331974ec8dbe6fd22b8)