### PR TITLE
Add working documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Modern Zig framework for modular AI services, vector search, and systems tooling
 - Web utilities (HTTP client/server helpers, weather helper)
 - Monitoring (logging, metrics, tracing, profiling)
 
+## Documentation
+
+- Docs folder (overview + guides): https://github.com/donaldfilimon/abi/tree/main/docs
+- Concise API summary: [API_REFERENCE.md](API_REFERENCE.md)
+
 ## Requirements
 
 - Zig 0.16.x (tested with 0.16.0-dev)


### PR DESCRIPTION
## Summary
- add a documentation section to the README
- link to the docs folder and API reference with working URLs

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cf12b16dc8331af5d4f1be21a5926)