### PR TITLE
Refactor Zig 0.16 full codebase

### DIFF
--- a/benchmarks/run.zig
+++ b/benchmarks/run.zig
@@ -136,10 +136,8 @@ fn configBenchmark(allocator: std.mem.Allocator) !void {
     std.mem.doNotOptimizeAway(&config);
 }
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
 
     var suite = benchmark.BenchmarkSuite.init(allocator);
     defer suite.deinit();

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -25,8 +25,8 @@
     .fingerprint = 0xd5f1a8dcca5fe58a, // Changing this has security and trust implications.
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    // Updated to support the latest stable Zig.
-    .minimum_zig_version = "0.16.0-dev.1892+53ebfde6b",
+    // Updated to support Zig 0.16.0 stable.
+    .minimum_zig_version = "0.16.0",
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.
     // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.

--- a/examples/agent.zig
+++ b/examples/agent.zig
@@ -1,10 +1,8 @@
 const std = @import("std");
 const abi = @import("abi");
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
 
     if (!abi.ai.isEnabled()) {
         std.debug.print("AI feature is disabled. Enable with -Denable-ai=true\n", .{});

--- a/examples/compute.zig
+++ b/examples/compute.zig
@@ -1,10 +1,8 @@
 const std = @import("std");
 const abi = @import("abi");
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
 
     var framework = abi.init(allocator, abi.FrameworkOptions{
         .enable_gpu = false,

--- a/examples/database.zig
+++ b/examples/database.zig
@@ -1,10 +1,8 @@
 const std = @import("std");
 const abi = @import("abi");
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
 
     var framework = try abi.init(allocator, abi.FrameworkOptions{
         .enable_database = true,

--- a/examples/gpu.zig
+++ b/examples/gpu.zig
@@ -1,10 +1,8 @@
 const std = @import("std");
 const abi = @import("abi");
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
 
     var framework = abi.init(allocator, abi.FrameworkOptions{
         .enable_gpu = true,

--- a/examples/hello.zig
+++ b/examples/hello.zig
@@ -1,10 +1,8 @@
 const std = @import("std");
 const abi = @import("abi");
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
 
     var framework = try abi.init(allocator, abi.FrameworkOptions{
         .enable_gpu = false,

--- a/examples/network.zig
+++ b/examples/network.zig
@@ -1,10 +1,8 @@
 const std = @import("std");
 const abi = @import("abi");
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
 
     if (!abi.network.isEnabled()) {
         std.debug.print("Network feature is disabled. Enable with -Denable-network=true\n", .{});

--- a/src/compute/runtime/benchmark.zig
+++ b/src/compute/runtime/benchmark.zig
@@ -86,10 +86,8 @@ fn buildResult(name: []const u8, iterations: u64, elapsed_ns: u64) BenchmarkResu
     };
 }
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
 
     const results = try runBenchmarks(allocator);
     defer allocator.free(results);

--- a/src/tests/integration.zig
+++ b/src/tests/integration.zig
@@ -2,12 +2,10 @@
 const std = @import("std");
 const abi = @import("abi");
 
-pub fn main() !void {
+pub fn main(init: std.process.Init) !void {
     std.debug.print("Running integration tests...\n", .{});
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+    const allocator = init.gpa;
 
     var framework = try abi.init(allocator, abi.FrameworkOptions{
         .enable_ai = true,

--- a/tools/cli/main.zig
+++ b/tools/cli/main.zig
@@ -15,6 +15,9 @@
 //!   agent            AI agent operations
 //!   explore          Code exploration
 
-pub fn main() !void {
-    return @import("cli").main();
+const std = @import("std");
+const cli = @import("cli");
+
+pub fn main(init: std.process.Init) !void {
+    return cli.main(init);
 }


### PR DESCRIPTION
- Update all executable entry points to use std.process.Init pattern
- Replace manual GeneralPurposeAllocator with init.gpa in examples
- Update tools/cli/main.zig to properly forward Init parameter
- Update benchmark files (benchmarks/run.zig, src/compute/runtime/benchmark.zig)
- Update integration tests to use std.process.Init
- Update build.zig.zon minimum_zig_version to 0.16.0 stable

Files updated:
- examples/{hello,compute,gpu,database,agent,network}.zig
- benchmarks/run.zig
- src/compute/runtime/benchmark.zig
- src/tests/integration.zig
- tools/cli/main.zig
- build.zig.zon