### PR TITLE
Add error handling

### DIFF
--- a/src/compute/concurrency/mod.zig
+++ b/src/compute/concurrency/mod.zig
@@ -116,7 +116,10 @@ pub const Backoff = struct {
             std.atomic.spinLoopHint();
             return;
         }
-        _ = std.Thread.yield() catch {};
+        // Thread yield failure is non-critical; log at debug level and continue
+        std.Thread.yield() catch |err| {
+            std.log.debug("Thread yield failed during backoff spin: {t}", .{err});
+        };
     }
 
     pub fn wait(self: *Backoff) void {
@@ -127,7 +130,10 @@ pub const Backoff = struct {
             std.atomic.spinLoopHint();
         }
         if (self.spins > 32) {
-            _ = std.Thread.yield() catch {};
+            // Thread yield failure is non-critical; log at debug level and continue
+            std.Thread.yield() catch |err| {
+                std.log.debug("Thread yield failed during backoff wait: {t}", .{err});
+            };
         }
     }
 };

--- a/src/core/profile.zig
+++ b/src/core/profile.zig
@@ -101,9 +101,14 @@ pub const ProfileWriter = struct {
 
 pub fn writeProfileLine(sink: LoggingSink, line: []const u8) void {
     const config = ProfileConfig{ .sink = sink };
-    var writer = ProfileWriter.init(config) catch return;
+    var writer = ProfileWriter.init(config) catch |err| {
+        std.log.warn("Failed to initialize profile writer: {t}", .{err});
+        return;
+    };
     defer writer.deinit();
-    _ = writer.writeLine(line) catch {};
+    writer.writeLine(line) catch |err| {
+        std.log.warn("Failed to write profile line: {t}", .{err});
+    };
 }
 
 pub fn writeProfileLineWithConfig(config: ProfileConfig, line: []const u8) ProfileError!void {


### PR DESCRIPTION
Replace silent catch blocks with proper error logging and handling:

- core/profile.zig: Log profile writing errors with warning level
- compute/concurrency/mod.zig: Add debug logging for thread yield failures
- compute/runtime/engine.zig: Log task errors, CPU affinity failures, and result storage errors with appropriate severity levels
- features/database/http.zig: Log backup directory and response errors
- features/ai/explore/parallel.zig: Log file processing errors in workers
- features/ai/tools/task.zig: Add SubagentError set, make listSubagents and getStatistics return errors properly with logging
- features/network/circuit_breaker.zig: Add NetworkOperationError set and debug logging for circuit state transitions

This improves debuggability by exposing previously silent failures and adds specific error sets to replace generic anyerror in key functions.