### PR TITLE
fix: Critical memory safety and type signature bugs

### DIFF
--- a/src/features/ai/streaming.zig
+++ b/src/features/ai/streaming.zig
@@ -216,12 +216,20 @@ pub fn createChunkedStream(
     return chunks;
 }
 
+/// Static buffer for single-byte token decoding to avoid dangling pointer
+const single_byte_tokens: [256][1]u8 = blk: {
+    var tokens: [256][1]u8 = undefined;
+    for (0..256) |i| {
+        tokens[i] = .{@as(u8, @intCast(i))};
+    }
+    break :blk tokens;
+};
+
 fn decodeToken(token: u32) []const u8 {
     if (token == 0) return "";
     if (token == 1) return "<unk>";
     if (token < 256) {
-        const buf: [1]u8 = .{@as(u8, @intCast(token))};
-        return &buf;
+        return &single_byte_tokens[token];
     }
     return "<token>";
 }

--- a/src/features/ai/transformer/mod.zig
+++ b/src/features/ai/transformer/mod.zig
@@ -495,12 +495,20 @@ fn hashToken(seed: u64, vocab_size: u32, token: []const u8) u32 {
     return @intCast(hash % vocab_size);
 }
 
+/// Static buffer for single-byte token decoding to avoid dangling pointer
+const single_byte_tokens: [256][1]u8 = blk: {
+    var tokens: [256][1]u8 = undefined;
+    for (0..256) |i| {
+        tokens[i] = .{@as(u8, @intCast(i))};
+    }
+    break :blk tokens;
+};
+
 fn decodeToken(token: u32) []const u8 {
     if (token == 0) return "<EOS>";
     if (token == 1) return "<UNK>";
     if (token < 256) {
-        const buf: [1]u8 = .{@as(u8, @intCast(token))};
-        return &buf;
+        return &single_byte_tokens[token];
     }
     return "<token>";
 }


### PR DESCRIPTION
Fix dangling pointer bugs in token decoding:
- streaming.zig: decodeToken was returning pointer to stack buffer
- transformer/mod.zig: decodeToken had same dangling pointer issue
- Solution: Use compile-time initialized static buffer for single-byte tokens

Fix type signature error:
- ha.zig: getUnhealthyNodes had incorrect return type syntax Changed from `std.ArrayList([]const u8)!void` to `!std.ArrayList([]const u8)`

Add ABA problem documentation:
- lockfree.zig: Add comprehensive module-level warning about ABA problem in LockFreeStack and document when to use alternative structures

Refactor duplicated code:
- ha.zig: Extract selectNewPrimary helper to consolidate logic from electPrimary and triggerFailover functions