### PR TITLE
claude/fix-todo-comment-lZ4ZZ

### DIFF
--- a/src/shared/security/audit.zig
+++ b/src/shared/security/audit.zig
@@ -612,7 +612,7 @@ pub const AuditLogger = struct {
             .type = try self.allocator.dupe(u8, target.type),
             .id = if (target.id) |id| try self.allocator.dupe(u8, id) else null,
             .path = if (target.path) |path| try self.allocator.dupe(u8, path) else null,
-            .metadata = null, // TODO: deep copy metadata
+            .metadata = if (target.metadata) |meta| try self.dupeContext(meta) else null,
         };
     }
 


### PR DESCRIPTION
Replace TODO with proper implementation that deep copies the metadata HashMap using the existing dupeContext helper function. This ensures complete duplication of Target structures in audit logging.

Fixes TODO at src/shared/security/audit.zig:615
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/donaldfilimon/abi/pull/368">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
