### PR TITLE
test: add e2e test skeletons

### DIFF
--- a/abi/src/tests/e2e_database_test.zig
+++ b/abi/src/tests/e2e_database_test.zig
@@ -1,0 +1,7 @@
+const std = @import("std");
+
+test "e2e: vector DB insert -> search -> update -> delete (skeleton)" {
+    // TODO: Use in-memory test helpers if available.
+    // This test is intentionally a compile-time skeleton to be fleshed out by maintainers.
+    _ = 0;
+}

--- a/abi/src/tests/e2e_llm_test.zig
+++ b/abi/src/tests/e2e_llm_test.zig
@@ -1,0 +1,7 @@
+const std = @import("std");
+
+test "e2e: llm pipeline (skeleton)" {
+    // TODO: implement full LLM pipeline test (load -> tokenize -> generate -> decode)
+    // This skeleton ensures the test file compiles in CI.
+    _ = 0;
+}

--- a/abi/src/tests/stress_test.zig
+++ b/abi/src/tests/stress_test.zig
@@ -1,0 +1,4 @@
+test "stress: placeholder (ignore by default)" {
+    // Long-running stress test placeholder. Mark as ignored by default in CI.
+    _ = 0;
+}


### PR DESCRIPTION
Adds compile-only e2e test skeletons for LLM pipeline and DB integration to be fleshed out by maintainers. Draft PR for review.