### PR TITLE
MCP Interop Onboarding: Two-HA + Cross-OS Launcher + Interop Docs (PR4)

### DIFF
--- a/.github/workflows/mock-interop-ci.yml
+++ b/.github/workflows/mock-interop-ci.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: '3.x'
       - name: Start mock MCP health servers
         run: |
-          python3 scripts/mock-mcp-health-servers.py 50051 50052 &
+          python3 scripts/mock-mcp-health-servers.py &
           echo $! > /tmp/mock_mcp_pids.txt
       - name: Wait for mock servers
         run: sleep 2

--- a/.github/workflows/mock-interop-ci.yml
+++ b/.github/workflows/mock-interop-ci.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: '3.x'
       - name: Start mock MCP health servers
         run: |
-          python3 scripts/mock-mcp-health-servers.py &
+          python3 scripts/mock-mcp-health-servers.py 50051 50052 &
           echo $! > /tmp/mock_mcp_pids.txt
       - name: Wait for mock servers
         run: sleep 2

--- a/scripts/mock-mcp-health-servers.py
+++ b/scripts/mock-mcp-health-servers.py
@@ -4,33 +4,28 @@ import socketserver
 import threading
 import sys
 
-PORTS = []
-
-class HealthHandler(http.server.BaseHTTPRequestHandler):
-    def do_GET(self):
-        if self.path == '/health':
-            self.send_response(200)
-            self.end_headers()
-            self.wfile.write(b'OK')
-        else:
-            self.send_response(404)
-            self.end_headers()
-
-    def log_message(self, format, *args):
-        return
-
 def run_server(port):
-    with socketserver.TCPServer(("127.0.0.1", port), HealthHandler) as httpd:
-        httpd.serve_forever()
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path == '/health':
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b'OK')
+            else:
+                self.send_response(404)
+                self.end_headers()
+        def log_message(self, format, *args):
+            return
+    httpd = http.server.ThreadingHTTPServer(("127.0.0.1", port), Handler)
+    httpd.serve_forever()
 
 def main():
-    ports = [int(p) for p in sys.argv[1:]] if len(sys.argv) > 1 else [50051, 50052]
+    ports = [50051, 50052] if len(sys.argv) <= 1 else [int(p) for p in sys.argv[1:]]
     threads = []
     for p in ports:
         t = threading.Thread(target=run_server, args=(p,), daemon=True)
         t.start()
         threads.append(t)
-    # Keep the main thread alive while servers run
     for t in threads:
         t.join()
 

--- a/scripts/mock-mcp-health-servers.py
+++ b/scripts/mock-mcp-health-servers.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+import http.server
+import socketserver
+import threading
+import sys
+
+PORTS = []
+
+class HealthHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/health':
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b'OK')
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, format, *args):
+        return
+
+def run_server(port):
+    with socketserver.TCPServer(("127.0.0.1", port), HealthHandler) as httpd:
+        httpd.serve_forever()
+
+def main():
+    ports = [int(p) for p in sys.argv[1:]] if len(sys.argv) > 1 else [50051, 50052]
+    threads = []
+    for p in ports:
+        t = threading.Thread(target=run_server, args=(p,), daemon=True)
+        t.start()
+        threads.append(t)
+    # Keep the main thread alive while servers run
+    for t in threads:
+        t.join()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- Onboarding: MCP multi-HA quick-start with two MCP instances using cross-OS launcher.
- MVP onboarding snippet for MCP (mcp/README.md) detailing two-instance startup and health checks.
- Mock CI workflow (mock-interop-ci.yml) to run a light interop test using mock MCP health endpoints.
- MCP Interop Quick Start reference in ONBOARDING.md: references/mcp-interoperability-workflow.md.
- Include MVP MVP MVP: onboarding commands for two MCPs using the launcher.

## Changes (PR4)
- ONBOARDING.md: added Two-HA interop quick-start commands and MVP section.
- mcp/README.md: MVP two-MCP onboarding snippet.
- references/mcp-interoperability-workflow.md: new reference guide.
- scripts/mock-mcp-health-servers.py: mock MCP health endpoints for CI.
- .github/workflows/mock-interop-ci.yml: mock CI for interop.
- references/mcp-interoperability-workflow.md: added detailed steps.

## How to verify
- Run local checks: bash scripts/check-mcp-health.sh; bash scripts/check-interop.sh.
- Spin up two MCP processes with the launcher and verify health endpoints on 50051 and 50052.
- CI mock interop: check that mock-interop-ci.yml passes by starting two mock MCP health servers and performing health/interop checks.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/donaldfilimon/abi/pull/643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
