### PR TITLE
docs(agents): capture learned prefs and workspace facts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,3 +132,22 @@ No unproven claims (distributed sharding, production FHE/AES/RBAC, non-loopback 
 ## OpenCode Setup
 
 `opencode.json` auto-loaded (instructions: `AGENTS.md`, `tasks/lessons.md`, `tasks/todo.md`). `.opencode/skills/` is a symlink to `.agents/skills/`. MCP servers: `abi-mcp`, `skill-loop`. Sync canonical skills: `.agents/skills/sync-clis/launch.sh`. Modern-refactor skills (codebase-analysis etc.) in `.agents/skills/` — use for refactors; follow with `./build.sh check`. Superpower + operational skills are enumerated in the system prompt's `available_skills`; don't maintain a parallel list here.
+
+## Learned User Preferences
+
+- Prefer feature branches named with the `cursor/` prefix; when creating a PR from the default branch, branch first and do not commit or push directly to `main`.
+- Prefer draft PRs when the create-pull-request flow requests draft.
+- Verify interactive dashboard/TUI with `.agents/skills/run-tui/tui.sh` (tmux pty); never prepend Homebrew `/opt/homebrew/bin` ahead of the pinned Zig on PATH.
+- Prefer honest status digests and labeled demos over fake live bridges when IPC or production capability is absent.
+- For refactor/organization work, prefer scoped tracks (module extraction vs north-star features vs docs/claims) over open-ended clean-slate rewrites; confirm scope before planning.
+
+## Learned Workspace Facts
+
+- Modern-refactor Phases 2–4 and major module-extraction waves are done; remaining high-value org hotspots are mainly `src/features/tui/repl.zig` and `src/features/tui/dashboard.zig` (next safe extracts often `repl_git.zig` / `dashboard_render.zig`).
+- Interactive `abi dashboard` / `abi tui` / `abi --tui` use a split layout (diagnostics + Agent Output); one-shot `--once` stays stacked panes — layouts diverge by design.
+- Dashboard Agent Output is a status digest, not live `agent tui` traffic; dashboard WDBX is an ephemeral CLI probe (labeled), not the durable agent store.
+- Plugin-declared slash-commands dispatch via `__cmd__:<name>` (parallel to `__context__:<name>` for context providers).
+- Open product goal for TUI/CLI north-star (streaming, pane-split, richer `@file`) is in `tasks/goals.md`; Partial north-star / demo modules must not be promoted to Current without source and tests.
+- MCP HTTP vs WDBX REST framing duplication is intentional (MCP module-root isolation); do not unify them as an organization refactor.
+- Canonical refactor layout/status: `docs/spec/abi-refactor-design.mdx`; Approach-1 waves: `docs/superpowers/plans/2026-07-15-approach1-waves-a-b-c.md`; `modern-refactor/examples/` is historical, not the active board.
+


### PR DESCRIPTION
## Summary
- Appends **Learned User Preferences** and **Learned Workspace Facts** to `AGENTS.md` from the continual-learning pass (TUI honesty, refactor scope, MCP/REST isolation).
- Keeps `origin/main` OpenCode / Zig 1398 / CLI surface wording intact (conflict-resolved onto current main).

## Test plan
- [ ] Confirm `AGENTS.md` Learned sections render correctly and do not duplicate skill enumerations already covered by `available_skills`
- [ ] Spot-check that Zig pin, `--soul` / `--stream` CLI notes, and reconciled-history wording from main remain unchanged
- [ ] No code/build impact expected (docs-only)


Made with [Cursor](https://cursor.com)