### PR TITLE
docs(agents): Cursor Cloud (Linux) dev-environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,3 +151,13 @@ No unproven claims (distributed sharding, production FHE/AES/RBAC, non-loopback 
 - MCP HTTP vs WDBX REST framing duplication is intentional (MCP module-root isolation); do not unify them as an organization refactor.
 - Canonical refactor layout/status: `docs/spec/abi-refactor-design.mdx`; Approach-1 waves: `docs/superpowers/plans/2026-07-15-approach1-waves-a-b-c.md`; `modern-refactor/examples/` is historical, not the active board.
 
+## Cursor Cloud specific instructions
+
+The cloud VM is **Linux x86_64**; this project is macOS-primary (CI is macOS-only). The startup update script installs the pinned Zig from `.zigversion` and symlinks it to `/usr/local/bin/zig`, so `zig`/`./build.sh` are ready without extra setup. Build commands are unchanged from the Commands table above.
+
+Non-obvious Linux caveats (macOS is unaffected):
+
+- **Ambient WDBX store panics on Linux.** CLI/MCP paths that use the ambient durable store (`abi complete`, `abi agent …`, `abi-mcp` with WDBX) hit a `std.Io` `setPermissions`/`fchmod` `BADF` panic in `src/features/wdbx/durable_store.zig` (`ensureOwnerOnlyDir`) on this Zig nightly. Run these with `ABI_WDBX_PERSIST=0` (or `ABI_WDBX_PATH=:memory:`) to use an in-memory store. Explicit `abi wdbx <path> …` subcommands (a separate open path in `src/cli/handlers/wdbx_db.zig`) persist to disk normally.
+- **`./build.sh check` does not fully pass on Linux.** Test targets for `src/mcp/server.zig`, `src/root.zig`, and `src/cli_test.zig` fail to link libc (`getsockname`/`getpid`) because libc is only wired for the macOS build. The `abi` and `abi-mcp` binaries themselves build and run fine. Focused suites `test-plugins`, `test-feature-contracts`, and `test-mcp-contracts` pass; `zig build lint` and `zig build check-parity` pass. Run the full `check` gate on macOS.
+- Two `tests/contracts/public_docs.zig` cases (README/audit version string) currently expect the old min-version `0.17.0-dev.1252+e4b325c19` while the docs carry the new pin `0.17.0-dev.1398+cb5635714`; this is a pre-existing repo mismatch, not an environment problem.
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and validates the Cursor Cloud dev environment for the ABI Zig framework, and records durable Linux run caveats for future cloud agents in `AGENTS.md`.

No source code was modified — only `AGENTS.md` gained a `## Cursor Cloud specific instructions` section. The toolchain install lives in the startup update script (guarded, idempotent install of the pinned Zig from `.zigversion`, symlinked to `/usr/local/bin/zig`).

## Environment

- Installed pinned Zig `0.17.0-dev.1398+cb5635714` (x86_64-linux) on PATH.
- No external package dependencies (`build.zig.zon` has none); the Zig toolchain is the only dependency.

## What was validated (Linux x86_64)

| Surface | Command | Result |
|---|---|---|
| Lint | `zig build lint` | ✅ pass |
| Parity | `zig build check-parity` | ✅ pass |
| CLI build/run | `./build.sh cli`, `abi backends` / `scheduler status` | ✅ |
| Core AI completion | `ABI_WDBX_PERSIST=0 abi complete "…"` | ✅ |
| WDBX on-disk round-trip | `abi wdbx db init` / `block insert` / `query` | ✅ |
| MCP server | `abi-mcp stdio` → `tools/list` (frozen 12 tools) | ✅ |
| Tests | `test-plugins`, `test-feature-contracts`, `test-mcp-contracts` | ✅ pass |

## Known Linux limitations (documented in AGENTS.md; macOS-primary project)

- Ambient WDBX durable store panics on this Zig nightly (`setPermissions`/`fchmod` `BADF`); run ambient-store CLI/MCP paths with `ABI_WDBX_PERSIST=0`. Explicit `abi wdbx <path>` persists to disk fine.
- `./build.sh check` does not fully pass on Linux: some test targets (`src/mcp/server.zig`, `src/root.zig`, `src/cli_test.zig`) don't link libc (`getsockname`/`getpid`); CI is macOS-only.
- Two `public_docs` contract tests are a pre-existing version-string mismatch, unrelated to the environment.

Demo log: [abi_env_demo.log](https://cursor.com/artifacts/c/art-63d89a55-e252-41f1-b334-98c59c95f1d2)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c15b19d2-5d89-4ccd-ba65-d8eaf1a314a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c15b19d2-5d89-4ccd-ba65-d8eaf1a314a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

