### PR TITLE
docs(agents): document Cursor Cloud dev-environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,3 +151,15 @@ No unproven claims (distributed sharding, production FHE/AES/RBAC, non-loopback 
 - MCP HTTP vs WDBX REST framing duplication is intentional (MCP module-root isolation); do not unify them as an organization refactor.
 - Canonical refactor layout/status: `docs/spec/abi-refactor-design.mdx`; Approach-1 waves: `docs/superpowers/plans/2026-07-15-approach1-waves-a-b-c.md`; `modern-refactor/examples/` is historical, not the active board.
 
+## Cursor Cloud specific instructions
+
+The Cloud Agent VM is **Linux x86_64**, but this repo is **macOS-primary** (CI is macOS-only). The pinned Zig from `.zigversion` is installed at `/opt/zig/...` and symlinked to `/usr/local/bin/zig` (persisted in the VM snapshot; the startup update script self-heals the symlink and reinstalls only if missing). Standard build/run commands are in the Commands table above; binaries land in `zig-out/bin/{abi,abi-mcp}`.
+
+Linux-only caveats discovered during setup (do NOT "fix" these by editing source — they don't reproduce on the macOS primary platform):
+
+- **`zig build check` does not fully pass on Linux.** Two independent reasons:
+  1. **libc link gap.** `build.zig` never calls `linkLibC()`; macOS auto-links libc for native builds, so test roots that reach `std.c` (`getpid` via `src/foundation/temp_path.zig`/`io/mod.zig`, `getsockname` via `src/mcp/server.zig`) fail to compile only on Linux (`error: dependency on libc must be explicitly specified` / `undefined symbol`). Affected suites: `test`, `test-cli`, `test-contracts`, `test-mcp-*`. Many other module/contract unit suites still compile and pass.
+  2. **Pre-existing doc drift** (platform-independent): `tests/contracts/public_docs.zig` still expects the old min-version string `0.17.0-dev.1252+e4b325c19`, but README/`docs/contracts/external-claims-audit.mdx` were updated to the pin `0.17.0-dev.1398+cb5635714`, so 2 `public_docs` tests fail.
+- **`zig build lint`, `zig build cli`, `zig build mcp` all succeed.** Use these plus targeted binary runs to validate work.
+- **Ambient durable WDBX store panics on Linux overlayfs.** `complete`, `agent`, and `train` open the ambient store (`~/.abi/wdbx` by default) which repairs the dir to `0700`; Zig 0.17 std `Threaded.setPermissionsPosix` (`fchmod`) returns `EBADF` on overlayfs, which debug std turns into a `programmer bug caused syscall error: BADF` panic. Workaround for those commands: **`ABI_WDBX_PERSIST=0`** (in-memory store, skips the on-disk permission-repair). Explicit `abi wdbx db init|block insert|query <path>` into an **already-existing** directory (e.g. `zig-out/...`) work durably and are unaffected.
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for the `abi` Zig framework and documents durable, non-obvious startup/run caveats for future agents. No source code changed — only `AGENTS.md` gains a `## Cursor Cloud specific instructions` section.

### Environment setup performed
- Installed the pinned Zig `0.17.0-dev.1398+cb5635714` (from `.zigversion`) to `/opt/zig`, symlinked to `/usr/local/bin/zig`.
- Registered an idempotent, self-healing update script (no-op when the pinned Zig is present; reinstalls/re-symlinks only if missing).

### Verified working on this Linux VM
- ✅ `zig build cli` and `zig build mcp` (binaries at `zig-out/bin/{abi,abi-mcp}`)
- ✅ `zig build lint`
- ✅ `abi backends`, `abi scheduler status`
- ✅ `abi complete` (core AI: routing + constitution audit) and `abi agent plan` via `ABI_WDBX_PERSIST=0`
- ✅ WDBX durable round-trip: `wdbx db init` → `block insert` → `query`
- ✅ `abi-mcp` frozen 12-tool `tools/list` contract

### Documented Linux-only caveats (macOS is the primary platform / CI)
- `zig build check` does not fully pass on Linux: (1) test roots reaching `std.c` (`getpid`/`getsockname`) fail to compile because `build.zig` never calls `linkLibC()` (macOS auto-links libc); (2) two `public_docs` contract tests are pre-existing doc drift (expect old min-version string `...1252...`).
- Ambient durable WDBX store (`complete`/`agent`/`train`) panics on Linux overlayfs via Zig 0.17 std `setPermissionsPosix` (`fchmod` → `EBADF`) during the `0700` permission-repair. Workaround: `ABI_WDBX_PERSIST=0`. Explicit `wdbx` file commands into existing dirs are unaffected.

Demo log: `/opt/cursor/artifacts/abi_env_demo.log`

[abi_env_demo.log](https://cursor.com/artifacts/c/art-d23c886e-292a-4ec4-9cfc-03d2926eb4c0)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d1db172-12df-4924-88e1-aa055392f23b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d1db172-12df-4924-88e1-aa055392f23b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

