### PR TITLE
chore(skills): fix stale pin refs + document modernized/ pointer

### DIFF
--- a/.agents/skills/abi-goal-orchestrator/SKILL.md
+++ b/.agents/skills/abi-goal-orchestrator/SKILL.md
@@ -12,8 +12,8 @@ Use this skill to turn ABI's active board and long-horizon specs into a concrete
 1. Start in `/Users/donaldfilimon/abi` unless the user gives another ABI checkout.
 2. Inspect `git status --short --branch` before edits; preserve unrelated dirty work.
 3. Read `AGENTS.md`, `tasks/todo.md`, and `tasks/lessons.md`.
-4. Generate or refresh the inventory with `../../scripts/abi_inventory.py --repo /Users/donaldfilimon/abi`.
-5. Load `references/current-goals.md` for the source map and goal taxonomy.
+4. Optional: refresh the inventory with `abi_inventory.py --repo /Users/donaldfilimon/abi` if available (ships with the codex `abi-mega` plugin, not this repo); skip when absent.
+5. Optional: load `references/current-goals.md` if present alongside this skill (codex plugin copies carry it; the canonical repo copy does not) — otherwise derive the source map from `tasks/todo.md` + `docs/spec/wdbx-north-star.mdx`.
 6. Derive a small executable slice. Prefer changes that make one TODO, roadmap gap, doc mismatch, or validation gap measurably more true.
 7. Keep claims honest: source/build/tests override prose.
 8. Verify with the narrow command that proves the slice, then the broader gate when the blast radius justifies it.
@@ -29,10 +29,10 @@ Use this skill to turn ABI's active board and long-horizon specs into a concrete
 ## Useful Commands
 
 ```bash
-../../scripts/abi_inventory.py --repo /Users/donaldfilimon/abi
+abi_inventory.py --repo /Users/donaldfilimon/abi   # optional; codex abi-mega plugin only
 zig version
 zig build check-parity --summary all
 ./build.sh check
 ```
 
-Use `references/current-goals.md` for the current source inventory and validation ladder.
+Use `references/current-goals.md` (when present — see Workflow step 5) for the current source inventory and validation ladder.

--- a/.agents/skills/agent-plan-train/SKILL.md
+++ b/.agents/skills/agent-plan-train/SKILL.md
@@ -1,14 +1,17 @@
 ---
 name: agent-plan-train
 description: Plan and execute ABI repo work from current TODOs, roadmap/spec docs, Zig 0.17 constraints, and validation gates. Use when user asks to find all ABI todos/roadmaps, compile ABI goals/specs, organize a large ABI implementation goal, or decide the next safe work slice in ~/abi.
+---
+
+# agent-plan-train
 
 ## Workflow
 
 1. Start in `/Users/donaldfilimon/abi` unless the user gives another ABI checkout.
 2. Inspect `git status --short --branch` before edits; preserve unrelated dirty work.
 3. Read `AGENTS.md`, `tasks/todo.md`, and `tasks/lessons.md`.
-4. Generate or refresh the inventory with `../../scripts/abi_inventory.py --repo /Users/donaldfilimon/abi`.
-5. Load `references/current-goals.md` for the source map and goal taxonomy.
+4. Optional: refresh the inventory with `abi_inventory.py --repo /Users/donaldfilimon/abi` if available (ships with the codex `abi-mega` plugin, not this repo); skip when absent.
+5. Optional: load `references/current-goals.md` if present alongside this skill (codex plugin copies carry it; the canonical repo copy does not) — otherwise derive the source map from `tasks/todo.md` + `docs/spec/wdbx-north-star.mdx`.
 6. Derive a small executable slice. Prefer changes that make one TODO, roadmap gap, doc mismatch, or validation gap measurably more true.
 7. Keep claims honest: source/build/tests override prose.
 8. Verify with the narrow command that proves the slice, then the broader gate when the blast radius justifies it.
@@ -24,10 +27,10 @@ description: Plan and execute ABI repo work from current TODOs, roadmap/spec doc
 ## Useful Commands
 
 ```bash
-../../scripts/abi_inventory.py --repo /Users/donaldfilimon/abi
+abi_inventory.py --repo /Users/donaldfilimon/abi   # optional; codex abi-mega plugin only
 zig version
 zig build check-parity --summary all
 ./build.sh check
 ```
 
-Use `references/current-goals.md` for the current source inventory and validation ladder.
+Use `references/current-goals.md` (when present — see Workflow step 5) for the current source inventory and validation ladder.

--- a/.agents/skills/agent-plan/SKILL.md
+++ b/.agents/skills/agent-plan/SKILL.md
@@ -1,16 +1,18 @@
 ---
 name: agent-plan
 priority: high
-
 description: Execute ABI repo work from current TODOs, roadmap/spec docs, Zig 0.17 constraints, and validation gates. Use when user asks to find all ABI todos/roadmaps, compile ABI goals/specs, organize a large ABI implementation goal, or decide the next safe work slice in ~/abi.
+---
+
+# agent-plan
 
 ## Workflow
 
 1. Start in `/Users/donaldfilimon/abi` unless the user gives another ABI checkout.
 2. Inspect `git status --short --branch` before edits; preserve unrelated dirty work.
 3. Read `AGENTS.md`, `tasks/todo.md`, and `tasks/lessons.md`.
-4. Generate or refresh the inventory with `../../scripts/abi_inventory.py --repo /Users/donaldfilimon/abi`.
-5. Load `references/current-goals.md` for the source map and goal taxonomy.
+4. Optional: refresh the inventory with `abi_inventory.py --repo /Users/donaldfilimon/abi` if available (ships with the codex `abi-mega` plugin, not this repo); skip when absent.
+5. Optional: load `references/current-goals.md` if present alongside this skill (codex plugin copies carry it; the canonical repo copy does not) — otherwise derive the source map from `tasks/todo.md` + `docs/spec/wdbx-north-star.mdx`.
 6. Derive a small executable slice. Prefer changes that make one TODO, roadmap gap, doc mismatch, or validation gap measurably more true.
 7. Keep claims honest: source/build/tests override prose.
 8. Verify with the narrow command that proves the slice, then the broader gate when the blast radius justifies it.

--- a/.agents/skills/zig-newest-skills/SKILL.md
+++ b/.agents/skills/zig-newest-skills/SKILL.md
@@ -6,7 +6,8 @@ description: Switch the abi repo to the newest Zig master nightly (via zvm), bui
 # zig-newest-skills — validate abi against the newest Zig master
 
 The abi repo pins a specific Zig nightly in `.zigversion`
-(`0.17.0-dev.1252+e4b325c19`). This skill does the opposite of pin-safety:
+(currently `0.17.0-dev.1398+cb5635714` — read the file for the live value).
+This skill does the opposite of pin-safety:
 it switches the active toolchain to the **current Zig master** via `zvm`,
 rebuilds the real binaries, and proves abi still compiles and runs against
 bleeding-edge `std` — surfacing forward API drift the pin would otherwise hide.
@@ -56,7 +57,8 @@ it's a build+exercise gate you read the tail of.
 ## Gotchas (battle scars from this session)
 
 - **Old nightlies are NOT re-downloadable.** zvm only serves the *current*
-  master from ziglang.org. `zvm install 0.17.0-dev.1252+e4b325c19` fails with
+  master from ziglang.org. e.g. `zvm install 0.17.0-dev.1252+e4b325c19` (a
+  since-superseded pin) fails with
   `unsupported Zig version`. So once master replaces the pin's local
   `~/.zvm/<version>` dir, the exact pin is **gone for good** unless you kept
   the tarball. Installing master can therefore permanently retire the

--- a/.agents/skills/zig-pin/SKILL.md
+++ b/.agents/skills/zig-pin/SKILL.md
@@ -25,7 +25,7 @@ toolchain. Exit 0 = match, exit 2 = mismatch with fix instructions.
 ## Steps (manual)
 
 1. **Read the pin.** Read `.zigversion` at the repo root (a single line, e.g.
-   `0.17.0-dev.1252+e4b325c19`). Call this `PIN`.
+   `0.17.0-dev.1398+cb5635714`). Call this `PIN`.
 
 2. **Read the active version.** Run `zig version`. Call this `ACTIVE`.
    - If `zig` is not on `PATH`, stop and report that no Zig is installed; point
@@ -53,5 +53,5 @@ toolchain. Exit 0 = match, exit 2 = mismatch with fix instructions.
 - The pin string is the **full** dev-build identifier including the
   `+<hash>` suffix; compare it exactly, since two `0.17.0-dev.*` builds with
   different revision numbers are not interchangeable.
-- Reference: the toolchain section at the top of `AGENTS.md` / `AGENTS.md` /
+- Reference: the toolchain section at the top of `AGENTS.md` / `CLAUDE.md` /
   `GEMINI.md`.

--- a/.claude/skills/agent-plan-train/SKILL.md
+++ b/.claude/skills/agent-plan-train/SKILL.md
@@ -1,14 +1,17 @@
 ---
 name: agent-plan-train
 description: Plan and execute ABI repo work from current TODOs, roadmap/spec docs, Zig 0.17 constraints, and validation gates. Use when user asks to find all ABI todos/roadmaps, compile ABI goals/specs, organize a large ABI implementation goal, or decide the next safe work slice in ~/abi.
+---
+
+# agent-plan-train
 
 ## Workflow
 
 1. Start in `/Users/donaldfilimon/abi` unless the user gives another ABI checkout.
 2. Inspect `git status --short --branch` before edits; preserve unrelated dirty work.
 3. Read `AGENTS.md`, `tasks/todo.md`, and `tasks/lessons.md`.
-4. Generate or refresh the inventory with `../../scripts/abi_inventory.py --repo /Users/donaldfilimon/abi`.
-5. Load `references/current-goals.md` for the source map and goal taxonomy.
+4. Optional: refresh the inventory with `abi_inventory.py --repo /Users/donaldfilimon/abi` if available (ships with the codex `abi-mega` plugin, not this repo); skip when absent.
+5. Optional: load `references/current-goals.md` if present alongside this skill (codex plugin copies carry it; the canonical repo copy does not) — otherwise derive the source map from `tasks/todo.md` + `docs/spec/wdbx-north-star.mdx`.
 6. Derive a small executable slice. Prefer changes that make one TODO, roadmap gap, doc mismatch, or validation gap measurably more true.
 7. Keep claims honest: source/build/tests override prose.
 8. Verify with the narrow command that proves the slice, then the broader gate when the blast radius justifies it.
@@ -24,10 +27,10 @@ description: Plan and execute ABI repo work from current TODOs, roadmap/spec doc
 ## Useful Commands
 
 ```bash
-../../scripts/abi_inventory.py --repo /Users/donaldfilimon/abi
+abi_inventory.py --repo /Users/donaldfilimon/abi   # optional; codex abi-mega plugin only
 zig version
 zig build check-parity --summary all
 ./build.sh check
 ```
 
-Use `references/current-goals.md` for the current source inventory and validation ladder.
+Use `references/current-goals.md` (when present — see Workflow step 5) for the current source inventory and validation ladder.

--- a/.claude/skills/zig-newest-skills/SKILL.md
+++ b/.claude/skills/zig-newest-skills/SKILL.md
@@ -6,7 +6,8 @@ description: Switch the abi repo to the newest Zig master nightly (via zvm), bui
 # zig-newest-skills — validate abi against the newest Zig master
 
 The abi repo pins a specific Zig nightly in `.zigversion`
-(`0.17.0-dev.1252+e4b325c19`). This skill does the opposite of pin-safety:
+(currently `0.17.0-dev.1398+cb5635714` — read the file for the live value).
+This skill does the opposite of pin-safety:
 it switches the active toolchain to the **current Zig master** via `zvm`,
 rebuilds the real binaries, and proves abi still compiles and runs against
 bleeding-edge `std` — surfacing forward API drift the pin would otherwise hide.
@@ -56,7 +57,8 @@ it's a build+exercise gate you read the tail of.
 ## Gotchas (battle scars from this session)
 
 - **Old nightlies are NOT re-downloadable.** zvm only serves the *current*
-  master from ziglang.org. `zvm install 0.17.0-dev.1252+e4b325c19` fails with
+  master from ziglang.org. e.g. `zvm install 0.17.0-dev.1252+e4b325c19` (a
+  since-superseded pin) fails with
   `unsupported Zig version`. So once master replaces the pin's local
   `~/.zvm/<version>` dir, the exact pin is **gone for good** unless you kept
   the tarball. Installing master can therefore permanently retire the

--- a/.claude/skills/zig-pin/SKILL.md
+++ b/.claude/skills/zig-pin/SKILL.md
@@ -25,7 +25,7 @@ toolchain. Exit 0 = match, exit 2 = mismatch with fix instructions.
 ## Steps (manual)
 
 1. **Read the pin.** Read `.zigversion` at the repo root (a single line, e.g.
-   `0.17.0-dev.1252+e4b325c19`). Call this `PIN`.
+   `0.17.0-dev.1398+cb5635714`). Call this `PIN`.
 
 2. **Read the active version.** Run `zig version`. Call this `ACTIVE`.
    - If `zig` is not on `PATH`, stop and report that no Zig is installed; point
@@ -53,5 +53,5 @@ toolchain. Exit 0 = match, exit 2 = mismatch with fix instructions.
 - The pin string is the **full** dev-build identifier including the
   `+<hash>` suffix; compare it exactly, since two `0.17.0-dev.*` builds with
   different revision numbers are not interchangeable.
-- Reference: the toolchain section at the top of `AGENTS.md` / `AGENTS.md` /
+- Reference: the toolchain section at the top of `AGENTS.md` / `CLAUDE.md` /
   `GEMINI.md`.

--- a/.gitignore
+++ b/.gitignore
@@ -345,6 +345,9 @@ test_imports3
 !/modern-refactor/.claude/
 !/modern-refactor/.claude/**
 
+# Pointer-only archive (no scaffold Zig; documents empty modernized/)
+!/modernized/README.md
+
 # Subsystem docs
 !/benchmarks/README.md
 !/benchmarks/STRUCTURE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,7 @@ No unproven claims (distributed sharding, production FHE/AES/RBAC, non-loopback 
 - Open product goal for TUI/CLI north-star (streaming, pane-split, richer `@file`) is in `tasks/goals.md`; Partial north-star / demo modules must not be promoted to Current without source and tests.
 - MCP HTTP vs WDBX REST framing duplication is intentional (MCP module-root isolation); do not unify them as an organization refactor.
 - Canonical refactor layout/status: `docs/spec/abi-refactor-design.mdx`; Approach-1 waves: `docs/superpowers/plans/2026-07-15-approach1-waves-a-b-c.md`; `modern-refactor/examples/` is historical, not the active board.
+- `modernized/` holds only a pointer-only README (allowlisted via `!/modernized/README.md` in `.gitignore`); the `src-reimagined/{ai,mcp,wdbx}` scaffolds it once described were never committed anywhere in git — do not scaffold reimagined trees until reimagine Phase D is approved; live code stays under `src/`.
 
 ## Cursor Cloud specific instructions
 

--- a/modernized/README.md
+++ b/modernized/README.md
@@ -1,0 +1,39 @@
+# modernized/ — pointer only (no scaffold tree)
+
+This directory is **not** a second production tree and does **not** contain
+Zig packages. Production code lives under repo-root `src/` and is gated by
+`./build.sh check`, frozen CLI (13 cmds), frozen MCP (12 tools), and
+`docs/contracts/external-claims-audit.mdx`.
+
+## What this folder is
+
+A local placeholder left from reimagine / modern-refactor discussion. An older
+draft claimed greenfield packages at `src-reimagined/{ai,mcp,wdbx}/` (also
+referred to elsewhere as `modernized/abi-reimagined/`). Those paths:
+
+- are **absent** on disk,
+- never appear in `git` history or on any branch,
+- were **not** supposed to be scaffolded yet — see Phase D in the local
+  (markdown-ignored) design note `analysis/src/REIMAGINED_ARCHITECTURE.md`
+  (“do not scaffold until explicitly approved”).
+
+Approach-1 waves explicitly left untracked `modernized/` out of scope
+(`docs/superpowers/plans/2026-07-15-approach1-waves-a-b-c.md`).
+
+## Live ownership (use these)
+
+| Domain | Production path |
+|--------|-----------------|
+| AI / SEA | `src/features/ai/`, `src/features/sea/` |
+| MCP | `src/mcp/` |
+| WDBX | `src/features/wdbx/` |
+
+Honest adoption is **incremental change in `src/`**, not a directory replace.
+Tracked planning sources: `docs/spec/abi-refactor-design.mdx`,
+`docs/superpowers/plans/`, `tasks/todo.md`, `tasks/goals.md`.
+
+## Do not
+
+- Treat this directory as package sources or run a separate `build.zig` here.
+- Invent `src-reimagined/` Zig to “match” the old claim without Phase D HITL.
+- Merge any future scaffold wholesale over live `src/`.


### PR DESCRIPTION
## Summary
- Document `modernized/` as a pointer-only archive (README + `.gitignore` allowlist).
- Fix stale Zig pin strings, malformed `agent-plan*` frontmatter, and broken inventory/refs paths in canonical skills (plus synced `.claude` copies).
- Record the `modernized/` pointer-only fact in `AGENTS.md`.

## Test plan
- [x] Skill edits are markdown-only (no `src/` changes)
- [x] Pin baseline and master drift gates already green on this machine from the prior session
- [ ] CI `zig build check` on macOS after merge


Made with [Cursor](https://cursor.com)