### PR TITLE
chore(skills): modernize zig-newest-skills (skill-development)

### DIFF
--- a/.agents/skills/zig-newest-skills/SKILL.md
+++ b/.agents/skills/zig-newest-skills/SKILL.md
@@ -1,91 +1,111 @@
 ---
 name: zig-newest-skills
-description: Switch the abi repo to the newest Zig master nightly (via zvm), build the CLI + MCP binaries, and verify the tree still compiles and runs against bleeding-edge std. Use when asked to test/build abi on the latest Zig, upgrade to Zig master/nightly, check forward compatibility with newest Zig, or validate toolchain drift past the .zigversion pin.
+description: "This skill should be used when the user asks to \"test abi on Zig master\", \"build on newest Zig\", \"upgrade to Zig nightly\", \"check forward compatibility with Zig master\", \"validate toolchain drift past .zigversion\", or run zig-master-check / zvm master against the abi tree. Switches the active toolchain to current Zig master via zvm, builds CLI + MCP, and proves the tree still compiles and runs against bleeding-edge std."
 ---
 
-# zig-newest-skills — validate abi against the newest Zig master
+# zig-newest-skills
 
-The abi repo pins a specific Zig nightly in `.zigversion`
-(currently `0.17.0-dev.1398+cb5635714` — read the file for the live value).
-This skill does the opposite of pin-safety:
-it switches the active toolchain to the **current Zig master** via `zvm`,
-rebuilds the real binaries, and proves abi still compiles and runs against
-bleeding-edge `std` — surfacing forward API drift the pin would otherwise hide.
+Validate **abi** against the **current Zig master** nightly. The repo pin lives
+in `.zigversion` (read that file for the live value; do not hardcode pins in
+new prose). CI uses the same pin (`.github/workflows/ci.yml` `ZIG_VERSION`).
+This skill is the inverse of pin-safety: surface forward `std` API drift the
+pin would hide.
 
-Driver: **`.agents/skills/zig-newest-skills/zig-master-check.sh`** (paths below
-are relative to the repo root). It's a CLI/toolchain check — no GUI, no
-screenshots; evidence is exit codes + the `RESULT:` line.
+**Canonical package:** `.agents/skills/zig-newest-skills/`  
+**Claude mirror:** `.claude/skills/zig-newest-skills/` (keep in sync)  
+**Driver:** `zig-master-check.sh` (repo-root relative; resolves path from `$0`)
+
+## When to run
+
+| Trigger | Action |
+|---------|--------|
+| Forward-compat check | Run driver (default) |
+| Fresh master tarball | Driver `--update` |
+| Deep CLI/MCP exercise | Driver `--smoke` |
+| Restore pin after master | Driver `--revert` |
+| Build failure only on master | Fix `src/` for moved `std` APIs, or revert pin |
+
+Do **not** use this skill to silently bump `.zigversion` / CI without an
+explicit pin-upgrade task and green `./build.sh check` on the new pin.
 
 ## Prerequisites
 
-- `zvm` on `PATH` (https://github.com/tristanisham/zvm). Verify: `zvm --version`.
-- macOS or Linux. On macOS, builds go through `./build.sh` (Metal link workflow).
+- `zvm` on `PATH` (`zvm --version`; install: https://github.com/tristanisham/zvm)
+- macOS or Linux; on macOS prefer `./build.sh` for Metal-linked CLI builds
+- Network only when installing/updating master (`zvm install master`)
 
-## Run (agent path) — FIRST
+## Agent path (run first)
+
+From the repo root:
 
 ```bash
-# From the repo root. Selects master (installs it if absent), then runs all gates.
 .agents/skills/zig-newest-skills/zig-master-check.sh
 ```
 
-What it does, cheapest gate first: `zvm use master` → `zig build check-parity`
-(std-only host gate) → `./build.sh cli` → `./build.sh mcp` → runs the built
-`abi help` and `abi backends`. Prints a summary ending in either
-`RESULT: PASS — abi builds + runs on the newest Zig master.` (exit 0) or
-`RESULT: FAIL — master drift broke N gate(s).` (exit N).
+Gate order (cheapest first):
 
-Historical verification on master `0.17.0-dev.1275` (pin was `1252` at the time):
-**PASS, 0 failed gates.**
+1. `zvm use master` (install master if missing)
+2. `zig build check-parity` — std-only host tool; isolates toolchain from feature graph
+3. `./build.sh cli` → `./build.sh mcp`
+4. Run `zig-out/bin/abi help` and `abi backends`
 
-Flags:
+Success ends with:
 
-```bash
-.agents/skills/zig-newest-skills/zig-master-check.sh --update   # re-fetch latest master nightly first
-.agents/skills/zig-newest-skills/zig-master-check.sh --smoke    # also run the full run-abi smoke (CLI + WDBX + MCP stdio)
-.agents/skills/zig-newest-skills/zig-master-check.sh --revert   # switch back to the .zigversion pin, then exit
+```text
+RESULT: PASS — abi builds + runs on the newest Zig master.
 ```
 
-`--smoke` chains the sibling `run-abi/smoke.sh` harness (13 checks: CLI
-subcommands, a WDBX round-trip, and JSON-RPC over the MCP stdio transport).
-Historical verification: `pass=13 fail=0 / SMOKE OK`.
+(exit 0). Failure: `RESULT: FAIL — master drift broke N gate(s).` (exit N).
 
-## Run (human path)
+### Flags
 
-Same as above — just run the script. There is no separate window or REPL;
-it's a build+exercise gate you read the tail of.
+```bash
+.agents/skills/zig-newest-skills/zig-master-check.sh --update
+.agents/skills/zig-newest-skills/zig-master-check.sh --smoke
+.agents/skills/zig-newest-skills/zig-master-check.sh --revert
+```
 
-## Gotchas (battle scars from this session)
+| Flag | Behavior |
+|------|----------|
+| `--update` | `zvm install master` before select |
+| `--smoke` | After binary gates, run `run-abi/smoke.sh` (CLI + WDBX + MCP stdio) |
+| `--revert` | Select `.zigversion` pin and exit (non-interactive install attempt if missing) |
 
-- **Old nightlies are NOT re-downloadable.** zvm only serves the *current*
-  master from ziglang.org. e.g. `zvm install 0.17.0-dev.1252+e4b325c19` (a
-  since-superseded pin) fails with
-  `unsupported Zig version`. So once master replaces the pin's local
-  `~/.zvm/<version>` dir, the exact pin is **gone for good** unless you kept
-  the tarball. Installing master can therefore permanently retire the
-  `.zigversion` pin — `--revert` will then fail with a clear explanation, not
-  silently. (If you need reproducibility, bump `.zigversion` to the master you
-  validated and treat that as the new pin.)
-- **`zvm list` output is ANSI-colored** (`\x1b[32mmaster`). Greping it with a
-  word boundary (`grep '\bmaster\b'`) silently fails — the `m` in `[32m`
-  abuts `master`. The driver checks `~/.zvm/<ver>/zig` on disk instead; do the
-  same in any wrapper, or you'll re-download ~54MB every run.
-- **`build.sh` does not enforce the pin.** It just runs whatever `zig` is on
-  `PATH` (echoes `Using Zig: …`). So "select master via zvm" is the *only*
-  thing that makes the build use master — there's no in-repo guard to fight.
-- **`check-parity` builds even when the feature graph wouldn't.** It's a
-  std-only, host-target line scanner. Running it first cleanly separates
-  "toolchain works" from "feature graph compiles under this std."
-- **`timeout(1)` is absent on macOS.** Don't wrap gates in it; the driver
-  relies on the caller's timeout instead.
-- **As of this session, abi has zero forward drift 1252→1275** — no source
-  changes were needed to build on master. If a future master breaks a gate,
-  the failing `./build.sh cli|mcp` output names the exact `std` API that moved.
+## After a PASS
 
-## Troubleshooting
+1. Record master version (`zig version`) vs pin in the report.
+2. **Default:** leave master selected for the rest of this session; run
+   `--revert` before any pin-gated day-to-day work (or when the user asks).
+3. If the user wants a pin bump: update `.zigversion`, CI `ZIG_VERSION`, and
+   instruction-file pin strings together; run full `./build.sh check` on the pin.
+
+## After a FAIL
+
+1. Capture the first failing gate and the `std` symbol / compile error.
+2. Prefer a minimal `src/` fix over disabling features.
+3. Re-run the driver; if unblockable, `--revert` and file a focused fix task.
+4. Consult **`references/src-touchpoints.md`** for high-churn Zig 0.17 surfaces.
+
+## Troubleshooting (quick)
 
 | Symptom | Fix |
-|---|---|
-| `zvm not found on PATH` | Install zvm; ensure `~/.zvm/bin` is on `PATH`. |
-| `--revert` → `unsupported Zig version` / `cannot revert to <pin>` | The pin nightly is no longer fetchable. Stay on master (`zvm use master`) or bump `.zigversion`. See Gotchas. |
-| Driver re-downloads master every run | You're on an old copy that greps `zvm list`; use the on-disk `have_ver` check (already in this driver). |
-| `./build.sh cli` fails only under master | Real forward drift — read the error for the moved `std` symbol; fix source or pin back. |
+|---------|-----|
+| `zvm not found` | Install zvm; put `~/.zvm/bin` on `PATH` |
+| `--revert` cannot fetch pin | Old nightlies not re-served; stay on master or bump pin |
+| Re-download master every run | Do not grep ANSI `zvm list`; use on-disk `~/.zvm/<ver>/zig` |
+| Fail only under master | Real drift — fix `src/` or pin back |
+| `--smoke` skipped | Ensure `.agents/skills/run-abi/smoke.sh` is executable |
+
+## Additional resources
+
+- **`references/gotchas.md`** — zvm/nightly battle scars (ANSI list, non-re-downloadable pins, no macOS `timeout`)
+- **`references/src-touchpoints.md`** — abi `src/` areas sensitive to Zig 0.17 / `std` churn
+- **Driver:** `zig-master-check.sh` — primary executable; prefer over ad-hoc `zvm` + build sequences
+
+## Claims boundary
+
+- Does **not** claim production multi-host, native ANE, or audited FHE.
+- Master PASS is **forward-compat evidence**, not a pin replacement, until
+  `.zigversion` + CI are updated deliberately.
+- Full `./build.sh check` on master is optional and slower; the driver covers
+  the minimum compile+run surface used for drift detection.

--- a/.agents/skills/zig-newest-skills/references/gotchas.md
+++ b/.agents/skills/zig-newest-skills/references/gotchas.md
@@ -1,0 +1,64 @@
+# zig-newest-skills — gotchas
+
+Battle scars for the master-toolchain driver. Keep SKILL.md lean; load this when
+debugging zvm, pin revert, or false re-downloads.
+
+## Old nightlies are not re-downloadable
+
+`zvm` serves the **current** master from ziglang.org. Once a pin like
+`0.17.0-dev.1252+…` is superseded, `zvm install <old-pin>` often fails with
+`unsupported Zig version`. Installing master can reclaim or replace local
+`~/.zvm/<pin>` state.
+
+**Implications:**
+
+- `--revert` may fail after a master install if the pin directory is gone.
+- The driver prints a clear FATAL with options: stay on master, bump
+  `.zigversion`, or restore a private tarball into `~/.zvm/<pin>`.
+- For reproducibility after a successful master validation, bump the pin
+  deliberately (`.zigversion` + CI + instruction files) rather than relying
+  on re-fetch of the old hash.
+
+## Never grep `zvm list` for presence
+
+`zvm list` is ANSI-colored (e.g. `\x1b[32mmaster`). A word-boundary grep like
+`grep '\bmaster\b'` can fail because the `m` in `[32m` abuts `master`.
+
+**Correct check (as in the driver):**
+
+```bash
+[ -x "${ZVM_PATH:-$HOME/.zvm}/master/zig" ]
+```
+
+Grepping list output causes needless ~50MB+ re-downloads every run.
+
+## `build.sh` does not enforce the pin
+
+`./build.sh` / `tools/build.sh` invoke whatever `zig` is on `PATH` and print
+`Using Zig: …`. Selecting master **must** be done via `zvm use master` (or
+equivalent) before the build. There is no in-repo toolchain switcher.
+
+## `check-parity` is not a feature-graph compile
+
+`zig build check-parity` is a std-only, host-target line scanner for mod/stub
+public names. It can succeed when the full feature graph would fail. The driver
+runs it **first** to separate “toolchain runs our tools” from “CLI/MCP feature
+graph compiles under this std.”
+
+## No macOS `timeout(1)`
+
+Do not wrap gates in GNU `timeout`; it is absent on stock macOS. Rely on the
+caller’s tool timeout (agent shell) instead.
+
+## Smoke path ports
+
+`--smoke` should prefer `.agents/skills/run-abi/smoke.sh`, falling back to
+`.claude/skills/run-abi/smoke.sh` when the mirror layout is used. Both must stay
+executable and hermetic (`ABI_WDBX_PERSIST=0` etc. inside the harness).
+
+## Historical note (do not treat as current)
+
+Past sessions validated intermediate masters (e.g. pin `1252` → master `1275`)
+with zero source changes. That is **historical**, not a promise for current
+master vs the live `.zigversion` pin. Always re-run the driver after pin or
+`std` churn.

--- a/.agents/skills/zig-newest-skills/references/src-touchpoints.md
+++ b/.agents/skills/zig-newest-skills/references/src-touchpoints.md
@@ -1,0 +1,68 @@
+# abi `src/` touchpoints for Zig master drift
+
+When master breaks the driver gates, inspect these surfaces first. Trust
+executable sources over this list if they diverge.
+
+## Toolchain pin surfaces (not `src/`, but co-move)
+
+| Path | Role |
+|------|------|
+| `.zigversion` | Live pin string |
+| `build.zig.zon` `minimum_zig_version` | Lower bound (may lag pin) |
+| `.github/workflows/ci.yml` `ZIG_VERSION` | CI pin; must match `.zigversion` when either moves |
+| `build.zig` / `tools/build.sh` / `./build.sh` | Invoke PATH `zig`; no auto-switch |
+
+## High-churn Zig 0.17 patterns (abi conventions)
+
+From `AGENTS.md` / live code:
+
+| Pattern | Where it bites |
+|---------|----------------|
+| `pub fn main(init: std.process.Init) !void` | `src/main.zig`, MCP entry |
+| `ArrayListUnmanaged(T).empty` | Many modules; old `.init(allocator)` fails |
+| `std.mem.trimEnd` (not `trimRight`) | String helpers |
+| `splitScalar` / `splitAny` / `splitSequence` | Parsers |
+| Relative `.zig` imports inside `src/` | Feature modules; only MCP handler group may `@import("abi")` |
+| `foundation.time.unixMs()` | Timestamps |
+| Explicit allocator; no global hidden allocator | New APIs |
+
+## Network / IO (WDBX + MCP)
+
+Zig 0.16 fails on WDBX/MCP listeners that use `std.Io.net.Stream`. Master
+churn often hits:
+
+| Area | Paths |
+|------|--------|
+| WDBX durable / REST | `src/features/wdbx/durable_store.zig`, `rest.zig`, cluster RPC |
+| MCP transports | `src/mcp/server.zig`, HTTP/SSE listeners |
+| Connectors HTTP | `src/connectors/http.zig` (SSE streaming) |
+
+Linux ambient store note (cloud VM): `setPermissions`/`fchmod` BADF on some
+nightlies — use `ABI_WDBX_PERSIST=0` for ambient paths; not a master-only issue
+but confuses smoke on Linux.
+
+## Build-feature graph
+
+Feature flags select `mod.zig` vs `stub.zig` under `src/features/`. Master
+breaks may appear only with default-on features:
+
+- `feat-foundationmodels` — arm64 macOS + `xcrun swiftc` (skip with
+  `-Dfeat-foundationmodels=false` when diagnosing pure Zig drift)
+- GPU Metal link path on macOS via `./build.sh`
+
+## Driver gate → likely blame
+
+| Failing gate | Look first |
+|--------------|------------|
+| `check-parity` | Toolchain / build.zig options / parity tool itself |
+| `./build.sh cli` | `src/main.zig`, `src/cli/**`, `src/features/**` graph |
+| `./build.sh mcp` | `src/mcp/**`, shared AI/WDBX imports |
+| `abi help` / `abi backends` | Runtime panic, missing dylib (FM shim), PATH |
+| `run-abi smoke` | Env, WDBX persist, MCP stdio protocol |
+
+## Fix discipline
+
+1. Minimal source fix; no drive-by refactors.
+2. Preserve mod/stub parity (`zig build check-parity`) if public AI/feature APIs change.
+3. Re-run `zig-master-check.sh` then, if promoting a pin, full `./build.sh check` on the new pin.
+4. Never force-push `main`; pin bumps use a normal PR.

--- a/.agents/skills/zig-newest-skills/zig-master-check.sh
+++ b/.agents/skills/zig-newest-skills/zig-master-check.sh
@@ -120,11 +120,21 @@ fi
 
 # --- optional deep smoke (reuses the run-abi harness) --------------------
 if [ "$SMOKE" -eq 1 ]; then
-    SMOKE_SH="$REPO_ROOT/.agents/skills/run-abi/smoke.sh"
-    if [ -x "$SMOKE_SH" ]; then
+    # Prefer canonical .agents path; fall back to Claude mirror layout.
+    SMOKE_SH=""
+    for candidate in \
+        "$REPO_ROOT/.agents/skills/run-abi/smoke.sh" \
+        "$REPO_ROOT/.claude/skills/run-abi/smoke.sh"
+    do
+        if [ -x "$candidate" ]; then
+            SMOKE_SH="$candidate"
+            break
+        fi
+    done
+    if [ -n "$SMOKE_SH" ]; then
         gate "run-abi smoke (full CLI+MCP)" -- "$SMOKE_SH"
     else
-        echo "note: --smoke requested but $SMOKE_SH not found/executable; skipping."
+        echo "note: --smoke requested but run-abi/smoke.sh not found/executable under .agents or .claude; skipping."
     fi
 fi
 

--- a/.claude/skills/zig-newest-skills/SKILL.md
+++ b/.claude/skills/zig-newest-skills/SKILL.md
@@ -1,91 +1,111 @@
 ---
 name: zig-newest-skills
-description: Switch the abi repo to the newest Zig master nightly (via zvm), build the CLI + MCP binaries, and verify the tree still compiles and runs against bleeding-edge std. Use when asked to test/build abi on the latest Zig, upgrade to Zig master/nightly, check forward compatibility with newest Zig, or validate toolchain drift past the .zigversion pin.
+description: "This skill should be used when the user asks to \"test abi on Zig master\", \"build on newest Zig\", \"upgrade to Zig nightly\", \"check forward compatibility with Zig master\", \"validate toolchain drift past .zigversion\", or run zig-master-check / zvm master against the abi tree. Switches the active toolchain to current Zig master via zvm, builds CLI + MCP, and proves the tree still compiles and runs against bleeding-edge std."
 ---
 
-# zig-newest-skills — validate abi against the newest Zig master
+# zig-newest-skills
 
-The abi repo pins a specific Zig nightly in `.zigversion`
-(currently `0.17.0-dev.1398+cb5635714` — read the file for the live value).
-This skill does the opposite of pin-safety:
-it switches the active toolchain to the **current Zig master** via `zvm`,
-rebuilds the real binaries, and proves abi still compiles and runs against
-bleeding-edge `std` — surfacing forward API drift the pin would otherwise hide.
+Validate **abi** against the **current Zig master** nightly. The repo pin lives
+in `.zigversion` (read that file for the live value; do not hardcode pins in
+new prose). CI uses the same pin (`.github/workflows/ci.yml` `ZIG_VERSION`).
+This skill is the inverse of pin-safety: surface forward `std` API drift the
+pin would hide.
 
-Driver: **`.agents/skills/zig-newest-skills/zig-master-check.sh`** (paths below
-are relative to the repo root). It's a CLI/toolchain check — no GUI, no
-screenshots; evidence is exit codes + the `RESULT:` line.
+**Canonical package:** `.agents/skills/zig-newest-skills/`  
+**Claude mirror:** `.claude/skills/zig-newest-skills/` (keep in sync)  
+**Driver:** `zig-master-check.sh` (repo-root relative; resolves path from `$0`)
+
+## When to run
+
+| Trigger | Action |
+|---------|--------|
+| Forward-compat check | Run driver (default) |
+| Fresh master tarball | Driver `--update` |
+| Deep CLI/MCP exercise | Driver `--smoke` |
+| Restore pin after master | Driver `--revert` |
+| Build failure only on master | Fix `src/` for moved `std` APIs, or revert pin |
+
+Do **not** use this skill to silently bump `.zigversion` / CI without an
+explicit pin-upgrade task and green `./build.sh check` on the new pin.
 
 ## Prerequisites
 
-- `zvm` on `PATH` (https://github.com/tristanisham/zvm). Verify: `zvm --version`.
-- macOS or Linux. On macOS, builds go through `./build.sh` (Metal link workflow).
+- `zvm` on `PATH` (`zvm --version`; install: https://github.com/tristanisham/zvm)
+- macOS or Linux; on macOS prefer `./build.sh` for Metal-linked CLI builds
+- Network only when installing/updating master (`zvm install master`)
 
-## Run (agent path) — FIRST
+## Agent path (run first)
+
+From the repo root:
 
 ```bash
-# From the repo root. Selects master (installs it if absent), then runs all gates.
 .agents/skills/zig-newest-skills/zig-master-check.sh
 ```
 
-What it does, cheapest gate first: `zvm use master` → `zig build check-parity`
-(std-only host gate) → `./build.sh cli` → `./build.sh mcp` → runs the built
-`abi help` and `abi backends`. Prints a summary ending in either
-`RESULT: PASS — abi builds + runs on the newest Zig master.` (exit 0) or
-`RESULT: FAIL — master drift broke N gate(s).` (exit N).
+Gate order (cheapest first):
 
-Historical verification on master `0.17.0-dev.1275` (pin was `1252` at the time):
-**PASS, 0 failed gates.**
+1. `zvm use master` (install master if missing)
+2. `zig build check-parity` — std-only host tool; isolates toolchain from feature graph
+3. `./build.sh cli` → `./build.sh mcp`
+4. Run `zig-out/bin/abi help` and `abi backends`
 
-Flags:
+Success ends with:
 
-```bash
-.agents/skills/zig-newest-skills/zig-master-check.sh --update   # re-fetch latest master nightly first
-.agents/skills/zig-newest-skills/zig-master-check.sh --smoke    # also run the full run-abi smoke (CLI + WDBX + MCP stdio)
-.agents/skills/zig-newest-skills/zig-master-check.sh --revert   # switch back to the .zigversion pin, then exit
+```text
+RESULT: PASS — abi builds + runs on the newest Zig master.
 ```
 
-`--smoke` chains the sibling `run-abi/smoke.sh` harness (13 checks: CLI
-subcommands, a WDBX round-trip, and JSON-RPC over the MCP stdio transport).
-Historical verification: `pass=13 fail=0 / SMOKE OK`.
+(exit 0). Failure: `RESULT: FAIL — master drift broke N gate(s).` (exit N).
 
-## Run (human path)
+### Flags
 
-Same as above — just run the script. There is no separate window or REPL;
-it's a build+exercise gate you read the tail of.
+```bash
+.agents/skills/zig-newest-skills/zig-master-check.sh --update
+.agents/skills/zig-newest-skills/zig-master-check.sh --smoke
+.agents/skills/zig-newest-skills/zig-master-check.sh --revert
+```
 
-## Gotchas (battle scars from this session)
+| Flag | Behavior |
+|------|----------|
+| `--update` | `zvm install master` before select |
+| `--smoke` | After binary gates, run `run-abi/smoke.sh` (CLI + WDBX + MCP stdio) |
+| `--revert` | Select `.zigversion` pin and exit (non-interactive install attempt if missing) |
 
-- **Old nightlies are NOT re-downloadable.** zvm only serves the *current*
-  master from ziglang.org. e.g. `zvm install 0.17.0-dev.1252+e4b325c19` (a
-  since-superseded pin) fails with
-  `unsupported Zig version`. So once master replaces the pin's local
-  `~/.zvm/<version>` dir, the exact pin is **gone for good** unless you kept
-  the tarball. Installing master can therefore permanently retire the
-  `.zigversion` pin — `--revert` will then fail with a clear explanation, not
-  silently. (If you need reproducibility, bump `.zigversion` to the master you
-  validated and treat that as the new pin.)
-- **`zvm list` output is ANSI-colored** (`\x1b[32mmaster`). Greping it with a
-  word boundary (`grep '\bmaster\b'`) silently fails — the `m` in `[32m`
-  abuts `master`. The driver checks `~/.zvm/<ver>/zig` on disk instead; do the
-  same in any wrapper, or you'll re-download ~54MB every run.
-- **`build.sh` does not enforce the pin.** It just runs whatever `zig` is on
-  `PATH` (echoes `Using Zig: …`). So "select master via zvm" is the *only*
-  thing that makes the build use master — there's no in-repo guard to fight.
-- **`check-parity` builds even when the feature graph wouldn't.** It's a
-  std-only, host-target line scanner. Running it first cleanly separates
-  "toolchain works" from "feature graph compiles under this std."
-- **`timeout(1)` is absent on macOS.** Don't wrap gates in it; the driver
-  relies on the caller's timeout instead.
-- **As of this session, abi has zero forward drift 1252→1275** — no source
-  changes were needed to build on master. If a future master breaks a gate,
-  the failing `./build.sh cli|mcp` output names the exact `std` API that moved.
+## After a PASS
 
-## Troubleshooting
+1. Record master version (`zig version`) vs pin in the report.
+2. **Default:** leave master selected for the rest of this session; run
+   `--revert` before any pin-gated day-to-day work (or when the user asks).
+3. If the user wants a pin bump: update `.zigversion`, CI `ZIG_VERSION`, and
+   instruction-file pin strings together; run full `./build.sh check` on the pin.
+
+## After a FAIL
+
+1. Capture the first failing gate and the `std` symbol / compile error.
+2. Prefer a minimal `src/` fix over disabling features.
+3. Re-run the driver; if unblockable, `--revert` and file a focused fix task.
+4. Consult **`references/src-touchpoints.md`** for high-churn Zig 0.17 surfaces.
+
+## Troubleshooting (quick)
 
 | Symptom | Fix |
-|---|---|
-| `zvm not found on PATH` | Install zvm; ensure `~/.zvm/bin` is on `PATH`. |
-| `--revert` → `unsupported Zig version` / `cannot revert to <pin>` | The pin nightly is no longer fetchable. Stay on master (`zvm use master`) or bump `.zigversion`. See Gotchas. |
-| Driver re-downloads master every run | You're on an old copy that greps `zvm list`; use the on-disk `have_ver` check (already in this driver). |
-| `./build.sh cli` fails only under master | Real forward drift — read the error for the moved `std` symbol; fix source or pin back. |
+|---------|-----|
+| `zvm not found` | Install zvm; put `~/.zvm/bin` on `PATH` |
+| `--revert` cannot fetch pin | Old nightlies not re-served; stay on master or bump pin |
+| Re-download master every run | Do not grep ANSI `zvm list`; use on-disk `~/.zvm/<ver>/zig` |
+| Fail only under master | Real drift — fix `src/` or pin back |
+| `--smoke` skipped | Ensure `.agents/skills/run-abi/smoke.sh` is executable |
+
+## Additional resources
+
+- **`references/gotchas.md`** — zvm/nightly battle scars (ANSI list, non-re-downloadable pins, no macOS `timeout`)
+- **`references/src-touchpoints.md`** — abi `src/` areas sensitive to Zig 0.17 / `std` churn
+- **Driver:** `zig-master-check.sh` — primary executable; prefer over ad-hoc `zvm` + build sequences
+
+## Claims boundary
+
+- Does **not** claim production multi-host, native ANE, or audited FHE.
+- Master PASS is **forward-compat evidence**, not a pin replacement, until
+  `.zigversion` + CI are updated deliberately.
+- Full `./build.sh check` on master is optional and slower; the driver covers
+  the minimum compile+run surface used for drift detection.

--- a/.claude/skills/zig-newest-skills/references/gotchas.md
+++ b/.claude/skills/zig-newest-skills/references/gotchas.md
@@ -1,0 +1,64 @@
+# zig-newest-skills — gotchas
+
+Battle scars for the master-toolchain driver. Keep SKILL.md lean; load this when
+debugging zvm, pin revert, or false re-downloads.
+
+## Old nightlies are not re-downloadable
+
+`zvm` serves the **current** master from ziglang.org. Once a pin like
+`0.17.0-dev.1252+…` is superseded, `zvm install <old-pin>` often fails with
+`unsupported Zig version`. Installing master can reclaim or replace local
+`~/.zvm/<pin>` state.
+
+**Implications:**
+
+- `--revert` may fail after a master install if the pin directory is gone.
+- The driver prints a clear FATAL with options: stay on master, bump
+  `.zigversion`, or restore a private tarball into `~/.zvm/<pin>`.
+- For reproducibility after a successful master validation, bump the pin
+  deliberately (`.zigversion` + CI + instruction files) rather than relying
+  on re-fetch of the old hash.
+
+## Never grep `zvm list` for presence
+
+`zvm list` is ANSI-colored (e.g. `\x1b[32mmaster`). A word-boundary grep like
+`grep '\bmaster\b'` can fail because the `m` in `[32m` abuts `master`.
+
+**Correct check (as in the driver):**
+
+```bash
+[ -x "${ZVM_PATH:-$HOME/.zvm}/master/zig" ]
+```
+
+Grepping list output causes needless ~50MB+ re-downloads every run.
+
+## `build.sh` does not enforce the pin
+
+`./build.sh` / `tools/build.sh` invoke whatever `zig` is on `PATH` and print
+`Using Zig: …`. Selecting master **must** be done via `zvm use master` (or
+equivalent) before the build. There is no in-repo toolchain switcher.
+
+## `check-parity` is not a feature-graph compile
+
+`zig build check-parity` is a std-only, host-target line scanner for mod/stub
+public names. It can succeed when the full feature graph would fail. The driver
+runs it **first** to separate “toolchain runs our tools” from “CLI/MCP feature
+graph compiles under this std.”
+
+## No macOS `timeout(1)`
+
+Do not wrap gates in GNU `timeout`; it is absent on stock macOS. Rely on the
+caller’s tool timeout (agent shell) instead.
+
+## Smoke path ports
+
+`--smoke` should prefer `.agents/skills/run-abi/smoke.sh`, falling back to
+`.claude/skills/run-abi/smoke.sh` when the mirror layout is used. Both must stay
+executable and hermetic (`ABI_WDBX_PERSIST=0` etc. inside the harness).
+
+## Historical note (do not treat as current)
+
+Past sessions validated intermediate masters (e.g. pin `1252` → master `1275`)
+with zero source changes. That is **historical**, not a promise for current
+master vs the live `.zigversion` pin. Always re-run the driver after pin or
+`std` churn.

--- a/.claude/skills/zig-newest-skills/references/src-touchpoints.md
+++ b/.claude/skills/zig-newest-skills/references/src-touchpoints.md
@@ -1,0 +1,68 @@
+# abi `src/` touchpoints for Zig master drift
+
+When master breaks the driver gates, inspect these surfaces first. Trust
+executable sources over this list if they diverge.
+
+## Toolchain pin surfaces (not `src/`, but co-move)
+
+| Path | Role |
+|------|------|
+| `.zigversion` | Live pin string |
+| `build.zig.zon` `minimum_zig_version` | Lower bound (may lag pin) |
+| `.github/workflows/ci.yml` `ZIG_VERSION` | CI pin; must match `.zigversion` when either moves |
+| `build.zig` / `tools/build.sh` / `./build.sh` | Invoke PATH `zig`; no auto-switch |
+
+## High-churn Zig 0.17 patterns (abi conventions)
+
+From `AGENTS.md` / live code:
+
+| Pattern | Where it bites |
+|---------|----------------|
+| `pub fn main(init: std.process.Init) !void` | `src/main.zig`, MCP entry |
+| `ArrayListUnmanaged(T).empty` | Many modules; old `.init(allocator)` fails |
+| `std.mem.trimEnd` (not `trimRight`) | String helpers |
+| `splitScalar` / `splitAny` / `splitSequence` | Parsers |
+| Relative `.zig` imports inside `src/` | Feature modules; only MCP handler group may `@import("abi")` |
+| `foundation.time.unixMs()` | Timestamps |
+| Explicit allocator; no global hidden allocator | New APIs |
+
+## Network / IO (WDBX + MCP)
+
+Zig 0.16 fails on WDBX/MCP listeners that use `std.Io.net.Stream`. Master
+churn often hits:
+
+| Area | Paths |
+|------|--------|
+| WDBX durable / REST | `src/features/wdbx/durable_store.zig`, `rest.zig`, cluster RPC |
+| MCP transports | `src/mcp/server.zig`, HTTP/SSE listeners |
+| Connectors HTTP | `src/connectors/http.zig` (SSE streaming) |
+
+Linux ambient store note (cloud VM): `setPermissions`/`fchmod` BADF on some
+nightlies — use `ABI_WDBX_PERSIST=0` for ambient paths; not a master-only issue
+but confuses smoke on Linux.
+
+## Build-feature graph
+
+Feature flags select `mod.zig` vs `stub.zig` under `src/features/`. Master
+breaks may appear only with default-on features:
+
+- `feat-foundationmodels` — arm64 macOS + `xcrun swiftc` (skip with
+  `-Dfeat-foundationmodels=false` when diagnosing pure Zig drift)
+- GPU Metal link path on macOS via `./build.sh`
+
+## Driver gate → likely blame
+
+| Failing gate | Look first |
+|--------------|------------|
+| `check-parity` | Toolchain / build.zig options / parity tool itself |
+| `./build.sh cli` | `src/main.zig`, `src/cli/**`, `src/features/**` graph |
+| `./build.sh mcp` | `src/mcp/**`, shared AI/WDBX imports |
+| `abi help` / `abi backends` | Runtime panic, missing dylib (FM shim), PATH |
+| `run-abi smoke` | Env, WDBX persist, MCP stdio protocol |
+
+## Fix discipline
+
+1. Minimal source fix; no drive-by refactors.
+2. Preserve mod/stub parity (`zig build check-parity`) if public AI/feature APIs change.
+3. Re-run `zig-master-check.sh` then, if promoting a pin, full `./build.sh check` on the new pin.
+4. Never force-push `main`; pin bumps use a normal PR.

--- a/.claude/skills/zig-newest-skills/zig-master-check.sh
+++ b/.claude/skills/zig-newest-skills/zig-master-check.sh
@@ -8,10 +8,10 @@
 # version, it proves (or disproves) that abi keeps working on the latest Zig.
 #
 # Usage:
-#   .claude/skills/zig-newest-skills/zig-master-check.sh            # use already-installed master
-#   .claude/skills/zig-newest-skills/zig-master-check.sh --update   # re-fetch latest master first
-#   .claude/skills/zig-newest-skills/zig-master-check.sh --smoke    # also run the full run-abi smoke
-#   .claude/skills/zig-newest-skills/zig-master-check.sh --revert   # switch back to the .zigversion pin and exit
+#   .agents/skills/zig-newest-skills/zig-master-check.sh            # use already-installed master
+#   .agents/skills/zig-newest-skills/zig-master-check.sh --update   # re-fetch latest master first
+#   .agents/skills/zig-newest-skills/zig-master-check.sh --smoke    # also run the full run-abi smoke
+#   .agents/skills/zig-newest-skills/zig-master-check.sh --revert   # switch back to the .zigversion pin and exit
 #
 # Resolves the repo root from its own location; safe to run from any cwd.
 set -uo pipefail
@@ -120,11 +120,21 @@ fi
 
 # --- optional deep smoke (reuses the run-abi harness) --------------------
 if [ "$SMOKE" -eq 1 ]; then
-    SMOKE_SH="$REPO_ROOT/.claude/skills/run-abi/smoke.sh"
-    if [ -x "$SMOKE_SH" ]; then
+    # Prefer canonical .agents path; fall back to Claude mirror layout.
+    SMOKE_SH=""
+    for candidate in \
+        "$REPO_ROOT/.agents/skills/run-abi/smoke.sh" \
+        "$REPO_ROOT/.claude/skills/run-abi/smoke.sh"
+    do
+        if [ -x "$candidate" ]; then
+            SMOKE_SH="$candidate"
+            break
+        fi
+    done
+    if [ -n "$SMOKE_SH" ]; then
         gate "run-abi smoke (full CLI+MCP)" -- "$SMOKE_SH"
     else
-        echo "note: --smoke requested but $SMOKE_SH not found/executable; skipping."
+        echo "note: --smoke requested but run-abi/smoke.sh not found/executable under .agents or .claude; skipping."
     fi
 fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -332,6 +332,10 @@ test_imports3
 #  *.md rule re-ignores skill docs — this negation must come after it.)
 !.claude/skills/**/SKILL.md
 !.agents/skills/**/SKILL.md
+!.agents/skills/**/references/**
+!.agents/skills/**/references/**/*.md
+!.claude/skills/**/references/**
+!.claude/skills/**/references/**/*.md
 !.agents/skills/abi-doc-claims-sync/references/claim-boundaries.md
 
 # Claude project agents: same story — .claude/agents/** is un-ignored above, but


### PR DESCRIPTION
## Summary

Apply skill-development hygiene to `zig-newest-skills` (canonical `.agents` + `.claude` mirror):

- Rewrite `SKILL.md`: third-person trigger description, imperative body, lean progressive disclosure
- Add `references/gotchas.md` and `references/src-touchpoints.md` (src/ Zig 0.17 drift map)
- Driver: dual-path `run-abi` smoke resolution (`.agents` then `.claude`)
- `.gitignore`: allow skill `references/**/*.md` so packages can ship refs under the blanket `*.md` rule
- Drop unrelated junk that was sitting under `references/`

## Test plan

- [x] `bash -n` on `zig-master-check.sh`
- [x] `.agents` and `.claude` trees identical (`diff -rq`)
- [x] Skill-reviewer: Pass (single-line description applied)
- [ ] Optional: full `zig-master-check.sh` when zvm/network available (not required for docs-only skill package)

## Notes

Does not bump `.zigversion` or claim a new master PASS. Forward-compat remains an operator run of the driver.