### PR TITLE
ci: self-hosted macOS arm64 runner with fork isolation

### DIFF
--- a/.github/self-hosted-runner.md
+++ b/.github/self-hosted-runner.md
@@ -1,0 +1,108 @@
+# Self-hosted GitHub Actions runner (macOS arm64)
+
+Ops and security notes for the repository self-hosted runner used by `.github/workflows/ci.yml`.
+
+## Current registration
+
+| Field | Value |
+|-------|--------|
+| Host labels | `self-hosted`, `macOS`, `ARM64`, `abi` |
+| Typical install dir | `~/actions-runner` |
+| LaunchAgent | `actions.runner.donaldfilimon-abi.<hostname>` |
+| Repo UI | [Settings → Actions → Runners](https://github.com/donaldfilimon/abi/settings/actions/runners) |
+
+CI jobs that need this machine use:
+
+```yaml
+runs-on: [self-hosted, macOS, ARM64, abi]
+```
+
+## Security model (public repository)
+
+Self-hosted runners on **public** repos are dangerous: a workflow that reaches `runs-on: self-hosted` can execute arbitrary PR code on the host.
+
+Hardening applied here:
+
+1. **Job-level trust gate** — self-hosted jobs run only when:
+   - `github.repository == 'donaldfilimon/abi'`, and
+   - event is `push` / `workflow_dispatch`, or a `pull_request` whose
+     `head.repo.full_name == github.repository` (same-repo PR only).
+2. **Fork PRs** use GitHub-hosted `macos-latest` jobs only (`check-hosted`, `cross-smoke-hosted`).
+3. **Least-privilege token** — workflow `permissions: contents: read`.
+4. **Pinned Zig from host PATH** — self-hosted jobs refuse to run if `zig version` ≠ `.zigversion` pin (no silent toolchain drift).
+
+Still recommended on the host and in GitHub settings:
+
+- Prefer a **dedicated machine or user account** for the runner (not your daily desktop) when possible.
+- In repo **Settings → Actions → General**:
+  - Require approval for first-time contributors (and preferably all outside collaborators).
+  - Restrict Actions permissions; do not grant write where unnecessary.
+- Do **not** store production secrets on the runner host beyond what CI needs.
+- Treat `_work` checkouts as untrusted after any job; do not reuse artifacts casually on the desktop.
+- Never register the same runner against untrusted org/repos.
+
+Making the repository **private** remains the strongest fix; this project stays public, so the gates above are mandatory.
+
+## Toolchain on the runner host
+
+CI expects the pin in `.zigversion` / workflow `ZIG_VERSION` on `PATH` (e.g. via `zvm` / `zigup`).
+
+```bash
+zig version   # must match .zigversion
+xcode-select -p   # needed for Apple-framework / Foundation Models paths when those features are on
+```
+
+After changing Zig or PATH, restart the service:
+
+```bash
+cd ~/actions-runner
+./svc.sh stop && ./svc.sh start
+./svc.sh status
+```
+
+## Install / reconfigure
+
+Use the helper (requires `gh` auth with `repo` scope):
+
+```bash
+./tools/github-runner/setup-macos-arm64.sh
+```
+
+Or follow GitHub’s UI at  
+https://github.com/donaldfilimon/abi/settings/actions/runners/new?arch=arm64  
+then install the service with `./svc.sh install && ./svc.sh start`.
+
+## Day-2 operations
+
+```bash
+cd ~/actions-runner
+./svc.sh status
+./svc.sh stop
+./svc.sh start
+./svc.sh uninstall   # remove LaunchAgent only; does not unregister
+
+# Unregister from GitHub (needs a removal token from the UI or API)
+./config.sh remove --token <REMOVE_TOKEN>
+```
+
+Logs:
+
+- `~/Library/Logs/actions.runner.donaldfilimon-abi.*/`
+- `~/actions-runner/_diag/`
+
+## Local host hardening checklist
+
+Run:
+
+```bash
+./tools/github-runner/harden-macos.sh
+```
+
+That script is read-only by default; it prints a checklist and optional steps (LaunchAgent confirm, PATH, disk free space, no world-writable runner dir).
+
+## Workflow author rules
+
+- Never add `runs-on: self-hosted` (or the `abi` label set) without the same-repo `if:` gate used in `ci.yml`.
+- Prefer `permissions:` minimal scopes on every workflow.
+- Do not use `pull_request_target` with checkout of the PR head on self-hosted runners.
+- Keep fork coverage on `macos-latest` (or another GitHub-hosted label).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,27 +1,97 @@
 name: CI
 
 # Primary gate + cross-compilation smoke for the ABI framework.
-# Runs on macOS (the project's primary platform — Apple frameworks available for
-# the native build) and cross-compiles the CLI for the supported non-native
-# targets. Keep the pinned Zig version below in sync with .zigversion and
+# Trusted same-repo events run on the macOS arm64 self-hosted runner.
+# Fork PRs (and any untrusted head) stay on GitHub-hosted runners only —
+# never schedule untrusted code on the self-hosted machine.
+# Keep the pinned Zig version below in sync with .zigversion and
 # build.zig.zon (the check_zigversion.sh hook flags edits to that pin).
+#
+# Runner ops / security: .github/self-hosted-runner.md
 
 on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 # Cancel superseded runs on the same ref.
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+# Least privilege for GITHUB_TOKEN (no write scopes by default).
+permissions:
+  contents: read
 
 env:
   ZIG_VERSION: 0.17.0-dev.1398+cb5635714
 
+# Same-repo only: push, workflow_dispatch, or PR whose head is this repository.
+# Fork PRs fail this predicate and must use the hosted jobs below.
 jobs:
   check:
     name: check (build + tests + lint + parity)
+    if: >
+      github.repository == 'donaldfilimon/abi' &&
+      (github.event_name == 'push' ||
+       github.event_name == 'workflow_dispatch' ||
+       (github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository))
+    runs-on: [self-hosted, macOS, ARM64, abi]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify pinned Zig on runner PATH
+        run: |
+          set -euo pipefail
+          expected="${ZIG_VERSION}"
+          if ! command -v zig >/dev/null 2>&1; then
+            echo "::error::zig not on PATH for self-hosted runner. Install pin ${expected} (zvm/zigup) and restart the runner service."
+            exit 1
+          fi
+          actual="$(zig version)"
+          if [ "${actual}" != "${expected}" ]; then
+            echo "::error::PATH zig is ${actual}, expected pin ${expected}. Update the runner toolchain and restart the service."
+            exit 1
+          fi
+          echo "Using zig ${actual}"
+      - name: zig build check
+        run: zig build check
+
+  cross-smoke:
+    name: cross-compile smoke (linux/windows/macos)
+    if: >
+      github.repository == 'donaldfilimon/abi' &&
+      (github.event_name == 'push' ||
+       github.event_name == 'workflow_dispatch' ||
+       (github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository))
+    runs-on: [self-hosted, macOS, ARM64, abi]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify pinned Zig on runner PATH
+        run: |
+          set -euo pipefail
+          expected="${ZIG_VERSION}"
+          if ! command -v zig >/dev/null 2>&1; then
+            echo "::error::zig not on PATH for self-hosted runner. Install pin ${expected} (zvm/zigup) and restart the runner service."
+            exit 1
+          fi
+          actual="$(zig version)"
+          if [ "${actual}" != "${expected}" ]; then
+            echo "::error::PATH zig is ${actual}, expected pin ${expected}. Update the runner toolchain and restart the service."
+            exit 1
+          fi
+          echo "Using zig ${actual}"
+      - name: zig build cross-smoke
+        run: zig build cross-smoke
+
+  # Hosted fallback: fork PRs only (untrusted code never touches self-hosted).
+  check-hosted:
+    name: check (GitHub-hosted, fork PRs)
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,8 +101,11 @@ jobs:
       - name: zig build check
         run: zig build check
 
-  cross-smoke:
-    name: cross-compile smoke (linux/windows/macos)
+  cross-smoke-hosted:
+    name: cross-compile smoke (GitHub-hosted, fork PRs)
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -308,6 +308,9 @@ test_imports3
 !/CODE_OF_CONDUCT.md
 !/walkthrough.md
 
+# GitHub Actions runner ops (self-hosted security + day-2)
+!/.github/self-hosted-runner.md
+
 # Documentation tree
 !/docs/README.md
 !/docs/index.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ Inside `src/`: relative `.zig` imports only. **Only** the MCP handler group (`sr
 
 - Conventional Commits (`feat:`, `fix:`, `refactor:`, `docs:`, `chore(build):`, …).
 - Local `main` and `origin/main` share history (reconciled at `848ec2c8`; the old no-common-ancestor state is resolved). Never force-push `main`.
-- CI (`.github/workflows/ci.yml`) runs `zig build check` + `cross-smoke` on macOS; keep its Zig version in sync with `.zigversion` when either moves.
+- CI (`.github/workflows/ci.yml`) runs `zig build check` + `cross-smoke` on macOS. Same-repo push/PR/workflow_dispatch use the labeled self-hosted runner (`self-hosted,macOS,ARM64,abi`); fork PRs stay on GitHub-hosted `macos-latest` only. Never add self-hosted jobs without the same-repo `if:` gate — see `.github/self-hosted-runner.md`. Keep workflow `ZIG_VERSION` in sync with `.zigversion` when either moves.
 
 ## Zig 0.17 Patterns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ Inside `src/`: relative `.zig` imports only. **Only** the MCP handler group (`sr
 
 - Conventional Commits (`feat:`, `fix:`, `refactor:`, `docs:`, `chore(build):`, …).
 - Local `main` and `origin/main` share history (reconciled at `848ec2c8`; the old no-common-ancestor state is resolved). Never force-push `main`.
-- CI (`.github/workflows/ci.yml`) runs `zig build check` + `cross-smoke` on macOS; keep its Zig version in sync with `.zigversion` when either moves.
+- CI (`.github/workflows/ci.yml`) runs `zig build check` + `cross-smoke` on macOS. Same-repo push/PR/workflow_dispatch use the labeled self-hosted runner (`self-hosted,macOS,ARM64,abi`); fork PRs stay on GitHub-hosted `macos-latest` only. Never add self-hosted jobs without the same-repo `if:` gate — see `.github/self-hosted-runner.md`. Keep workflow `ZIG_VERSION` in sync with `.zigversion` when either moves.
 
 ## Zig 0.17 Patterns
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -94,7 +94,7 @@ Inside `src/`: relative `.zig` imports only. **Only** the MCP handler group (`sr
 
 - Conventional Commits (`feat:`, `fix:`, `refactor:`, `docs:`, `chore(build):`, …).
 - Local `main` and `origin/main` share history (reconciled at `848ec2c8`; the old no-common-ancestor state is resolved). Never force-push `main`.
-- CI (`.github/workflows/ci.yml`) runs `zig build check` + `cross-smoke` on macOS; keep its Zig version in sync with `.zigversion` when either moves.
+- CI (`.github/workflows/ci.yml`) runs `zig build check` + `cross-smoke` on macOS. Same-repo push/PR/workflow_dispatch use the labeled self-hosted runner (`self-hosted,macOS,ARM64,abi`); fork PRs stay on GitHub-hosted `macos-latest` only. Never add self-hosted jobs without the same-repo `if:` gate — see `.github/self-hosted-runner.md`. Keep workflow `ZIG_VERSION` in sync with `.zigversion` when either moves.
 
 ## Zig 0.17 Patterns
 

--- a/src/cli/handlers/auth.zig
+++ b/src/cli/handlers/auth.zig
@@ -141,25 +141,45 @@ fn authSigninHelp() u8 {
     return 0;
 }
 
-/// Disable terminal echo while reading a secret on POSIX TTYs (TM-010).
-/// Returns the prior termios when echo was successfully disabled (caller must
-/// restore). Non-TTY / non-POSIX / unavailable termios returns null and the
-/// secret is still read with echo unchanged (disclosed Windows/non-TTY gap).
-fn disableEchoIfTty(fd: std.posix.fd_t) ?std.posix.termios {
-    if (builtin.target.os.tag == .windows) return null;
-    if (@hasDecl(std.posix.system, "isatty") and std.posix.system.isatty(fd) == 0) return null;
-    const original = std.posix.tcgetattr(fd) catch return null;
-    var raw = original;
-    raw.lflag.ECHO = false;
-    std.posix.tcsetattr(fd, .FLUSH, raw) catch return null;
-    return original;
-}
+/// Platform echo helpers: Windows never references termios/libc (required for
+/// clean `x86_64-windows-gnu` cross-smoke). POSIX path is TM-010 no-echo entry.
+const echo_platform = if (builtin.os.tag == .windows) echo_windows else echo_posix;
 
-fn restoreEcho(fd: std.posix.fd_t, original: std.posix.termios) void {
-    std.posix.tcsetattr(fd, .FLUSH, original) catch |err| {
-        std.log.warn("auth: failed to restore terminal echo: {s}", .{@errorName(err)});
-    };
-}
+const echo_windows = struct {
+    const Saved = void;
+
+    fn disableEchoIfTty(fd: std.posix.fd_t) ?Saved {
+        _ = fd;
+        return null;
+    }
+
+    fn restoreEcho(fd: std.posix.fd_t, original: Saved) void {
+        _ = fd;
+        _ = original;
+    }
+};
+
+const echo_posix = struct {
+    const Saved = std.posix.termios;
+
+    fn disableEchoIfTty(fd: std.posix.fd_t) ?Saved {
+        if (@hasDecl(std.posix.system, "isatty") and std.posix.system.isatty(fd) == 0) return null;
+        const original = std.posix.tcgetattr(fd) catch return null;
+        var raw = original;
+        raw.lflag.ECHO = false;
+        std.posix.tcsetattr(fd, .FLUSH, raw) catch return null;
+        return original;
+    }
+
+    fn restoreEcho(fd: std.posix.fd_t, original: Saved) void {
+        std.posix.tcsetattr(fd, .FLUSH, original) catch |err| {
+            std.log.warn("auth: failed to restore terminal echo: {s}", .{@errorName(err)});
+        };
+    }
+};
+
+const disableEchoIfTty = echo_platform.disableEchoIfTty;
+const restoreEcho = echo_platform.restoreEcho;
 
 /// Pure helper used by tests: reports whether secret entry should attempt
 /// no-echo based on OS. Windows remains a disclosed gap (no termios path).

--- a/tests/contracts/public_docs.zig
+++ b/tests/contracts/public_docs.zig
@@ -100,3 +100,26 @@ test "master spec keeps GPU acceleration claim boundary explicit" {
     try expectContains(spec, "native Metal execution is claimed only when the runtime backend reports initialized native kernels");
     try expectNotContains(spec, "real GPU acceleration for HNSW cosine *has* been implemented");
 }
+
+test "CI workflow isolates self-hosted jobs from fork PRs" {
+    // Drives the shipped workflow file: same-repo jobs must request the labeled
+    // self-hosted runner; fork-only jobs must stay on GitHub-hosted macos-latest
+    // with mutually exclusive trust predicates (public-repo hardening).
+    const ci = try std.Io.Dir.cwd().readFileAlloc(
+        std.Options.debug_io,
+        ".github/workflows/ci.yml",
+        std.testing.allocator,
+        .limited(256 * 1024),
+    );
+    defer std.testing.allocator.free(ci);
+
+    try expectContains(ci, "permissions:");
+    try expectContains(ci, "contents: read");
+    try expectContains(ci, "runs-on: [self-hosted, macOS, ARM64, abi]");
+    try expectContains(ci, "runs-on: macos-latest");
+    try expectContains(ci, "github.event.pull_request.head.repo.full_name == github.repository");
+    try expectContains(ci, "github.event.pull_request.head.repo.full_name != github.repository");
+    try expectContains(ci, "check-hosted:");
+    try expectContains(ci, "cross-smoke-hosted:");
+    try expectContains(ci, "self-hosted-runner.md");
+}

--- a/tools/github-runner/harden-macos.sh
+++ b/tools/github-runner/harden-macos.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Read-only hardening checklist for the abi self-hosted runner host.
+# Exit 0 if no critical failures; non-zero if something blocks safe CI use.
+set -euo pipefail
+
+INSTALL_DIR="${GITHUB_RUNNER_DIR:-${HOME}/actions-runner}"
+EXPECTED_ZIG="${EXPECTED_ZIG:-}"
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+if [[ -z "${EXPECTED_ZIG}" && -f "${REPO_ROOT}/.zigversion" ]]; then
+  EXPECTED_ZIG="$(tr -d '[:space:]' <"${REPO_ROOT}/.zigversion")"
+fi
+
+failures=0
+warns=0
+
+ok() { printf '  [ok]  %s\n' "$*"; }
+warn() { printf '  [warn] %s\n' "$*"; warns=$((warns + 1)); }
+fail() { printf '  [FAIL] %s\n' "$*"; failures=$((failures + 1)); }
+
+echo "==> Host"
+echo "    $(uname -s) $(uname -m) — $(sw_vers -productName) $(sw_vers -productVersion)"
+
+if [[ "$(uname -m)" != "arm64" ]]; then
+  fail "host is not arm64 (CI labels expect ARM64)"
+else
+  ok "architecture arm64"
+fi
+
+echo "==> Zig toolchain"
+if ! command -v zig >/dev/null 2>&1; then
+  fail "zig not on PATH"
+else
+  actual="$(zig version)"
+  ok "zig on PATH: ${actual}"
+  if [[ -n "${EXPECTED_ZIG}" && "${actual}" != "${EXPECTED_ZIG}" ]]; then
+    fail "zig version ${actual} != pin ${EXPECTED_ZIG}"
+  elif [[ -n "${EXPECTED_ZIG}" ]]; then
+    ok "matches pin ${EXPECTED_ZIG}"
+  fi
+fi
+
+echo "==> Runner install (${INSTALL_DIR})"
+if [[ ! -d "${INSTALL_DIR}" ]]; then
+  fail "install dir missing — run tools/github-runner/setup-macos-arm64.sh"
+else
+  ok "install dir exists"
+  if [[ -f "${INSTALL_DIR}/.runner" ]]; then
+    ok "runner configured (.runner present)"
+  else
+    fail "runner not configured (no .runner)"
+  fi
+  # World-writable install dir is unsafe
+  if [[ -n "$(find "${INSTALL_DIR}" -maxdepth 0 -perm -0002 2>/dev/null)" ]]; then
+    fail "install dir is world-writable"
+  else
+    ok "install dir not world-writable"
+  fi
+fi
+
+echo "==> LaunchAgent / service"
+if [[ -x "${INSTALL_DIR}/svc.sh" ]]; then
+  if (cd "${INSTALL_DIR}" && ./svc.sh status) >/tmp/abi-runner-svc.status 2>&1; then
+    if grep -q 'Started:' /tmp/abi-runner-svc.status 2>/dev/null; then
+      ok "svc.sh reports Started"
+    else
+      warn "svc.sh status did not show Started — see /tmp/abi-runner-svc.status"
+      cat /tmp/abi-runner-svc.status || true
+    fi
+  else
+    warn "svc.sh status failed (runner may be run via ./run.sh instead)"
+  fi
+else
+  warn "svc.sh missing"
+fi
+
+echo "==> Disk"
+# Need headroom for Zig caches + cross-smoke
+avail_kb="$(df -k "${INSTALL_DIR:-${HOME}}" | awk 'NR==2 {print $4}')"
+avail_gb=$((avail_kb / 1024 / 1024))
+if (( avail_gb < 15 )); then
+  fail "only ~${avail_gb}GiB free; recommend ≥15GiB for check + cross-smoke"
+else
+  ok "~${avail_gb}GiB free"
+fi
+
+echo "==> GitHub visibility reminder"
+if command -v gh >/dev/null 2>&1; then
+  vis="$(gh api repos/donaldfilimon/abi --jq .visibility 2>/dev/null || echo unknown)"
+  if [[ "${vis}" == "public" ]]; then
+    warn "repo is public — keep job-level same-repo gates; prefer dedicated host"
+  elif [[ "${vis}" == "private" ]]; then
+    ok "repo is private"
+  else
+    warn "could not determine repo visibility (${vis})"
+  fi
+  online="$(gh api repos/donaldfilimon/abi/actions/runners --jq '[.runners[]|select(.status=="online")]|length' 2>/dev/null || echo 0)"
+  if [[ "${online}" == "0" ]]; then
+    fail "no online self-hosted runners registered for donaldfilimon/abi"
+  else
+    ok "${online} online runner(s) on GitHub"
+  fi
+else
+  warn "gh not installed; skip remote checks"
+fi
+
+echo "==> Manual GitHub settings (confirm in UI)"
+echo "    - Actions → General: require approval for outside collaborators"
+echo "    - Actions → General: restrict GITHUB_TOKEN permissions (read on workflow is set in ci.yml)"
+echo "    - Do not disable the same-repo if: gates in .github/workflows/ci.yml"
+echo "    - Prefer not storing extra secrets on this host"
+echo "    - Docs: .github/self-hosted-runner.md"
+
+echo
+if (( failures > 0 )); then
+  echo "RESULT: ${failures} failure(s), ${warns} warning(s)"
+  exit 1
+fi
+echo "RESULT: ok (${warns} warning(s))"
+exit 0

--- a/tools/github-runner/setup-macos-arm64.sh
+++ b/tools/github-runner/setup-macos-arm64.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Install or reconfigure the macOS arm64 GitHub Actions runner for donaldfilimon/abi.
+# Requires: curl, tar, gh (repo scope), macOS arm64.
+set -euo pipefail
+
+REPO="${GITHUB_RUNNER_REPO:-donaldfilimon/abi}"
+INSTALL_DIR="${GITHUB_RUNNER_DIR:-${HOME}/actions-runner}"
+RUNNER_NAME="${GITHUB_RUNNER_NAME:-$(hostname -s)-arm64}"
+LABELS="${GITHUB_RUNNER_LABELS:-self-hosted,macOS,ARM64,abi}"
+WORK_DIR="${GITHUB_RUNNER_WORK:-_work}"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "error: this script is for macOS only" >&2
+  exit 1
+fi
+if [[ "$(uname -m)" != "arm64" ]]; then
+  echo "error: expected arm64 host, got $(uname -m)" >&2
+  exit 1
+fi
+if ! command -v gh >/dev/null 2>&1; then
+  echo "error: gh CLI required (https://cli.github.com/)" >&2
+  exit 1
+fi
+
+echo "==> Resolving latest actions/runner osx-arm64 release"
+TAG="$(gh api repos/actions/runner/releases/latest --jq .tag_name)"
+VERSION="${TAG#v}"
+ASSET="actions-runner-osx-arm64-${VERSION}.tar.gz"
+URL="https://github.com/actions/runner/releases/download/${TAG}/${ASSET}"
+
+mkdir -p "${INSTALL_DIR}"
+cd "${INSTALL_DIR}"
+
+if [[ -f .runner ]]; then
+  echo "==> Existing runner config in ${INSTALL_DIR}"
+  if [[ "${GITHUB_RUNNER_REPLACE:-1}" == "1" ]]; then
+    echo "    Will reconfigure with --replace"
+  fi
+else
+  echo "==> Downloading ${URL}"
+  curl -fsSL -o "${ASSET}" "${URL}"
+  tar xzf "${ASSET}"
+  rm -f "${ASSET}"
+fi
+
+if [[ ! -x ./config.sh ]]; then
+  echo "error: config.sh missing in ${INSTALL_DIR}; remove the directory and re-run" >&2
+  exit 1
+fi
+
+echo "==> Requesting registration token for ${REPO}"
+TOKEN="$(gh api -X POST "repos/${REPO}/actions/runners/registration-token" --jq .token)"
+
+echo "==> Configuring runner name=${RUNNER_NAME} labels=${LABELS}"
+./config.sh \
+  --url "https://github.com/${REPO}" \
+  --token "${TOKEN}" \
+  --unattended \
+  --name "${RUNNER_NAME}" \
+  --labels "${LABELS}" \
+  --work "${WORK_DIR}" \
+  --replace
+
+if [[ "${GITHUB_RUNNER_INSTALL_SERVICE:-1}" == "1" ]]; then
+  if [[ -x ./svc.sh ]]; then
+    if [[ -f .service ]]; then
+      ./svc.sh stop || true
+    else
+      ./svc.sh install
+    fi
+    ./svc.sh start
+    ./svc.sh status || true
+  else
+    echo "warn: svc.sh not present; start manually with ./run.sh" >&2
+  fi
+else
+  echo "Skipping service install (GITHUB_RUNNER_INSTALL_SERVICE=0). Start with: cd ${INSTALL_DIR} && ./run.sh"
+fi
+
+echo "==> Done. Confirm online:"
+echo "    gh api repos/${REPO}/actions/runners --jq '.runners[] | {name,status,labels:[.labels[].name]}'"
+echo "Security notes: .github/self-hosted-runner.md"


### PR DESCRIPTION
## Summary
- Route same-repo CI (`check` + `cross-smoke`) to the labeled self-hosted runner (`self-hosted`, `macOS`, `ARM64`, `abi`).
- Keep **fork PRs** on GitHub-hosted `macos-latest` only, with job-level same-repo trust gates so untrusted code never schedules on the host.
- Set workflow `permissions: contents: read`; repo default workflow token permissions set to **read**.
- Add runner install/harden scripts under `tools/github-runner/` and ops/security docs in `.github/self-hosted-runner.md`.
- Sync CI notes in `AGENTS.md` / `CLAUDE.md` / `GEMINI.md`.

## Security
Public-repo self-hosted risk is mitigated by same-repo `if:` gates + hosted fallback for forks. Making the repo private remains stronger but is intentionally not done (public project).

## Test plan
- [x] Runner online (`MacBook-arm64`)
- [x] `tools/github-runner/harden-macos.sh` passes (public-repo warn only)
- [ ] PR CI jobs run on self-hosted and go green
- [ ] Confirm fork-PR path would use `*-hosted` jobs (logic-only; no fork required)