### PR TITLE
docs(mega): refresh abi-mega ops paths and board note

### DIFF
--- a/ABI-MEGA-PLUGIN.md
+++ b/ABI-MEGA-PLUGIN.md
@@ -66,18 +66,21 @@ Audit Markdown and old plan files:
   /Users/donaldfilimon/plugins/abi-mega/assets/abi-markdown-audit.md
 ```
 
-Validate the plugin and skills:
+Validate the four plugin skills (Codex `skill-creator` cache path; install
+PyYAML into `/tmp/codex-pyyaml` if needed):
 
 ```bash
-PYTHONPATH=/tmp/codex-pyyaml python3 /Users/donaldfilimon/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py /Users/donaldfilimon/plugins/abi-mega
-PYTHONPATH=/tmp/codex-pyyaml python3 /Users/donaldfilimon/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/donaldfilimon/plugins/abi-mega/skills/abi-goal-orchestrator
-PYTHONPATH=/tmp/codex-pyyaml python3 /Users/donaldfilimon/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/donaldfilimon/plugins/abi-mega/skills/abi-doc-claims-sync
-PYTHONPATH=/tmp/codex-pyyaml python3 /Users/donaldfilimon/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/donaldfilimon/plugins/abi-mega/skills/abi-surface-validator
-PYTHONPATH=/tmp/codex-pyyaml python3 /Users/donaldfilimon/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/donaldfilimon/plugins/abi-mega/skills/abi-markdown-auditor
+python3 -m pip install --target /tmp/codex-pyyaml pyyaml
+VALIDATE="$HOME/.codex/plugins/cache/claude-plugins-official/skill-creator/local/skills/skill-creator/scripts/quick_validate.py"
+for s in abi-goal-orchestrator abi-doc-claims-sync abi-surface-validator abi-markdown-auditor; do
+  PYTHONPATH=/tmp/codex-pyyaml python3 "$VALIDATE" \
+    "$HOME/plugins/abi-mega/skills/$s"
+done
 ```
 
-`PYTHONPATH=/tmp/codex-pyyaml` is only needed on hosts where the validator
-Python lacks `PyYAML`.
+There is no separate `validate_plugin.py` on this host; skill-level
+`quick_validate.py` is the supported check. Marketplace entry:
+`~/.agents/plugins/marketplace.json` → local `~/plugins/abi-mega`.
 
 ## Maintenance Rules
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -98,7 +98,8 @@ Do not schedule these as “complete”:
 
 Full detail: `git log` + `CHANGELOG.md`. Keep this list short.
 
-- **Ops docs + Metal path** — claims sync; host SIMD `sumF32`; REST threat review; cluster mTLS ops + Phase D cutover HITL plan.
+- **abi-mega refresh** — inventory + fast gates PASS; markdown audit fix-severity counts 0; four mega skills `quick_validate` PASS; `ABI-MEGA-PLUGIN.md` validator paths updated (Codex skill-creator cache).
+- **Ops docs + Metal path** — claims sync; host SIMD `sumF32`; REST threat review; cluster mTLS ops + Phase D cutover HITL plan (#681).
 - **#678** — Metal status probe before backends/gpu/dashboard; `donald-mode`; Abbey agents; `check_skills` `>-` fold.
 - **#676 Tracks A–G** — `incremental.zig`; Metal fused cosine; Win32 credential DACL; `ans.zig` demo; FHE param honesty; cluster TLS-fronting ops; `modernized/packages/*` Phase D scaffold.
 - **#674 Feature polish** — RankedNode/SearchResult borrowed vectors; stream footers; Ctrl-R redraw; constitution `/status`; POSIX `secureZero`.
@@ -117,4 +118,5 @@ Full detail: `git log` + `CHANGELOG.md`. Keep this list short.
 - `docs/spec/cluster-mtls-ops.mdx` — cluster RPC mTLS/membership ops (not sharding)
 - `docs/spec/phase-d-cutover-plan.mdx` — HITL cutover checklist
 - `modernized/README.md` — Phase D scaffold rules
+- `ABI-MEGA-PLUGIN.md` — local Codex `~/plugins/abi-mega` operator plugin (inventory/gates/audit)
 - `CHANGELOG.md` — release notes


### PR DESCRIPTION
## Summary
- Update `ABI-MEGA-PLUGIN.md` validator paths to working Codex skill-creator `quick_validate.py` + PyYAML target
- Note completed mega refresh (inventory/gates/audit) on `tasks/todo.md`
- Operator-local: marketplace path absolute; plugin version 0.1.1 (outside this repo)

## Verification
- [x] refresh-inventory.sh
- [x] run-fast-gates.sh → abi fast gates: ok
- [x] scan-markdown.sh → fix-severity counts 0
- [x] four skills quick_validate → Skill is valid!


Made with [Cursor](https://cursor.com)