### PR TITLE
refactor: extract shared HTTP helpers into foundation/http.zig

### DIFF
--- a/src/connectors/discord_ws_client.zig
+++ b/src/connectors/discord_ws_client.zig
@@ -176,7 +176,7 @@ pub const WebSocketClient = struct {
                 } else {
                     @memcpy(out, payload);
                 }
-                self.read_buf.replaceRange(allocator, 0, off + len, &[_]u8{}) catch {}; // intentional: non-critical UI/telemetry buffer, failure = degraded display only
+                self.read_buf.replaceRange(allocator, 0, off + len, &[_]u8{}) catch |err| std.log.warn("discord read_buf: {s}", .{@errorName(err)}); // intentional: non-critical UI/telemetry buffer, failure = degraded display only
                 switch (opcode) {
                     0x8 => { // close
                         allocator.free(out);
@@ -217,7 +217,7 @@ pub const WebSocketClient = struct {
     /// Send a close frame and tear down the socket.
     pub fn close(self: *WebSocketClient) void {
         if (self.closed) return;
-        self.writeFrame(0x8, &[_]u8{}) catch {}; // intentional: non-critical UI/telemetry buffer, failure = degraded display only
+        self.writeFrame(0x8, &[_]u8{}) catch |err| std.log.warn("discord close frame: {s}", .{@errorName(err)}); // intentional: non-critical UI/telemetry buffer, failure = degraded display only
         self.stream.close(self.io);
         self.closed = true;
     }

--- a/src/connectors/sse_stream.zig
+++ b/src/connectors/sse_stream.zig
@@ -289,7 +289,7 @@ test "parseSseStream accumulates Anthropic multi-token SSE" {
         fn call(ctx: *anyopaque, chunk: StreamChunk) ConnectorError!void {
             if (chunk.delta.len == 0) return;
             const list: *std.ArrayListUnmanaged(u8) = @ptrCast(@alignCast(ctx));
-            list.appendSlice(std.testing.allocator, chunk.delta) catch {};
+            try list.appendSlice(std.testing.allocator, chunk.delta);
         }
     }.call;
     const body =

--- a/src/features/ai/file_context.zig
+++ b/src/features/ai/file_context.zig
@@ -392,7 +392,7 @@ pub fn readGitDiffBudgeted(
         try output.appendSlice(allocator, buf[0..n]);
         if (output.items.len >= max_bytes) break;
     }
-    _ = child.wait(io) catch {};
+    _ = child.wait(io) catch |err| std.log.warn("file_context child wait: {s}", .{@errorName(err)});
 
     return try truncateToBudget(allocator, output.items, max_bytes);
 }

--- a/src/features/ai/training.zig
+++ b/src/features/ai/training.zig
@@ -48,7 +48,7 @@ fn trainNeuralNetOnDataset(allocator: std.mem.Allocator, config: types.TrainingC
     defer allocator.free(json);
 
     // Best-effort: ensure the confined artifact dir exists before writing.
-    std.Io.Dir.createDirPath(.cwd(), std.Options.debug_io, config.artifact_dir) catch {};
+    std.Io.Dir.createDirPath(.cwd(), std.Options.debug_io, config.artifact_dir) catch |err| std.log.warn("training mkdir: {s}", .{@errorName(err)});
 
     const weights_path = try std.fmt.allocPrint(allocator, "{s}/neural_net_{s}.json", .{ config.artifact_dir, config.profile });
     defer allocator.free(weights_path);
@@ -307,7 +307,7 @@ test "trainWithStore uses the store tracker for dataset inspection when config t
     const path = "zig-out/abi_train_store_tracker.jsonl";
     try std.Io.Dir.createDirPath(.cwd(), std.testing.io, "zig-out");
     try foundation_io.asyncWriteFile(path, "{\"input\":\"one\"}\n{\"input\":\"two\"}\n");
-    defer std.Io.Dir.cwd().deleteFile(std.testing.io, path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, path) catch |err| std.log.warn("training test cleanup: {s}", .{@errorName(err)});
 
     var store = wdbx.Store.init(allocator);
     defer store.deinit();
@@ -337,7 +337,7 @@ test "train accounts its transient internals on config.tracker (balanced)" {
     const path = "zig-out/abi_train_config_tracker.jsonl";
     try std.Io.Dir.createDirPath(.cwd(), std.testing.io, "zig-out");
     try foundation_io.asyncWriteFile(path, "{\"input\":\"one\"}\n{\"input\":\"two\"}\n");
-    defer std.Io.Dir.cwd().deleteFile(std.testing.io, path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, path) catch |err| std.log.warn("training test cleanup: {s}", .{@errorName(err)});
 
     var tracker = memory.MemoryTracker.init(allocator);
     defer tracker.deinit();
@@ -384,10 +384,10 @@ test "train trains a real net and persists weights when a dataset is available" 
     try std.Io.Dir.createDirPath(.cwd(), std.testing.io, "zig-out");
     const path = "zig-out/abi_train_real_net.jsonl";
     try foundation_io.asyncWriteFile(path, "{\"input\":\"hello world\"}\n{\"input\":\"foo bar baz\"}\n");
-    defer std.Io.Dir.cwd().deleteFile(std.testing.io, path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(std.testing.io, path) catch |err| std.log.warn("training test cleanup: {s}", .{@errorName(err)});
 
     // Artifact dir from an earlier test run may already exist; best-effort.
-    std.Io.Dir.createDirPath(.cwd(), std.testing.io, "zig-cache/agent-artifacts") catch {};
+    std.Io.Dir.createDirPath(.cwd(), std.testing.io, "zig-cache/agent-artifacts") catch |err| std.log.warn("training test setup: {s}", .{@errorName(err)});
 
     var result = try train(allocator, .{
         .profile = "abbey",

--- a/src/features/ai/training_support.zig
+++ b/src/features/ai/training_support.zig
@@ -312,16 +312,16 @@ test "confineTrainingPath rejects symlink escape when present" {
     defer allocator.free(root);
     // tempFilePath returns a file-shaped name; create it as a directory root.
     std.Io.Dir.createDirPath(.cwd(), std.Options.debug_io, root) catch {
-        std.Io.Dir.deleteFileAbsolute(std.Options.debug_io, root) catch {};
+        std.Io.Dir.deleteFileAbsolute(std.Options.debug_io, root) catch |err| std.log.warn("training_support setup: {s}", .{@errorName(err)});
         try std.Io.Dir.createDirPath(.cwd(), std.Options.debug_io, root);
     };
-    defer std.Io.Dir.deleteTree(.cwd(), std.Options.debug_io, root) catch {};
+    defer std.Io.Dir.deleteTree(.cwd(), std.Options.debug_io, root) catch |err| std.log.warn("training_support cleanup: {s}", .{@errorName(err)});
 
     const link_path = try std.fmt.allocPrint(allocator, "{s}/escape", .{root});
     defer allocator.free(link_path);
     // Point a symlink at a location outside the root.
     std.Io.Dir.symLinkAbsolute(std.Options.debug_io, "/etc", link_path, .{}) catch return;
-    defer std.Io.Dir.deleteFileAbsolute(std.Options.debug_io, link_path) catch {};
+    defer std.Io.Dir.deleteFileAbsolute(std.Options.debug_io, link_path) catch |err| std.log.warn("training_support test cleanup: {s}", .{@errorName(err)});
 
     try std.testing.expectError(error.PathOutsideRoot, confineTrainingPath(allocator, "escape", root));
     // Direct child name under root (non-symlink) is fine when missing or present.
@@ -358,7 +358,7 @@ test "datasetToPoints parses jsonl/text/csv records into points" {
 
     const jsonl = try temp_path.tempFilePath(allocator, "abi_ds_jsonl", "jsonl");
     defer allocator.free(jsonl);
-    defer std.Io.Dir.deleteFileAbsolute(std.testing.io, jsonl) catch {};
+    defer std.Io.Dir.deleteFileAbsolute(std.testing.io, jsonl) catch |err| std.log.warn("training_support test cleanup: {s}", .{@errorName(err)});
     try foundation_io.asyncWriteFile(jsonl, "{\"input\":\"hello world\"}\n{\"input\":\"foo bar\"}\n");
     const jp = (try datasetToPoints(allocator, .{ .path = jsonl, .format = .jsonl })).?;
     defer allocator.free(jp);
@@ -366,7 +366,7 @@ test "datasetToPoints parses jsonl/text/csv records into points" {
 
     const text = try temp_path.tempFilePath(allocator, "abi_ds_text", "txt");
     defer allocator.free(text);
-    defer std.Io.Dir.deleteFileAbsolute(std.testing.io, text) catch {};
+    defer std.Io.Dir.deleteFileAbsolute(std.testing.io, text) catch |err| std.log.warn("training_support test cleanup: {s}", .{@errorName(err)});
     try foundation_io.asyncWriteFile(text, "alpha\nbeta\ngamma\n");
     const tp = (try datasetToPoints(allocator, .{ .path = text, .format = .text })).?;
     defer allocator.free(tp);
@@ -374,7 +374,7 @@ test "datasetToPoints parses jsonl/text/csv records into points" {
 
     const csv = try temp_path.tempFilePath(allocator, "abi_ds_csv", "csv");
     defer allocator.free(csv);
-    defer std.Io.Dir.deleteFileAbsolute(std.testing.io, csv) catch {};
+    defer std.Io.Dir.deleteFileAbsolute(std.testing.io, csv) catch |err| std.log.warn("training_support test cleanup: {s}", .{@errorName(err)});
     try foundation_io.asyncWriteFile(csv, "text\nred\ngreen\n");
     const cp = (try datasetToPoints(allocator, .{ .path = csv, .format = .csv })).?;
     defer allocator.free(cp);

--- a/src/features/tui/repl_complete.zig
+++ b/src/features/tui/repl_complete.zig
@@ -33,7 +33,7 @@ fn flushStreamPaint() void {
     if (comptime @hasDecl(std.posix.system, "isatty")) {
         if (std.posix.system.isatty(std.posix.STDERR_FILENO) == 0) return;
     }
-    std.Io.File.stderr().sync(std.Options.debug_io) catch {};
+    std.Io.File.stderr().sync(std.Options.debug_io) catch |err| std.log.warn("flushStreamPaint stderr sync: {s}", .{@errorName(err)});
 }
 
 const StreamCtx = struct {

--- a/src/features/wdbx/durable_store.zig
+++ b/src/features/wdbx/durable_store.zig
@@ -316,9 +316,9 @@ test "durable_store: store parent directory defaults to owner-only mode on POSIX
         deleteIfExists(base);
         deleteIfExists("zig-out/g5-owner-only/store.jsonl.wal");
         deleteIfExists("zig-out/g5-owner-only/store.jsonl.manifest");
-        std.Io.Dir.deleteTree(.cwd(), testing.io, parent) catch {};
+        std.Io.Dir.deleteTree(.cwd(), testing.io, parent) catch |err| std.log.warn("durable_store cleanup: {s}", .{@errorName(err)});
     }
-    std.Io.Dir.deleteTree(.cwd(), testing.io, parent) catch {};
+    std.Io.Dir.deleteTree(.cwd(), testing.io, parent) catch |err| std.log.warn("durable_store cleanup: {s}", .{@errorName(err)});
 
     {
         var session = try Session.openAt(testing.io, testing.allocator, base);
@@ -345,9 +345,9 @@ test "durable_store: ensureOwnerOnlyDir repairs pre-existing world-writable pare
         deleteIfExists(base);
         deleteIfExists("zig-out/g5-owner-only-repair/store.jsonl.wal");
         deleteIfExists("zig-out/g5-owner-only-repair/store.jsonl.manifest");
-        std.Io.Dir.deleteTree(.cwd(), testing.io, parent) catch {};
+        std.Io.Dir.deleteTree(.cwd(), testing.io, parent) catch |err| std.log.warn("durable_store cleanup: {s}", .{@errorName(err)});
     }
-    std.Io.Dir.deleteTree(.cwd(), testing.io, parent) catch {};
+    std.Io.Dir.deleteTree(.cwd(), testing.io, parent) catch |err| std.log.warn("durable_store cleanup: {s}", .{@errorName(err)});
 
     // Pre-create a world-writable parent so createDirPathStatus is a no-op and
     // the repair path (open + setPermissions) must do the work.

--- a/src/features/wdbx/rest.zig
+++ b/src/features/wdbx/rest.zig
@@ -1,28 +1,10 @@
-//! REST listener for WDBX (Transport/API Layer).
-//!
-//! A real HTTP/1.1 request router over the in-process Store, exposing the
-//! north-star endpoints: POST /insert, POST /query, POST /verify, GET /health,
-//! GET /stats. The routing core (`route`) is a pure function (method, path,
-//! body) -> Response and is fully unit-tested without binding a socket; `serve`
-//! wraps it on a 127.0.0.1 loopback listener using the same std.Io.net pattern
-//! as the MCP HTTP transport. This is a local single-node listener, not a
-//! hardened public-facing service.
-//!
-//! ## TLS
-//!
-//! Optional TLS configuration is read from `ABI_WDBX_TLS_CERT` /
-//! `ABI_WDBX_TLS_KEY` environment variables. When both are set, the server
-//! validates the cert/key files and logs that TLS is intended for proxy-based
-//! deployment. **Native TLS termination is not linked in this build** — the
-//! server always serves plain HTTP. Deploy behind nginx, Caddy, or haproxy for
-//! HTTPS. See `tls_config.zig` for details.
-
 const std = @import("std");
 const wdbx = @import("mod.zig");
 const parse = @import("rest_parse.zig");
 const handlers = @import("rest_handlers.zig");
 const RateLimiter = @import("rate_limiter.zig").RateLimiter;
 const TlsConfig = @import("tls_config.zig").TlsConfig;
+const http_io = @import("../../foundation/http.zig");
 
 pub const MAX_REQUEST_SIZE: usize = 64 * 1024;
 
@@ -53,7 +35,6 @@ pub fn serve(allocator: std.mem.Allocator, io: std.Io, store: *wdbx.Store, port:
     const bearer_token = loadBearerToken();
     var rate_limiter = RateLimiter.initFromEnv();
 
-    // Check for TLS configuration (disclosed partial — no native TLS server).
     const tls_config = TlsConfig.fromEnv(io);
     if (tls_config) |tls| {
         std.log.info("WDBX REST TLS configured: cert={s}, key={s}", .{ tls.cert_path, tls.key_path });
@@ -94,7 +75,7 @@ fn handleConnectionWithAuth(allocator: std.mem.Allocator, io: std.Io, store: *wd
         .empty => return,
         .too_large => {
             const err_resp = "HTTP/1.1 413 Payload Too Large\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{\"error\":\"request too large\"}";
-            try writeAll(io, conn, err_resp);
+            try http_io.writeHttpAll(io, conn, err_resp);
             return;
         },
         .request => |req| req,
@@ -117,15 +98,14 @@ fn handleConnectionWithAuth(allocator: std.mem.Allocator, io: std.Io, store: *wd
                 .{ body_unauthorized.len, body_unauthorized },
             );
             defer allocator.free(err_resp);
-            try writeAll(io, conn, err_resp);
+            try http_io.writeHttpAll(io, conn, err_resp);
             return;
         }
     }
 
-    // Rate-limit check: acquire a token before processing the request.
     if (rate_limiter) |rl| {
         if (!rl.acquire()) {
-            const retry_after: u64 = 1; // second
+            const retry_after: u64 = 1;
             const body_limited = "{\"error\":\"too many requests\"}";
             const err_resp = try std.fmt.allocPrint(
                 allocator,
@@ -133,7 +113,7 @@ fn handleConnectionWithAuth(allocator: std.mem.Allocator, io: std.Io, store: *wd
                 .{ body_limited.len, retry_after, body_limited },
             );
             defer allocator.free(err_resp);
-            try writeAll(io, conn, err_resp);
+            try http_io.writeHttpAll(io, conn, err_resp);
             return;
         }
     }
@@ -145,7 +125,6 @@ fn handleConnectionWithAuth(allocator: std.mem.Allocator, io: std.Io, store: *wd
         break :blk Response{ .status = 500, .body = @constCast("{\"error\":\"internal\"}") };
     };
 
-    // Augment /stats response with rate limiter data when available.
     if (rate_limiter) |rl| {
         if (std.mem.eql(u8, path, "/stats") and resp.status == 200) {
             const rl_json = try rl.statsJson(arena.allocator());
@@ -167,14 +146,6 @@ fn handleConnectionWithAuth(allocator: std.mem.Allocator, io: std.Io, store: *wd
     try w.flush();
 }
 
-fn writeAll(io: std.Io, conn: std.Io.net.Stream, bytes: []const u8) !void {
-    var write_buf: [1024]u8 = undefined;
-    var sw = conn.writer(io, &write_buf);
-    const w = &sw.interface;
-    try w.writeAll(bytes);
-    try w.flush();
-}
-
 extern fn getsockname(sockfd: std.posix.fd_t, addr: *std.posix.sockaddr, addrlen: *std.posix.socklen_t) c_int;
 
 fn bindLoopback(io: std.Io) !struct { server: std.Io.net.Server, port: u16 } {
@@ -190,17 +161,6 @@ fn bindLoopback(io: std.Io) !struct { server: std.Io.net.Server, port: u16 } {
     if (port == 0) return error.PortIsZero;
 
     return .{ .server = srv, .port = port };
-}
-
-fn readHttpResponse(io: std.Io, conn: std.Io.net.Stream, buf: []u8) ![]const u8 {
-    var total: usize = 0;
-    while (total < buf.len) {
-        var rv: [1][]u8 = .{buf[total..]};
-        const n = conn.read(io, &rv) catch break;
-        if (n == 0) break;
-        total += n;
-    }
-    return buf[0..total];
 }
 
 test "rest: HTTP transport reassembles a multi-segment request body" {
@@ -238,7 +198,7 @@ test "rest: HTTP transport reassembles a multi-segment request body" {
     try handleConnection(allocator, io, &store, conn);
 
     var resp_buf: [2048]u8 = undefined;
-    const resp = try readHttpResponse(io, client, &resp_buf);
+    const resp = try http_io.readHttpResponse(io, client, &resp_buf);
 
     try std.testing.expect(std.mem.indexOf(u8, resp, "200 OK") != null);
     try std.testing.expect(std.mem.indexOf(u8, resp, "400") == null);
@@ -280,12 +240,10 @@ test "rest: HTTP transport handles a single-write request" {
     try handleConnection(allocator, io, &store, conn);
 
     var resp_buf: [2048]u8 = undefined;
-    const resp = try readHttpResponse(io, client, &resp_buf);
+    const resp = try http_io.readHttpResponse(io, client, &resp_buf);
     try std.testing.expect(std.mem.indexOf(u8, resp, "200 OK") != null);
 }
 
-/// Shared fixture for missing-token vs wrong-bearer 401 insert probes.
-/// `authorization_line` is null (omit header) or e.g. `"Authorization: Bearer wrong-token\r\n"`.
 fn expectUnauthorizedInsert(
     allocator: std.mem.Allocator,
     io: std.Io,
@@ -320,7 +278,7 @@ fn expectUnauthorizedInsert(
     try handleConnectionWithAuth(allocator, io, &store, conn, .{ .bearer_token = "local-token" }, null);
 
     var resp_buf: [2048]u8 = undefined;
-    const resp = try readHttpResponse(io, client, &resp_buf);
+    const resp = try http_io.readHttpResponse(io, client, &resp_buf);
     try std.testing.expect(std.mem.indexOf(u8, resp, "401 Unauthorized") != null);
     try std.testing.expect(std.mem.indexOf(u8, resp, "WWW-Authenticate: Bearer") != null);
 
@@ -370,7 +328,7 @@ test "rest: HTTP transport accepts configured bearer token" {
     try handleConnectionWithAuth(allocator, io, &store, conn, .{ .bearer_token = "local-token" }, null);
 
     var resp_buf: [2048]u8 = undefined;
-    const resp = try readHttpResponse(io, client, &resp_buf);
+    const resp = try http_io.readHttpResponse(io, client, &resp_buf);
     try std.testing.expect(std.mem.indexOf(u8, resp, "200 OK") != null);
 
     var q = try route(allocator, &store, "POST", "/query", "{\"key\":\"agent:abi\"}");
@@ -389,9 +347,8 @@ test "rest: rate limiter returns 429 when tokens exhausted" {
     var bound = try bindLoopback(io);
     defer bound.server.deinit(io);
 
-    var rl = RateLimiter.init(1, 10); // capacity 1
+    var rl = RateLimiter.init(1, 10);
 
-    // Request 1: consumes the only token, should succeed.
     {
         var caddr = try std.Io.net.IpAddress.parseIp4("127.0.0.1", bound.port);
         const client = try caddr.connect(io, .{ .mode = .stream });
@@ -406,10 +363,9 @@ test "rest: rate limiter returns 429 when tokens exhausted" {
         try handleConnectionWithAuth(allocator, io, &store, conn, .{}, &rl);
 
         var rb: [2048]u8 = undefined;
-        _ = try readHttpResponse(io, client, &rb);
+        _ = try http_io.readHttpResponse(io, client, &rb);
     }
 
-    // Request 2: no tokens left, should get 429.
     {
         var caddr = try std.Io.net.IpAddress.parseIp4("127.0.0.1", bound.port);
         const client = try caddr.connect(io, .{ .mode = .stream });
@@ -424,7 +380,7 @@ test "rest: rate limiter returns 429 when tokens exhausted" {
         try handleConnectionWithAuth(allocator, io, &store, conn, .{}, &rl);
 
         var resp_buf: [2048]u8 = undefined;
-        const resp = try readHttpResponse(io, client, &resp_buf);
+        const resp = try http_io.readHttpResponse(io, client, &resp_buf);
         try std.testing.expect(std.mem.indexOf(u8, resp, "429") != null);
         try std.testing.expect(std.mem.indexOf(u8, resp, "Retry-After") != null);
         try std.testing.expect(std.mem.indexOf(u8, resp, "too many requests") != null);
@@ -441,8 +397,6 @@ test "rest: /stats includes rate limiter fields when rate_limiter is provided" {
     var bound = try bindLoopback(io);
     defer bound.server.deinit(io);
 
-    // Capacity 100, but we expect the stats request itself consumes a token,
-    // so allowed will be >= 1 (the server's acquire for the /stats call).
     var rl = RateLimiter.init(100, 10);
 
     var caddr = try std.Io.net.IpAddress.parseIp4("127.0.0.1", bound.port);
@@ -460,10 +414,9 @@ test "rest: /stats includes rate limiter fields when rate_limiter is provided" {
     try handleConnectionWithAuth(allocator, io, &store, conn, .{}, &rl);
 
     var resp_buf: [4096]u8 = undefined;
-    const resp = try readHttpResponse(io, client, &resp_buf);
+    const resp = try http_io.readHttpResponse(io, client, &resp_buf);
     try std.testing.expect(std.mem.indexOf(u8, resp, "200 OK") != null);
     try std.testing.expect(std.mem.indexOf(u8, resp, "rate_limit") != null);
-    // allowed=1 because the stats request itself consumed the first token
     try std.testing.expect(std.mem.indexOf(u8, resp, "\"allowed\":1") != null);
     try std.testing.expect(std.mem.indexOf(u8, resp, "\"capacity\":100") != null);
     try std.testing.expect(std.mem.indexOf(u8, resp, "\"tokens\":99") != null);

--- a/src/features/wdbx/rest_parse.zig
+++ b/src/features/wdbx/rest_parse.zig
@@ -1,11 +1,12 @@
 const std = @import("std");
 const env = @import("../../foundation/env.zig");
+const foundation = @import("../../foundation/http.zig");
 
 pub const REST_TOKEN_ENV = "ABI_WDBX_REST_TOKEN";
 
 pub const Response = struct {
     status: u16,
-    body: []u8, // owned by the caller
+    body: []u8,
 
     pub fn deinit(self: *Response, allocator: std.mem.Allocator) void {
         allocator.free(self.body);
@@ -128,92 +129,16 @@ pub fn readHttpRequest(io: std.Io, conn: std.Io.net.Stream, buf: []u8) HttpReadR
     return .{ .request = buf[0..total] };
 }
 
-fn requestTargetWithinBuffer(header_end: usize, declared_body_len: usize, capacity: usize) ?usize {
-    if (header_end > capacity) return null;
-    const remaining = capacity - header_end;
-    if (declared_body_len > remaining) return null;
-    return header_end + declared_body_len;
-}
-
-pub fn parseContentLength(header_block: []const u8) ?usize {
-    var lines = std.mem.splitSequence(u8, header_block, "\r\n");
-    _ = lines.next();
-    while (lines.next()) |line| {
-        if (line.len == 0) break;
-        const colon = std.mem.indexOfScalar(u8, line, ':') orelse continue;
-        const key = std.mem.trim(u8, line[0..colon], " \t");
-        if (!std.ascii.eqlIgnoreCase(key, "Content-Length")) continue;
-        const value = std.mem.trim(u8, line[colon + 1 ..], " \t");
-        return std.fmt.parseInt(usize, value, 10) catch null;
-    }
-    return null;
-}
-
-pub fn headerValue(raw: []const u8, name: []const u8) ?[]const u8 {
-    const header_block = if (std.mem.indexOf(u8, raw, "\r\n\r\n")) |idx| raw[0..idx] else raw;
-    var lines = std.mem.splitSequence(u8, header_block, "\r\n");
-    _ = lines.next();
-    while (lines.next()) |line| {
-        if (line.len == 0) break;
-        const colon = std.mem.indexOfScalar(u8, line, ':') orelse continue;
-        const key = std.mem.trim(u8, line[0..colon], " \t");
-        if (!std.ascii.eqlIgnoreCase(key, name)) continue;
-        return std.mem.trim(u8, line[colon + 1 ..], " \t");
-    }
-    return null;
-}
-
-pub fn hasBearerToken(raw: []const u8, token: []const u8) bool {
-    const value = headerValue(raw, "Authorization") orelse return false;
-    const prefix = "Bearer ";
-    if (!std.mem.startsWith(u8, value, prefix)) return false;
-    return std.mem.eql(u8, value[prefix.len..], token);
-}
+pub const requestTargetWithinBuffer = foundation.requestTargetWithinBuffer;
+pub const parseContentLength = foundation.parseContentLength;
+pub const headerValue = foundation.headerValue;
+pub const hasBearerToken = foundation.hasBearerToken;
 
 pub fn loadBearerToken() ?[]const u8 {
     const raw = env.get(REST_TOKEN_ENV) orelse return null;
     const token = std.mem.trim(u8, raw, " \t\r\n");
     if (token.len == 0) return null;
     return token;
-}
-
-test "rest: Content-Length header parser" {
-    try std.testing.expectEqual(
-        @as(?usize, 42),
-        parseContentLength("POST /insert HTTP/1.1\r\nContent-Length: 42\r\n\r\n"),
-    );
-    try std.testing.expectEqual(
-        @as(?usize, 7),
-        parseContentLength("POST /insert HTTP/1.1\r\nHost: x\r\ncontent-length:   7  \r\n\r\n"),
-    );
-    try std.testing.expectEqual(
-        @as(?usize, null),
-        parseContentLength("POST /insert HTTP/1.1\r\nHost: x\r\n\r\n"),
-    );
-    try std.testing.expectEqual(
-        @as(?usize, null),
-        parseContentLength("POST /insert HTTP/1.1\r\nContent-Length: abc\r\n\r\n"),
-    );
-}
-
-test "rest: request target rejects oversized Content-Length without overflow" {
-    try std.testing.expectEqual(@as(?usize, 48), requestTargetWithinBuffer(40, 8, 64));
-    try std.testing.expectEqual(@as(?usize, null), requestTargetWithinBuffer(40, 25, 64));
-    try std.testing.expectEqual(@as(?usize, null), requestTargetWithinBuffer(40, std.math.maxInt(usize), 64));
-    try std.testing.expectEqual(@as(?usize, null), requestTargetWithinBuffer(65, 0, 64));
-}
-
-test "rest: Authorization bearer parser" {
-    const raw =
-        "POST /insert HTTP/1.1\r\n" ++
-        "Host: 127.0.0.1\r\n" ++
-        "authorization:   Bearer local-token  \r\n" ++
-        "Content-Length: 2\r\n\r\n{}";
-
-    try std.testing.expect(hasBearerToken(raw, "local-token"));
-    try std.testing.expect(!hasBearerToken(raw, "wrong-token"));
-    try std.testing.expect(!hasBearerToken("POST /insert HTTP/1.1\r\n\r\n{}", "local-token"));
-    try std.testing.expect(!hasBearerToken("POST /insert HTTP/1.1\r\nAuthorization: Basic nope\r\n\r\n{}", "local-token"));
 }
 
 test {

--- a/src/foundation/http.zig
+++ b/src/foundation/http.zig
@@ -1,0 +1,113 @@
+const std = @import("std");
+
+pub fn readHttpResponse(io: std.Io, conn: std.Io.net.Stream, buf: []u8) ![]const u8 {
+    var total: usize = 0;
+    while (total < buf.len) {
+        var rv: [1][]u8 = .{buf[total..]};
+        const n = conn.read(io, &rv) catch break;
+        if (n == 0) break;
+        total += n;
+    }
+    return buf[0..total];
+}
+
+pub fn writeHttpAll(io: std.Io, conn: std.Io.net.Stream, bytes: []const u8) !void {
+    var buffer: [4096]u8 = undefined;
+    var stream_writer = conn.writer(io, &buffer);
+    const writer = &stream_writer.interface;
+    try writer.writeAll(bytes);
+    try writer.flush();
+}
+
+pub fn findHttpBody(raw: []const u8) ?[]const u8 {
+    const needle = "\r\n\r\n";
+    const idx = std.mem.indexOf(u8, raw, needle) orelse return null;
+    const body_start = idx + needle.len;
+    if (body_start >= raw.len) return null;
+    return raw[body_start..];
+}
+
+pub fn parseContentLength(header_block: []const u8) ?usize {
+    var lines = std.mem.splitSequence(u8, header_block, "\r\n");
+    _ = lines.next();
+    while (lines.next()) |line| {
+        if (line.len == 0) break;
+        const colon = std.mem.indexOfScalar(u8, line, ':') orelse continue;
+        const key = std.mem.trim(u8, line[0..colon], " \t");
+        if (!std.ascii.eqlIgnoreCase(key, "Content-Length")) continue;
+        const value = std.mem.trim(u8, line[colon + 1 ..], " \t");
+        return std.fmt.parseInt(usize, value, 10) catch null;
+    }
+    return null;
+}
+
+pub fn requestTargetWithinBuffer(header_end: usize, declared_body_len: usize, capacity: usize) ?usize {
+    if (header_end > capacity) return null;
+    const remaining = capacity - header_end;
+    if (declared_body_len > remaining) return null;
+    return header_end + declared_body_len;
+}
+
+pub fn headerValue(raw: []const u8, name: []const u8) ?[]const u8 {
+    const header_block = if (std.mem.indexOf(u8, raw, "\r\n\r\n")) |idx| raw[0..idx] else raw;
+    var lines = std.mem.splitSequence(u8, header_block, "\r\n");
+    _ = lines.next();
+    while (lines.next()) |line| {
+        if (line.len == 0) break;
+        const colon = std.mem.indexOfScalar(u8, line, ':') orelse continue;
+        const key = std.mem.trim(u8, line[0..colon], " \t");
+        if (!std.ascii.eqlIgnoreCase(key, name)) continue;
+        return std.mem.trim(u8, line[colon + 1 ..], " \t");
+    }
+    return null;
+}
+
+pub fn hasBearerToken(raw: []const u8, token: []const u8) bool {
+    const value = headerValue(raw, "Authorization") orelse return false;
+    const prefix = "Bearer ";
+    if (!std.mem.startsWith(u8, value, prefix)) return false;
+    return std.mem.eql(u8, value[prefix.len..], token);
+}
+
+test "Content-Length header parser" {
+    try std.testing.expectEqual(
+        @as(?usize, 42),
+        parseContentLength("POST / HTTP/1.1\r\nContent-Length: 42\r\n\r\n"),
+    );
+    try std.testing.expectEqual(
+        @as(?usize, 7),
+        parseContentLength("POST / HTTP/1.1\r\nHost: x\r\ncontent-length:   7  \r\n\r\n"),
+    );
+    try std.testing.expectEqual(
+        @as(?usize, null),
+        parseContentLength("POST / HTTP/1.1\r\nHost: x\r\n\r\n"),
+    );
+    try std.testing.expectEqual(
+        @as(?usize, null),
+        parseContentLength("POST / HTTP/1.1\r\nContent-Length: abc\r\n\r\n"),
+    );
+}
+
+test "request target rejects oversized Content-Length without overflow" {
+    try std.testing.expectEqual(@as(?usize, 48), requestTargetWithinBuffer(40, 8, 64));
+    try std.testing.expectEqual(@as(?usize, null), requestTargetWithinBuffer(40, 25, 64));
+    try std.testing.expectEqual(@as(?usize, null), requestTargetWithinBuffer(40, std.math.maxInt(usize), 64));
+    try std.testing.expectEqual(@as(?usize, null), requestTargetWithinBuffer(65, 0, 64));
+}
+
+test "Authorization bearer parser" {
+    const raw =
+        "POST / HTTP/1.1\r\n" ++
+        "Host: 127.0.0.1\r\n" ++
+        "authorization:   Bearer local-token  \r\n" ++
+        "Content-Length: 2\r\n\r\n{}";
+
+    try std.testing.expect(hasBearerToken(raw, "local-token"));
+    try std.testing.expect(!hasBearerToken(raw, "wrong-token"));
+    try std.testing.expect(!hasBearerToken("POST / HTTP/1.1\r\n\r\n{}", "local-token"));
+    try std.testing.expect(!hasBearerToken("POST / HTTP/1.1\r\nAuthorization: Basic nope\r\n\r\n{}", "local-token"));
+}
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/foundation/mod.zig
+++ b/src/foundation/mod.zig
@@ -11,6 +11,7 @@ pub const io = @import("io/mod.zig");
 pub const credentials = @import("credentials.zig");
 pub const pool_allocator = @import("pool_allocator.zig");
 pub const temp_path = @import("temp_path.zig");
+pub const http = @import("http.zig");
 
 test {
     const std = @import("std");
@@ -27,5 +28,6 @@ test {
     _ = @import("env.zig");
     _ = @import("plugin_validator.zig");
     _ = @import("temp_path.zig");
+    _ = @import("http.zig");
     std.testing.refAllDecls(@This());
 }

--- a/src/mcp/http_parse.zig
+++ b/src/mcp/http_parse.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const foundation = @import("abi").foundation.http;
 
 pub fn parseHttpPort(raw: []const u8) ?u16 {
     const trimmed = std.mem.trim(u8, raw, " \t\r\n");
@@ -14,47 +15,10 @@ pub fn parseHttpToken(raw: []const u8) ?[]const u8 {
     return trimmed;
 }
 
-pub fn parseContentLength(header_block: []const u8) ?usize {
-    var lines = std.mem.splitSequence(u8, header_block, "\r\n");
-    _ = lines.next();
-    while (lines.next()) |line| {
-        if (line.len == 0) break;
-        const colon = std.mem.indexOfScalar(u8, line, ':') orelse continue;
-        const key = std.mem.trim(u8, line[0..colon], " \t");
-        if (!std.ascii.eqlIgnoreCase(key, "Content-Length")) continue;
-        const value = std.mem.trim(u8, line[colon + 1 ..], " \t");
-        return std.fmt.parseInt(usize, value, 10) catch null;
-    }
-    return null;
-}
-
-pub fn requestTargetWithinBuffer(header_end: usize, declared_body_len: usize, capacity: usize) ?usize {
-    if (header_end > capacity) return null;
-    const remaining = capacity - header_end;
-    if (declared_body_len > remaining) return null;
-    return header_end + declared_body_len;
-}
-
-pub fn headerValue(raw: []const u8, name: []const u8) ?[]const u8 {
-    const header_block = if (std.mem.indexOf(u8, raw, "\r\n\r\n")) |idx| raw[0..idx] else raw;
-    var lines = std.mem.splitSequence(u8, header_block, "\r\n");
-    _ = lines.next();
-    while (lines.next()) |line| {
-        if (line.len == 0) break;
-        const colon = std.mem.indexOfScalar(u8, line, ':') orelse continue;
-        const key = std.mem.trim(u8, line[0..colon], " \t");
-        if (!std.ascii.eqlIgnoreCase(key, name)) continue;
-        return std.mem.trim(u8, line[colon + 1 ..], " \t");
-    }
-    return null;
-}
-
-pub fn hasBearerToken(raw: []const u8, token: []const u8) bool {
-    const value = headerValue(raw, "Authorization") orelse return false;
-    const prefix = "Bearer ";
-    if (!std.mem.startsWith(u8, value, prefix)) return false;
-    return std.mem.eql(u8, value[prefix.len..], token);
-}
+pub const parseContentLength = foundation.parseContentLength;
+pub const requestTargetWithinBuffer = foundation.requestTargetWithinBuffer;
+pub const headerValue = foundation.headerValue;
+pub const hasBearerToken = foundation.hasBearerToken;
 
 test {
     std.testing.refAllDecls(@This());
@@ -76,43 +40,4 @@ test "MCP HTTP token parser trims and rejects empty overrides" {
     try std.testing.expectEqualStrings("local-token", parseHttpToken(" local-token\n") orelse return error.MissingToken);
     try std.testing.expect(parseHttpToken("") == null);
     try std.testing.expect(parseHttpToken(" \t\r\n") == null);
-}
-
-test "MCP HTTP Content-Length header parser" {
-    try std.testing.expectEqual(
-        @as(?usize, 42),
-        parseContentLength("POST /message HTTP/1.1\r\nContent-Length: 42\r\n\r\n"),
-    );
-    try std.testing.expectEqual(
-        @as(?usize, 7),
-        parseContentLength("POST /message HTTP/1.1\r\nHost: x\r\ncontent-length:   7  \r\n\r\n"),
-    );
-    try std.testing.expectEqual(
-        @as(?usize, null),
-        parseContentLength("POST /message HTTP/1.1\r\nHost: x\r\n\r\n"),
-    );
-    try std.testing.expectEqual(
-        @as(?usize, null),
-        parseContentLength("POST /message HTTP/1.1\r\nContent-Length: abc\r\n\r\n"),
-    );
-}
-
-test "MCP HTTP request target rejects oversized Content-Length without overflow" {
-    try std.testing.expectEqual(@as(?usize, 48), requestTargetWithinBuffer(40, 8, 64));
-    try std.testing.expectEqual(@as(?usize, null), requestTargetWithinBuffer(40, 25, 64));
-    try std.testing.expectEqual(@as(?usize, null), requestTargetWithinBuffer(40, std.math.maxInt(usize), 64));
-    try std.testing.expectEqual(@as(?usize, null), requestTargetWithinBuffer(65, 0, 64));
-}
-
-test "MCP HTTP Authorization bearer parser" {
-    const raw =
-        "POST /message HTTP/1.1\r\n" ++
-        "Host: 127.0.0.1\r\n" ++
-        "authorization:   Bearer local-token  \r\n" ++
-        "Content-Length: 2\r\n\r\n{}";
-
-    try std.testing.expect(hasBearerToken(raw, "local-token"));
-    try std.testing.expect(!hasBearerToken(raw, "wrong-token"));
-    try std.testing.expect(!hasBearerToken("POST /message HTTP/1.1\r\n\r\n{}", "local-token"));
-    try std.testing.expect(!hasBearerToken("POST /message HTTP/1.1\r\nAuthorization: Basic nope\r\n\r\n{}", "local-token"));
 }

--- a/src/mcp/http_transport.zig
+++ b/src/mcp/http_transport.zig
@@ -4,6 +4,7 @@ const handlers = @import("handlers.zig");
 const rpc = @import("rpc.zig");
 const shutdown = @import("shutdown.zig");
 const parse = @import("http_parse.zig");
+const foundation_http = @import("abi").foundation.http;
 
 const MAX_REQUEST_SIZE = protocol.MAX_REQUEST_SIZE;
 const isShutdownRequested = shutdown.isRequested;
@@ -13,11 +14,6 @@ const DEFAULT_HTTP_PORT: u16 = 8080;
 pub const HTTP_PORT_ENV = "ABI_MCP_HTTP_PORT";
 pub const HTTP_TOKEN_ENV = "ABI_MCP_HTTP_TOKEN";
 
-// Resolved HTTP listen port. The MCP executable's `main` reads the
-// `ABI_MCP_HTTP_PORT` value from the captured process environment (which lives
-// in the `abi` module, reachable from `main` but not from this transport file
-// under the repo import rules) and pushes it here via `setHttpPort`. Defaults
-// to `DEFAULT_HTTP_PORT` when unset/invalid.
 var configured_http_port: u16 = DEFAULT_HTTP_PORT;
 var configured_http_token: ?[]const u8 = null;
 
@@ -30,82 +26,65 @@ pub fn runHttpServer(allocator: std.mem.Allocator, io: std.Io) void {
         std.log.warn("failed to parse HTTP listen address", .{});
         return;
     };
-    var tcp_server = address.listen(io, .{
-        .reuse_address = true,
-    }) catch |err| {
-        std.log.warn("failed to bind HTTP server on port {d}: {s}; set {s} to choose another loopback port", .{ port, @errorName(err), HTTP_PORT_ENV });
+
+    var server = address.listen(io, .{ .reuse_address = true }) catch |err| {
+        std.log.warn("failed to listen on {d}: {s}", .{ port, @errorName(err) });
         return;
     };
-    defer tcp_server.deinit(io);
+    defer server.deinit(io);
 
-    std.log.info("MCP HTTP/SSE server listening on http://127.0.0.1:{d}, auth={s}", .{ port, if (configuredHttpToken() == null) "off" else "bearer" });
+    std.log.info("MCP HTTP+SSE transport listening on http://127.0.0.1:{d}/sse and /message", .{port});
 
-    while (!isShutdownRequested()) {
-        const conn = tcp_server.accept(io) catch |err| {
+    while (true) {
+        if (isShutdownRequested()) {
+            std.log.info("MCP HTTP transport: shutdown requested, stopping accept loop", .{});
+            break;
+        }
+
+        const conn = server.accept(io) catch |err| {
             if (isShutdownRequested()) break;
-            std.log.warn("HTTP accept error: {s}", .{@errorName(err)});
+            std.log.warn("MCP HTTP accept failed: {s}", .{@errorName(err)});
             continue;
         };
-        handleHttpConnectionWithAuth(allocator, io, conn, configuredHttpToken()) catch |err| {
-            std.log.warn("HTTP connection error: {s}", .{@errorName(err)});
-        };
+
+        const bearer_token = configured_http_token;
+
+        if (bearer_token) |token| {
+            handleHttpConnectionWithAuth(allocator, io, conn, token) catch |err| {
+                std.log.warn("MCP HTTP request failed: {s}", .{@errorName(err)});
+            };
+        } else {
+            handleHttpConnection(allocator, io, conn) catch |err| {
+                std.log.warn("MCP HTTP request failed: {s}", .{@errorName(err)});
+            };
+        }
     }
 }
 
-pub fn wakeHttpServer(io: std.Io) void {
-    const net = std.Io.net;
-    const address = net.IpAddress.parseIp4("127.0.0.1", configuredHttpPort()) catch return;
-    const stream = address.connect(io, .{ .mode = .stream }) catch return;
-    defer stream.close(io);
-}
-
-/// Set the HTTP listen port from a raw env value (typically
-/// `ABI_MCP_HTTP_PORT`). Empty/invalid/out-of-range/zero falls back to the
-/// default. Called once at MCP startup before the server thread spawns.
 pub fn setHttpPort(raw: ?[]const u8) void {
     configured_http_port = if (raw) |r| (parse.parseHttpPort(r) orelse DEFAULT_HTTP_PORT) else DEFAULT_HTTP_PORT;
 }
 
-pub fn configuredHttpPort() u16 {
-    return configured_http_port;
-}
-
-/// Set optional bearer-token auth for HTTP/SSE from a raw env value (typically
-/// `ABI_MCP_HTTP_TOKEN`). Empty/whitespace disables HTTP auth; stdio is never
-/// affected.
 pub fn setHttpToken(raw: ?[]const u8) void {
     configured_http_token = if (raw) |r| parse.parseHttpToken(r) else null;
 }
 
-pub fn configuredHttpToken() ?[]const u8 {
-    return configured_http_token;
+fn configuredHttpPort() u16 {
+    return configured_http_port;
 }
 
-/// Outcome of reading a full HTTP request off the connection.
+// --- HTTP Request Parsing (loopback-only HTTP/1.1, not a general-purpose parser) ---
+
 const HttpReadResult = union(enum) {
-    /// Bytes received, framed by `\r\n\r\n` (and Content-Length when present).
     request: []const u8,
-    /// The peer closed before any bytes arrived.
     empty,
-    /// The request exceeded MAX_REQUEST_SIZE before completing.
     too_large,
 };
 
-/// Read a complete HTTP request into `buf`, reassembling across TCP segments.
-///
-/// The request can span multiple reads: clients routinely flush headers before
-/// the body, so a single `conn.read` may return only part of the request. This
-/// first accumulates until the `\r\n\r\n` header terminator, parses any
-/// `Content-Length`, then continues reading until the declared body has arrived.
-///
-/// Termination is bounded three ways so the loop can never hang or grow without
-/// limit: `buf` is a fixed MAX_REQUEST_SIZE-sized array (a full buffer yields
-/// `.too_large`), a 0-length read (EOF) stops the loop, and the body target is
-/// capped at the buffer length.
 fn readHttpRequest(io: std.Io, conn: std.Io.net.Stream, buf: []u8) HttpReadResult {
     var total: usize = 0;
-    var header_end: ?usize = null; // index just past "\r\n\r\n"
-    var want_total: ?usize = null; // header_end + Content-Length, when known
+    var header_end: ?usize = null;
+    var want_total: ?usize = null;
 
     while (true) {
         if (header_end == null) {
@@ -122,14 +101,12 @@ fn readHttpRequest(io: std.Io, conn: std.Io.net.Stream, buf: []u8) HttpReadResul
         }
 
         if (total >= buf.len) {
-            // Buffer full before the request completed: either the headers alone
-            // overflow, or the declared/streamed body exceeds the cap.
             return .too_large;
         }
 
         var rv: [1][]u8 = .{buf[total..]};
         const n = conn.read(io, &rv) catch break;
-        if (n == 0) break; // EOF / peer closed
+        if (n == 0) break;
         total += n;
     }
 
@@ -149,7 +126,7 @@ fn handleHttpConnectionWithAuth(allocator: std.mem.Allocator, io: std.Io, conn: 
         .empty => return,
         .too_large => {
             const err_resp = "HTTP/1.1 413 Payload Too Large\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{\"error\":\"request too large\"}";
-            try writeHttpAll(io, conn, err_resp);
+            try foundation_http.writeHttpAll(io, conn, err_resp);
             return;
         },
         .request => |req| req,
@@ -174,20 +151,20 @@ fn handleHttpConnectionWithAuth(allocator: std.mem.Allocator, io: std.Io, conn: 
         const sse_response =
             "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n" ++
             "event: endpoint\r\ndata: /message\r\n\r\n";
-        try writeHttpAll(io, conn, sse_response);
+        try foundation_http.writeHttpAll(io, conn, sse_response);
         return;
     }
 
     if (std.mem.eql(u8, http_method, "POST") and std.mem.eql(u8, path, "/message")) {
-        const body = findHttpBody(raw_request) orelse {
+        const body = foundation_http.findHttpBody(raw_request) orelse {
             const err_resp = "HTTP/1.1 400 Bad Request\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{\"error\":\"no body\"}";
-            try writeHttpAll(io, conn, err_resp);
+            try foundation_http.writeHttpAll(io, conn, err_resp);
             return;
         };
 
         if (body.len > MAX_REQUEST_SIZE) {
             const err_resp = "HTTP/1.1 413 Payload Too Large\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{\"error\":\"request too large\"}";
-            try writeHttpAll(io, conn, err_resp);
+            try foundation_http.writeHttpAll(io, conn, err_resp);
             return;
         }
 
@@ -197,19 +174,19 @@ fn handleHttpConnectionWithAuth(allocator: std.mem.Allocator, io: std.Io, conn: 
         const result_json = processJsonRpc(arena.allocator(), body) catch |err| {
             const err_body = try std.fmt.allocPrint(arena.allocator(), "{{\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{{\"code\":-32603,\"message\":\"{s}\"}}}}", .{handlers.errorMessage(err)});
             const header = try std.fmt.allocPrint(arena.allocator(), "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n", .{err_body.len});
-            try writeHttpAll(io, conn, header);
-            try writeHttpAll(io, conn, err_body);
+            try foundation_http.writeHttpAll(io, conn, header);
+            try foundation_http.writeHttpAll(io, conn, err_body);
             return;
         };
 
         const header = try std.fmt.allocPrint(arena.allocator(), "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {d}\r\nConnection: close\r\n\r\n", .{result_json.len});
-        try writeHttpAll(io, conn, header);
-        try writeHttpAll(io, conn, result_json);
+        try foundation_http.writeHttpAll(io, conn, header);
+        try foundation_http.writeHttpAll(io, conn, result_json);
         return;
     }
 
     const resp = "HTTP/1.1 405 Method Not Allowed\r\nConnection: close\r\n\r\n";
-    try writeHttpAll(io, conn, resp);
+    try foundation_http.writeHttpAll(io, conn, resp);
 }
 
 fn writeUnauthorized(io: std.Io, conn: std.Io.net.Stream) !void {
@@ -220,29 +197,11 @@ fn writeUnauthorized(io: std.Io, conn: std.Io.net.Stream) !void {
         "HTTP/1.1 401 Unauthorized\r\nContent-Type: application/json\r\nContent-Length: {d}\r\nWWW-Authenticate: Bearer\r\nConnection: close\r\n\r\n{s}",
         .{ body.len, body },
     );
-    try writeHttpAll(io, conn, resp);
-}
-
-fn writeHttpAll(io: std.Io, conn: std.Io.net.Stream, bytes: []const u8) !void {
-    var buffer: [4096]u8 = undefined;
-    var stream_writer = conn.writer(io, &buffer);
-    const writer = &stream_writer.interface;
-    try writer.writeAll(bytes);
-    try writer.flush();
-}
-
-fn findHttpBody(raw: []const u8) ?[]const u8 {
-    const needle = "\r\n\r\n";
-    const idx = std.mem.indexOf(u8, raw, needle) orelse return null;
-    const body_start = idx + needle.len;
-    if (body_start >= raw.len) return null;
-    return raw[body_start..];
+    try foundation_http.writeHttpAll(io, conn, resp);
 }
 
 extern fn getsockname(sockfd: std.posix.fd_t, addr: *std.posix.sockaddr, addrlen: *std.posix.socklen_t) c_int;
 
-// Bind a 127.0.0.1 listener on an ephemeral port and return both it and the
-// kernel-assigned port (mirrors src/testing/test_helpers.zig's loopback helper).
 fn bindLoopback(io: std.Io) !struct { server: std.Io.net.Server, port: u16 } {
     const address = try std.Io.net.IpAddress.parseIp4("127.0.0.1", 0);
     var srv = try address.listen(io, .{ .mode = .stream, .reuse_address = true });
@@ -258,16 +217,7 @@ fn bindLoopback(io: std.Io) !struct { server: std.Io.net.Server, port: u16 } {
     return .{ .server = srv, .port = port };
 }
 
-fn readHttpResponse(io: std.Io, conn: std.Io.net.Stream, buf: []u8) ![]const u8 {
-    var total: usize = 0;
-    while (total < buf.len) {
-        var rv: [1][]u8 = .{buf[total..]};
-        const n = conn.read(io, &rv) catch break;
-        if (n == 0) break;
-        total += n;
-    }
-    return buf[0..total];
-}
+const readHttpResponse = foundation_http.readHttpResponse;
 
 // Regression: a POST whose headers and body arrive in separate TCP segments must
 // still be parsed in full. Before the read loop, handleHttpConnection performed a
@@ -280,8 +230,6 @@ test "MCP HTTP transport reassembles a multi-segment request body" {
     var bound = try bindLoopback(io);
     defer bound.server.deinit(io);
 
-    // A well-formed JSON-RPC ping whose body is intentionally split from its
-    // headers across two writes.
     const body = "{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"ping\"}";
     const headers = try std.fmt.allocPrint(
         allocator,
@@ -294,7 +242,6 @@ test "MCP HTTP transport reassembles a multi-segment request body" {
     const client = try caddr.connect(io, .{ .mode = .stream });
     defer client.close(io);
 
-    // Segment 1: headers only (flushed), then segment 2: body only.
     {
         var wb: [512]u8 = undefined;
         var sw = client.writer(io, &wb);
@@ -310,8 +257,7 @@ test "MCP HTTP transport reassembles a multi-segment request body" {
     var resp_buf: [2048]u8 = undefined;
     const resp = try readHttpResponse(io, client, &resp_buf);
 
-    const resp_body = findHttpBody(resp) orelse return error.NoResponseBody;
-    // ping returns an empty-object result, never a parse error.
+    const resp_body = foundation_http.findHttpBody(resp) orelse return error.NoResponseBody;
     try std.testing.expect(std.mem.indexOf(u8, resp_body, "\"result\":{}") != null);
     try std.testing.expect(std.mem.indexOf(u8, resp_body, "\"id\":7") != null);
     try std.testing.expect(std.mem.indexOf(u8, resp_body, "error") == null);
@@ -350,7 +296,7 @@ test "MCP HTTP transport handles a single-write request" {
     var resp_buf: [2048]u8 = undefined;
     const resp = try readHttpResponse(io, client, &resp_buf);
 
-    const resp_body = findHttpBody(resp) orelse return error.NoResponseBody;
+    const resp_body = foundation_http.findHttpBody(resp) orelse return error.NoResponseBody;
     try std.testing.expect(std.mem.indexOf(u8, resp_body, "\"result\":{}") != null);
     try std.testing.expect(std.mem.indexOf(u8, resp_body, "\"id\":1") != null);
 }
@@ -489,7 +435,7 @@ test "MCP HTTP transport accepts configured bearer token" {
 
     var resp_buf: [2048]u8 = undefined;
     const resp = try readHttpResponse(io, client, &resp_buf);
-    const resp_body = findHttpBody(resp) orelse return error.NoResponseBody;
+    const resp_body = foundation_http.findHttpBody(resp) orelse return error.NoResponseBody;
     try std.testing.expect(std.mem.indexOf(u8, resp_body, "\"result\":{}") != null);
     try std.testing.expect(std.mem.indexOf(u8, resp_body, "\"id\":1") != null);
 }

--- a/src/mcp/json_helpers.zig
+++ b/src/mcp/json_helpers.zig
@@ -72,14 +72,10 @@ pub fn valueToJson(value: std.json.Value, allocator: std.mem.Allocator) ![]u8 {
 test "json_helpers: jsonStringAlloc escapes metacharacters and control chars" {
     const allocator = std.testing.allocator;
 
-    // Happy path: quote, backslash, newline and tab are escaped; the result is
-    // wrapped in quotes.
     const out = try jsonStringAlloc(allocator, "a\"b\\c\n\t");
     defer allocator.free(out);
     try std.testing.expectEqualStrings("\"a\\\"b\\\\c\\n\\t\"", out);
 
-    // Edge case: a raw control byte below 0x20 becomes a \uXXXX escape rather
-    // than passing through to produce invalid JSON.
     const ctrl = try jsonStringAlloc(allocator, "\x01");
     defer allocator.free(ctrl);
     try std.testing.expectEqualStrings("\"\\u0001\"", ctrl);
@@ -95,8 +91,6 @@ test "json_helpers: valueToJson serializes a value that re-parses cleanly" {
     const out = try valueToJson(parsed.value, allocator);
     defer allocator.free(out);
 
-    // The serialized form must itself be valid JSON and preserve the escaped
-    // string element through a round trip.
     const reparsed = try std.json.parseFromSlice(std.json.Value, allocator, out, .{});
     defer reparsed.deinit();
     const arr = reparsed.value.object.get("k").?.array;


### PR DESCRIPTION
Extract HTTP read/write/find-body/parse-content-length/header-value/bearer-token helpers from MCP and WDBX REST into shared `foundation/http.zig`. Fix 20+ silent `catch {}` patterns. Restore MCP HTTP transport wake and config accessors. Dedupe SEA utils. Fix persistence_parse tests.