### PR TITLE
refactor: extract readHttpRequest/HttpReadResult to foundation, add foundation/json.zig

### DIFF
--- a/src/features/wdbx/rest_parse.zig
+++ b/src/features/wdbx/rest_parse.zig
@@ -90,44 +90,8 @@ pub fn findBody(raw: []const u8) []const u8 {
     return "";
 }
 
-pub const HttpReadResult = union(enum) {
-    request: []const u8,
-    empty,
-    too_large,
-};
-
-pub fn readHttpRequest(io: std.Io, conn: std.Io.net.Stream, buf: []u8) HttpReadResult {
-    var total: usize = 0;
-    var header_end: ?usize = null;
-    var want_total: ?usize = null;
-
-    while (true) {
-        if (header_end == null) {
-            if (std.mem.indexOf(u8, buf[0..total], "\r\n\r\n")) |idx| {
-                const end = idx + 4;
-                header_end = end;
-                const declared = parseContentLength(buf[0..end]) orelse 0;
-                want_total = requestTargetWithinBuffer(end, declared, buf.len) orelse return .too_large;
-            }
-        }
-
-        if (want_total) |want| {
-            if (total >= want) break;
-        }
-
-        if (total >= buf.len) {
-            return .too_large;
-        }
-
-        var rv: [1][]u8 = .{buf[total..]};
-        const n = conn.read(io, &rv) catch break;
-        if (n == 0) break;
-        total += n;
-    }
-
-    if (total == 0) return .empty;
-    return .{ .request = buf[0..total] };
-}
+pub const HttpReadResult = foundation.HttpReadResult;
+pub const readHttpRequest = foundation.readHttpRequest;
 
 pub const requestTargetWithinBuffer = foundation.requestTargetWithinBuffer;
 pub const parseContentLength = foundation.parseContentLength;

--- a/src/foundation/http.zig
+++ b/src/foundation/http.zig
@@ -27,6 +27,45 @@ pub fn findHttpBody(raw: []const u8) ?[]const u8 {
     return raw[body_start..];
 }
 
+pub const HttpReadResult = union(enum) {
+    request: []const u8,
+    empty,
+    too_large,
+};
+
+pub fn readHttpRequest(io: std.Io, conn: std.Io.net.Stream, buf: []u8) HttpReadResult {
+    var total: usize = 0;
+    var header_end: ?usize = null;
+    var want_total: ?usize = null;
+
+    while (true) {
+        if (header_end == null) {
+            if (std.mem.indexOf(u8, buf[0..total], "\r\n\r\n")) |idx| {
+                const end = idx + 4;
+                header_end = end;
+                const declared = parseContentLength(buf[0..end]) orelse 0;
+                want_total = requestTargetWithinBuffer(end, declared, buf.len) orelse return .too_large;
+            }
+        }
+
+        if (want_total) |want| {
+            if (total >= want) break;
+        }
+
+        if (total >= buf.len) {
+            return .too_large;
+        }
+
+        var rv: [1][]u8 = .{buf[total..]};
+        const n = conn.read(io, &rv) catch break;
+        if (n == 0) break;
+        total += n;
+    }
+
+    if (total == 0) return .empty;
+    return .{ .request = buf[0..total] };
+}
+
 pub fn parseContentLength(header_block: []const u8) ?usize {
     var lines = std.mem.splitSequence(u8, header_block, "\r\n");
     _ = lines.next();

--- a/src/foundation/json.zig
+++ b/src/foundation/json.zig
@@ -1,0 +1,52 @@
+const std = @import("std");
+
+pub fn appendJsonString(out: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, value: []const u8) !void {
+    try out.append(allocator, '"');
+    for (value) |byte| {
+        switch (byte) {
+            '"' => try out.appendSlice(allocator, "\\\""),
+            '\\' => try out.appendSlice(allocator, "\\\\"),
+            '\n' => try out.appendSlice(allocator, "\\n"),
+            '\r' => try out.appendSlice(allocator, "\\r"),
+            '\t' => try out.appendSlice(allocator, "\\t"),
+            0x00...0x07 => try out.print(allocator, "\\u{X:0>4}", .{byte}),
+            0x08 => try out.appendSlice(allocator, "\\b"),
+            0x0c => try out.appendSlice(allocator, "\\f"),
+            0x0b => try out.print(allocator, "\\u{X:0>4}", .{byte}),
+            0x0e...0x1f => try out.print(allocator, "\\u{X:0>4}", .{byte}),
+            else => try out.append(allocator, byte),
+        }
+    }
+    try out.append(allocator, '"');
+}
+
+pub fn escapeJsonString(allocator: std.mem.Allocator, value: []const u8) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+    try appendJsonString(&out, allocator, value);
+    return try out.toOwnedSlice(allocator);
+}
+
+test "appendJsonString escapes metacharacters and control chars" {
+    const allocator = std.testing.allocator;
+
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(allocator);
+    try appendJsonString(&out, allocator, "a\"b\\c\n\t");
+    try std.testing.expectEqualStrings("\"a\\\"b\\\\c\\n\\t\"", out.items);
+
+    out.clearRetainingCapacity();
+    try appendJsonString(&out, allocator, "\x01");
+    try std.testing.expectEqualStrings("\"\\u0001\"", out.items);
+}
+
+test "escapeJsonString returns an owned slice" {
+    const allocator = std.testing.allocator;
+    const out = try escapeJsonString(allocator, "hello\nworld");
+    defer allocator.free(out);
+    try std.testing.expectEqualStrings("\"hello\\nworld\"", out);
+}
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/foundation/mod.zig
+++ b/src/foundation/mod.zig
@@ -12,6 +12,7 @@ pub const credentials = @import("credentials.zig");
 pub const pool_allocator = @import("pool_allocator.zig");
 pub const temp_path = @import("temp_path.zig");
 pub const http = @import("http.zig");
+pub const json = @import("json.zig");
 
 test {
     const std = @import("std");
@@ -29,5 +30,6 @@ test {
     _ = @import("plugin_validator.zig");
     _ = @import("temp_path.zig");
     _ = @import("http.zig");
+    _ = @import("json.zig");
     std.testing.refAllDecls(@This());
 }

--- a/src/mcp/http_transport.zig
+++ b/src/mcp/http_transport.zig
@@ -61,6 +61,13 @@ pub fn runHttpServer(allocator: std.mem.Allocator, io: std.Io) void {
     }
 }
 
+pub fn wakeHttpServer(io: std.Io) void {
+    const net = std.Io.net;
+    const address = net.IpAddress.parseIp4("127.0.0.1", configuredHttpPort()) catch return;
+    const stream = address.connect(io, .{ .mode = .stream }) catch return;
+    defer stream.close(io);
+}
+
 pub fn setHttpPort(raw: ?[]const u8) void {
     configured_http_port = if (raw) |r| (parse.parseHttpPort(r) orelse DEFAULT_HTTP_PORT) else DEFAULT_HTTP_PORT;
 }
@@ -69,50 +76,18 @@ pub fn setHttpToken(raw: ?[]const u8) void {
     configured_http_token = if (raw) |r| parse.parseHttpToken(r) else null;
 }
 
-fn configuredHttpPort() u16 {
+pub fn configuredHttpPort() u16 {
     return configured_http_port;
+}
+
+pub fn configuredHttpToken() ?[]const u8 {
+    return configured_http_token;
 }
 
 // --- HTTP Request Parsing (loopback-only HTTP/1.1, not a general-purpose parser) ---
 
-const HttpReadResult = union(enum) {
-    request: []const u8,
-    empty,
-    too_large,
-};
-
-fn readHttpRequest(io: std.Io, conn: std.Io.net.Stream, buf: []u8) HttpReadResult {
-    var total: usize = 0;
-    var header_end: ?usize = null;
-    var want_total: ?usize = null;
-
-    while (true) {
-        if (header_end == null) {
-            if (std.mem.indexOf(u8, buf[0..total], "\r\n\r\n")) |idx| {
-                const end = idx + 4;
-                header_end = end;
-                const declared = parse.parseContentLength(buf[0..end]) orelse 0;
-                want_total = parse.requestTargetWithinBuffer(end, declared, buf.len) orelse return .too_large;
-            }
-        }
-
-        if (want_total) |want| {
-            if (total >= want) break;
-        }
-
-        if (total >= buf.len) {
-            return .too_large;
-        }
-
-        var rv: [1][]u8 = .{buf[total..]};
-        const n = conn.read(io, &rv) catch break;
-        if (n == 0) break;
-        total += n;
-    }
-
-    if (total == 0) return .empty;
-    return .{ .request = buf[0..total] };
-}
+const HttpReadResult = foundation_http.HttpReadResult;
+const readHttpRequest = foundation_http.readHttpRequest;
 
 fn handleHttpConnection(allocator: std.mem.Allocator, io: std.Io, conn: std.Io.net.Stream) !void {
     try handleHttpConnectionWithAuth(allocator, io, conn, null);

--- a/src/mcp/json_helpers.zig
+++ b/src/mcp/json_helpers.zig
@@ -1,24 +1,8 @@
 const std = @import("std");
 
-pub fn appendJsonString(out: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, value: []const u8) !void {
-    try out.append(allocator, '"');
-    for (value) |byte| {
-        switch (byte) {
-            '"' => try out.appendSlice(allocator, "\\\""),
-            '\\' => try out.appendSlice(allocator, "\\\\"),
-            '\n' => try out.appendSlice(allocator, "\\n"),
-            '\r' => try out.appendSlice(allocator, "\\r"),
-            '\t' => try out.appendSlice(allocator, "\\t"),
-            0x00...0x07 => try out.print(allocator, "\\u{X:0>4}", .{byte}),
-            0x08 => try out.appendSlice(allocator, "\\b"),
-            0x0c => try out.appendSlice(allocator, "\\f"),
-            0x0b => try out.print(allocator, "\\u{X:0>4}", .{byte}),
-            0x0e...0x1f => try out.print(allocator, "\\u{X:0>4}", .{byte}),
-            else => try out.append(allocator, byte),
-        }
-    }
-    try out.append(allocator, '"');
-}
+const foundation_json = @import("abi").foundation.json;
+
+pub const appendJsonString = foundation_json.appendJsonString;
 
 pub fn jsonStringAlloc(allocator: std.mem.Allocator, value: []const u8) ![]u8 {
     var out: std.ArrayListUnmanaged(u8) = .empty;


### PR DESCRIPTION
Extract the duplicated `readHttpRequest` + `HttpReadResult` (shared by MCP and WDBX REST) into `foundation/http.zig`. Create `foundation/json.zig` with `appendJsonString` and `escapeJsonString`. Restore `wakeHttpServer` and public `configuredHttpPort`/Token that the earlier merge squash dropped.