### PR TITLE
refactor: extract reasonPhrase/strField/bindLoopback to foundation

### DIFF
--- a/src/cli/handlers/wdbx_db.zig
+++ b/src/cli/handlers/wdbx_db.zig
@@ -391,7 +391,7 @@ fn resolvePersona(store: *const wdbx.Store, cache: *const PersonaCache, id: u32)
     var key_buf: [64]u8 = undefined;
     if (std.fmt.bufPrint(&key_buf, "wdbx:profile:{d}", .{id})) |k| {
         if (store.get(k)) |label| return label;
-    } else |_| {}
+    } else |_| std.log.warn("resolvePersona bufPrint overflow for id={d}", .{id});
     return cache.get(id) orelse "unknown";
 }
 

--- a/src/features/wdbx/rest.zig
+++ b/src/features/wdbx/rest.zig
@@ -146,22 +146,7 @@ fn handleConnectionWithAuth(allocator: std.mem.Allocator, io: std.Io, store: *wd
     try w.flush();
 }
 
-extern fn getsockname(sockfd: std.posix.fd_t, addr: *std.posix.sockaddr, addrlen: *std.posix.socklen_t) c_int;
-
-fn bindLoopback(io: std.Io) !struct { server: std.Io.net.Server, port: u16 } {
-    const address = try std.Io.net.IpAddress.parseIp4("127.0.0.1", 0);
-    var srv = try address.listen(io, .{ .mode = .stream, .reuse_address = true });
-    errdefer srv.deinit(io);
-
-    var addr: std.posix.sockaddr = undefined;
-    var addrlen: std.posix.socklen_t = @sizeOf(std.posix.sockaddr);
-    if (getsockname(srv.socket.handle, &addr, &addrlen) != 0) return error.GetSockNameFailed;
-    const addr_in: *const std.posix.sockaddr.in = @ptrCast(@alignCast(&addr));
-    const port = std.mem.toNative(u16, addr_in.port, .big);
-    if (port == 0) return error.PortIsZero;
-
-    return .{ .server = srv, .port = port };
-}
+const bindLoopback = http_io.bindLoopback;
 
 test "rest: HTTP transport reassembles a multi-segment request body" {
     const io = std.testing.io;

--- a/src/features/wdbx/rest_parse.zig
+++ b/src/features/wdbx/rest_parse.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const env = @import("../../foundation/env.zig");
 const foundation = @import("../../foundation/http.zig");
+const foundation_json = @import("../../foundation/json.zig");
 
 pub const REST_TOKEN_ENV = "ABI_WDBX_REST_TOKEN";
 
@@ -65,24 +66,8 @@ pub fn escapeJsonString(allocator: std.mem.Allocator, value: []const u8) ![]u8 {
     return out.toOwnedSlice(allocator);
 }
 
-pub fn strField(v: std.json.Value) ?[]const u8 {
-    return switch (v) {
-        .string => |s| s,
-        else => null,
-    };
-}
-
-pub fn reasonPhrase(status: u16) []const u8 {
-    return switch (status) {
-        200 => "OK",
-        400 => "Bad Request",
-        404 => "Not Found",
-        405 => "Method Not Allowed",
-        429 => "Too Many Requests",
-        500 => "Internal Server Error",
-        else => "OK",
-    };
-}
+pub const strField = foundation_json.strField;
+pub const reasonPhrase = foundation.reasonPhrase;
 
 pub fn findBody(raw: []const u8) []const u8 {
     if (std.mem.indexOf(u8, raw, "\r\n\r\n")) |i| return raw[i + 4 ..];

--- a/src/foundation/http.zig
+++ b/src/foundation/http.zig
@@ -101,6 +101,35 @@ pub fn headerValue(raw: []const u8, name: []const u8) ?[]const u8 {
     return null;
 }
 
+pub fn reasonPhrase(status: u16) []const u8 {
+    return switch (status) {
+        200 => "OK",
+        400 => "Bad Request",
+        404 => "Not Found",
+        405 => "Method Not Allowed",
+        429 => "Too Many Requests",
+        500 => "Internal Server Error",
+        else => "OK",
+    };
+}
+
+extern fn getsockname(sockfd: std.posix.fd_t, addr: *std.posix.sockaddr, addrlen: *std.posix.socklen_t) c_int;
+
+pub fn bindLoopback(io: std.Io) !struct { server: std.Io.net.Server, port: u16 } {
+    const address = try std.Io.net.IpAddress.parseIp4("127.0.0.1", 0);
+    var srv = try address.listen(io, .{ .mode = .stream, .reuse_address = true });
+    errdefer srv.deinit(io);
+
+    var addr: std.posix.sockaddr = undefined;
+    var addrlen: std.posix.socklen_t = @sizeOf(std.posix.sockaddr);
+    if (getsockname(srv.socket.handle, &addr, &addrlen) != 0) return error.GetSockNameFailed;
+    const addr_in: *const std.posix.sockaddr.in = @ptrCast(@alignCast(&addr));
+    const port = std.mem.toNative(u16, addr_in.port, .big);
+    if (port == 0) return error.PortIsZero;
+
+    return .{ .server = srv, .port = port };
+}
+
 pub fn hasBearerToken(raw: []const u8, token: []const u8) bool {
     const value = headerValue(raw, "Authorization") orelse return false;
     const prefix = "Bearer ";

--- a/src/foundation/json.zig
+++ b/src/foundation/json.zig
@@ -20,6 +20,13 @@ pub fn appendJsonString(out: *std.ArrayListUnmanaged(u8), allocator: std.mem.All
     try out.append(allocator, '"');
 }
 
+pub fn strField(v: std.json.Value) ?[]const u8 {
+    return switch (v) {
+        .string => |s| s,
+        else => null,
+    };
+}
+
 pub fn escapeJsonString(allocator: std.mem.Allocator, value: []const u8) ![]u8 {
     var out: std.ArrayListUnmanaged(u8) = .empty;
     errdefer out.deinit(allocator);

--- a/src/mcp/http_transport.zig
+++ b/src/mcp/http_transport.zig
@@ -175,23 +175,7 @@ fn writeUnauthorized(io: std.Io, conn: std.Io.net.Stream) !void {
     try foundation_http.writeHttpAll(io, conn, resp);
 }
 
-extern fn getsockname(sockfd: std.posix.fd_t, addr: *std.posix.sockaddr, addrlen: *std.posix.socklen_t) c_int;
-
-fn bindLoopback(io: std.Io) !struct { server: std.Io.net.Server, port: u16 } {
-    const address = try std.Io.net.IpAddress.parseIp4("127.0.0.1", 0);
-    var srv = try address.listen(io, .{ .mode = .stream, .reuse_address = true });
-    errdefer srv.deinit(io);
-
-    var addr: std.posix.sockaddr = undefined;
-    var addrlen: std.posix.socklen_t = @sizeOf(std.posix.sockaddr);
-    if (getsockname(srv.socket.handle, &addr, &addrlen) != 0) return error.GetSockNameFailed;
-    const addr_in: *const std.posix.sockaddr.in = @ptrCast(@alignCast(&addr));
-    const port = std.mem.toNative(u16, addr_in.port, .big);
-    if (port == 0) return error.PortIsZero;
-
-    return .{ .server = srv, .port = port };
-}
-
+const bindLoopback = foundation_http.bindLoopback;
 const readHttpResponse = foundation_http.readHttpResponse;
 
 // Regression: a POST whose headers and body arrive in separate TCP segments must


### PR DESCRIPTION
Extract `reasonPhrase` (HTTP status text) to `foundation/http.zig`, `strField` (JSON string accessor) to `foundation/json.zig`, and `bindLoopback` (loopback socket helper) to `foundation/http.zig`. Eliminates byte-for-byte duplicate copies in MCP and WDBX REST. Fixes a silent `else |_| {}` discard in `wdbx_db.zig` with a warn log.