### PR TITLE
refactor: centralize env vars, consolidate JSON escaping, fix rest_parse.zig

### DIFF
--- a/src/cli/handlers/complete_handlers.zig
+++ b/src/cli/handlers/complete_handlers.zig
@@ -202,7 +202,7 @@ pub fn handleFmComplete(allocator: std.mem.Allocator, input: []const u8, model: 
 /// OpenAI-compatible server (llama-server, ollama, mlx-server) via HTTP.
 pub fn handleLocalBridgeComplete(io: std.Io, allocator: std.mem.Allocator, input: []const u8, model: []const u8, stream: bool) !u8 {
     const is_mlx = std.mem.startsWith(u8, model, "mlx/") or std.mem.startsWith(u8, model, "mlx-");
-    const env_key = if (is_mlx) "ABI_MLX_ENDPOINT" else "ABI_LLAMA_CPP_ENDPOINT";
+    const env_key = if (is_mlx) env.MLX_ENDPOINT_ENV else env.LLAMA_CPP_ENDPOINT_ENV;
     const override = env.get(env_key);
     const endpoint = connectors.local_bridge.endpointFor(model, override);
     if (!connectors.local_bridge.healthCheck(io, allocator, endpoint)) {

--- a/src/cli/handlers/wdbx.zig
+++ b/src/cli/handlers/wdbx.zig
@@ -5,6 +5,7 @@ const db_commands = @import("wdbx_db.zig");
 const runtime_commands = @import("wdbx_runtime.zig");
 const test_helpers = @import("../../testing/test_helpers.zig");
 const usage_mod = @import("../usage.zig");
+const env = @import("../../foundation/env.zig");
 
 const wdbx = features.wdbx;
 
@@ -228,7 +229,7 @@ fn wdbxGpuHelp() u8 {
 }
 
 fn wdbxApiHelp() u8 {
-    std.debug.print("usage: abi wdbx api serve [port]\n\nServe the loopback WDBX REST API.\n\nEnv:\n  ABI_WDBX_REST_TOKEN     Optional bearer token for request auth.\n  ABI_WDBX_TLS_CERT       Path to PEM certificate (TLS config / proxy deployment).\n  ABI_WDBX_TLS_KEY        Path to PEM private key (TLS config / proxy deployment).\n\nTLS: native termination is not linked; deploy behind nginx/Caddy/haproxy.\n", .{});
+    std.debug.print("usage: abi wdbx api serve [port]\n\nServe the loopback WDBX REST API.\n\nEnv:\n  {s}     Optional bearer token for request auth.\n  ABI_WDBX_TLS_CERT       Path to PEM certificate (TLS config / proxy deployment).\n  ABI_WDBX_TLS_KEY        Path to PEM private key (TLS config / proxy deployment).\n\nTLS: native termination is not linked; deploy behind nginx/Caddy/haproxy.\n", .{env.WDBX_REST_TOKEN_ENV});
     return 0;
 }
 

--- a/src/cli/handlers/wdbx_runtime.zig
+++ b/src/cli/handlers/wdbx_runtime.zig
@@ -5,7 +5,7 @@ const foundation_time = @import("../../foundation/time.zig");
 
 const wdbx = features.wdbx;
 
-pub const CLUSTER_TOKEN_ENV = "ABI_WDBX_CLUSTER_TOKEN";
+pub const CLUSTER_TOKEN_ENV = env.WDBX_CLUSTER_TOKEN_ENV;
 pub const CLUSTER_PEERS_ENV = "ABI_WDBX_CLUSTER_PEERS";
 
 const ClusterConfig = struct {

--- a/src/cli/wiring.zig
+++ b/src/cli/wiring.zig
@@ -8,6 +8,7 @@ const reg = @import("registry.zig");
 const usage_mod = @import("usage.zig");
 const handlers = @import("handlers/mod.zig");
 const arg = @import("arg.zig");
+const env = @import("../foundation/env.zig");
 
 const Ctx = reg.Ctx;
 const Command = reg.Command;
@@ -121,7 +122,7 @@ pub const wdbx_subcommands = [_]Command{
     .{ .name = "compute", .summary = "Report CPU/GPU/NPU/TPU backend selection and fallback state.", .usage = "abi wdbx compute info" },
     .{ .name = "secure", .summary = "Demonstrate local compression plus reference homomorphic aggregation; not security-audited FHE.", .usage = "abi wdbx secure demo" },
     .{ .name = "gpu", .summary = "Report GPU backend capability and native-kernel status.", .usage = "abi wdbx gpu info" },
-    .{ .name = "api", .summary = "Serve the loopback WDBX REST API; bearer token via ABI_WDBX_REST_TOKEN; TLS via ABI_WDBX_TLS_CERT/KEY (proxy-terminated).", .usage = "abi wdbx api serve [port]" },
+    .{ .name = "api", .summary = "Serve the loopback WDBX REST API; bearer token via " ++ env.WDBX_REST_TOKEN_ENV ++ "; TLS via ABI_WDBX_TLS_CERT/KEY (proxy-terminated).", .usage = "abi wdbx api serve [port]" },
 };
 
 // --- Typed handlers ----------------------------------------------------------

--- a/src/features/tui/repl_complete.zig
+++ b/src/features/tui/repl_complete.zig
@@ -129,7 +129,7 @@ pub fn completePrompt(
         // to the in-process persona router with post-hoc chunked output.
         const model = state.config.model;
         const is_mlx = std.mem.startsWith(u8, model, "mlx/") or std.mem.startsWith(u8, model, "mlx-");
-        const env_key = if (is_mlx) "ABI_MLX_ENDPOINT" else "ABI_LLAMA_CPP_ENDPOINT";
+        const env_key = if (is_mlx) env.MLX_ENDPOINT_ENV else env.LLAMA_CPP_ENDPOINT_ENV;
         const override = env.get(env_key);
         const endpoint = local_bridge.endpointFor(model, override);
 

--- a/src/features/wdbx/durable_store.zig
+++ b/src/features/wdbx/durable_store.zig
@@ -24,8 +24,8 @@ const env = @import("../../foundation/env.zig");
 /// Home-dir env var name, Windows-aware (USERPROFILE vs HOME).
 const HOME_VAR = if (builtin.target.os.tag == .windows) "USERPROFILE" else "HOME";
 
-pub const PATH_ENV = "ABI_WDBX_PATH";
-pub const PERSIST_ENV = "ABI_WDBX_PERSIST";
+pub const PATH_ENV = env.WDBX_PATH_ENV;
+pub const PERSIST_ENV = env.WDBX_PERSIST_ENV;
 pub const MEMORY_SENTINEL = ":memory:";
 pub const DEFAULT_SUBPATH = ".abi/wdbx";
 

--- a/src/features/wdbx/rate_limiter.zig
+++ b/src/features/wdbx/rate_limiter.zig
@@ -26,8 +26,8 @@ const Lock = struct {
     }
 };
 
-pub const RATE_LIMIT_CAPACITY_ENV = "ABI_WDBX_RATE_LIMIT_CAPACITY";
-pub const RATE_LIMIT_REFILL_ENV = "ABI_WDBX_RATE_LIMIT_REFILL";
+pub const RATE_LIMIT_CAPACITY_ENV = env.WDBX_RATE_LIMIT_CAPACITY_ENV;
+pub const RATE_LIMIT_REFILL_ENV = env.WDBX_RATE_LIMIT_REFILL_ENV;
 
 /// Token-bucket rate limiter.
 ///

--- a/src/features/wdbx/rest_parse.zig
+++ b/src/features/wdbx/rest_parse.zig
@@ -3,7 +3,7 @@ const env = @import("../../foundation/env.zig");
 const foundation = @import("../../foundation/http.zig");
 const foundation_json = @import("../../foundation/json.zig");
 
-pub const REST_TOKEN_ENV = "ABI_WDBX_REST_TOKEN";
+pub const REST_TOKEN_ENV = env.WDBX_REST_TOKEN_ENV;
 
 pub const Response = struct {
     status: u16,
@@ -48,22 +48,7 @@ pub fn vectorParseErrorResponse(allocator: std.mem.Allocator, err: VectorParseEr
 }
 
 pub fn escapeJsonString(allocator: std.mem.Allocator, value: []const u8) ![]u8 {
-    var out: std.ArrayListUnmanaged(u8) = .empty;
-    errdefer out.deinit(allocator);
-    for (value) |byte| {
-        switch (byte) {
-            '"' => try out.appendSlice(allocator, "\\\""),
-            '\\' => try out.appendSlice(allocator, "\\\\"),
-            '\n' => try out.appendSlice(allocator, "\\n"),
-            '\r' => try out.appendSlice(allocator, "\\r"),
-            '\t' => try out.appendSlice(allocator, "\\t"),
-            0x08 => try out.appendSlice(allocator, "\\b"),
-            0x0c => try out.appendSlice(allocator, "\\f"),
-            0x00...0x07, 0x0b, 0x0e...0x1f => try out.print(allocator, "\\u{X:0>4}", .{byte}),
-            else => try out.append(allocator, byte),
-        }
-    }
-    return out.toOwnedSlice(allocator);
+    return foundation_json.escapeJsonStringRaw(allocator, value);
 }
 
 pub const strField = foundation_json.strField;

--- a/src/features/wdbx/stub.zig
+++ b/src/features/wdbx/stub.zig
@@ -3,6 +3,7 @@ const build_options = @import("build_options");
 const memory = @import("../../core/memory.zig");
 const gpu = if (build_options.feat_gpu) @import("../gpu/mod.zig") else @import("../gpu/stub.zig");
 const types = @import("stub_types.zig");
+const env = @import("../../foundation/env.zig");
 
 pub const MAX_LAYERS = types.MAX_LAYERS;
 pub const HNSW_DIMENSIONS = types.HNSW_DIMENSIONS;
@@ -37,8 +38,8 @@ pub const remote_compute = struct {};
 pub const rest = struct {};
 
 pub const tls_config = struct {
-    pub const TLS_CERT_ENV = "ABI_WDBX_TLS_CERT";
-    pub const TLS_KEY_ENV = "ABI_WDBX_TLS_KEY";
+    pub const TLS_CERT_ENV = env.WDBX_TLS_CERT_ENV;
+    pub const TLS_KEY_ENV = env.WDBX_TLS_KEY_ENV;
 
     pub const TlsConfig = struct {
         cert_path: []const u8 = "",

--- a/src/features/wdbx/tls_config.zig
+++ b/src/features/wdbx/tls_config.zig
@@ -25,8 +25,8 @@
 const std = @import("std");
 const env = @import("../../foundation/env.zig");
 
-pub const TLS_CERT_ENV = "ABI_WDBX_TLS_CERT";
-pub const TLS_KEY_ENV = "ABI_WDBX_TLS_KEY";
+pub const TLS_CERT_ENV = env.WDBX_TLS_CERT_ENV;
+pub const TLS_KEY_ENV = env.WDBX_TLS_KEY_ENV;
 
 /// TLS configuration loaded from environment variables.
 ///

--- a/src/foundation/env.zig
+++ b/src/foundation/env.zig
@@ -38,6 +38,23 @@ pub fn get(key: []const u8) ?[]const u8 {
     return if (v.len == 0) null else v;
 }
 
+// --- Canonical environment variable names (shared across MCP, WDBX REST, connectors) ---
+
+pub const MCP_HTTP_PORT_ENV = "ABI_MCP_HTTP_PORT";
+pub const MCP_HTTP_TOKEN_ENV = "ABI_MCP_HTTP_TOKEN";
+pub const WDBX_REST_TOKEN_ENV = "ABI_WDBX_REST_TOKEN";
+pub const WDBX_REST_PORT_ENV = "ABI_WDBX_REST_PORT";
+pub const WDBX_CLUSTER_TOKEN_ENV = "ABI_WDBX_CLUSTER_TOKEN";
+pub const WDBX_CLUSTER_PEERS_ENV = "ABI_WDBX_CLUSTER_PEERS";
+pub const WDBX_TLS_CERT_ENV = "ABI_WDBX_TLS_CERT";
+pub const WDBX_TLS_KEY_ENV = "ABI_WDBX_TLS_KEY";
+pub const WDBX_PATH_ENV = "ABI_WDBX_PATH";
+pub const WDBX_PERSIST_ENV = "ABI_WDBX_PERSIST";
+pub const WDBX_RATE_LIMIT_CAPACITY_ENV = "ABI_WDBX_RATE_LIMIT_CAPACITY";
+pub const WDBX_RATE_LIMIT_REFILL_ENV = "ABI_WDBX_RATE_LIMIT_REFILL";
+pub const LLAMA_CPP_ENDPOINT_ENV = "ABI_LLAMA_CPP_ENDPOINT";
+pub const MLX_ENDPOINT_ENV = "ABI_MLX_ENDPOINT";
+
 test "get reports unset before install" {
     // No install() in this unit-test process, so every key resolves to null.
     try std.testing.expect(get("ABI_DEFINITELY_UNSET_VAR_XYZ") == null);

--- a/src/foundation/json.zig
+++ b/src/foundation/json.zig
@@ -41,6 +41,27 @@ pub fn jsonStringAlloc(allocator: std.mem.Allocator, value: []const u8) ![]u8 {
     return try out.toOwnedSlice(allocator);
 }
 
+pub fn escapeJsonStringRaw(allocator: std.mem.Allocator, value: []const u8) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+    for (value) |byte| {
+        switch (byte) {
+            '"' => try out.appendSlice(allocator, "\\\""),
+            '\\' => try out.appendSlice(allocator, "\\\\"),
+            '\n' => try out.appendSlice(allocator, "\\n"),
+            '\r' => try out.appendSlice(allocator, "\\r"),
+            '\t' => try out.appendSlice(allocator, "\\t"),
+            0x00...0x07 => try out.print(allocator, "\\u{X:0>4}", .{byte}),
+            0x08 => try out.appendSlice(allocator, "\\b"),
+            0x0c => try out.appendSlice(allocator, "\\f"),
+            0x0b => try out.print(allocator, "\\u{X:0>4}", .{byte}),
+            0x0e...0x1f => try out.print(allocator, "\\u{X:0>4}", .{byte}),
+            else => try out.append(allocator, byte),
+        }
+    }
+    return try out.toOwnedSlice(allocator);
+}
+
 test "appendJsonString escapes metacharacters and control chars" {
     const allocator = std.testing.allocator;
 

--- a/src/mcp/http_transport.zig
+++ b/src/mcp/http_transport.zig
@@ -5,14 +5,15 @@ const rpc = @import("rpc.zig");
 const shutdown = @import("shutdown.zig");
 const parse = @import("http_parse.zig");
 const foundation_http = @import("abi").foundation.http;
+const foundation_env = @import("abi").foundation.env;
 
 const MAX_REQUEST_SIZE = protocol.MAX_REQUEST_SIZE;
 const isShutdownRequested = shutdown.isRequested;
 const processJsonRpc = rpc.processJsonRpc;
 
 const DEFAULT_HTTP_PORT: u16 = 8080;
-pub const HTTP_PORT_ENV = "ABI_MCP_HTTP_PORT";
-pub const HTTP_TOKEN_ENV = "ABI_MCP_HTTP_TOKEN";
+pub const HTTP_PORT_ENV = foundation_env.MCP_HTTP_PORT_ENV;
+pub const HTTP_TOKEN_ENV = foundation_env.MCP_HTTP_TOKEN_ENV;
 
 var configured_http_port: u16 = DEFAULT_HTTP_PORT;
 var configured_http_token: ?[]const u8 = null;


### PR DESCRIPTION
Centralize env var names in foundation/env.zig. Add escapeJsonStringRaw to foundation/json.zig for unquoted JSON escaping (used by WDBX REST). Remove duplicate escapeJsonString from rest_parse.zig. Update all consumers to use centralized constants.