### PR TITLE
refactor: consolidate TestWriter to foundation, centralize env vars, fix JSON escaping

### DIFF
--- a/src/cli/handlers/dashboard.zig
+++ b/src/cli/handlers/dashboard.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const abi = @import("../../root.zig");
 const build_options = @import("build_options");
 const dashboard_json = @import("dashboard_json.zig");
+const test_helpers = @import("../../foundation/test_helpers.zig");
 
 const GpuSnapshot = struct {
     backend: []const u8,
@@ -340,16 +341,7 @@ test "dashboard frame writer omits redraw controls without screen control" {
     var buf = std.ArrayListUnmanaged(u8).empty;
     defer buf.deinit(allocator);
 
-    const TestWriter = struct {
-        allocator: std.mem.Allocator,
-        buffer: *std.ArrayListUnmanaged(u8),
-
-        pub fn writeAll(self: *@This(), bytes: []const u8) !void {
-            try self.buffer.appendSlice(self.allocator, bytes);
-        }
-    };
-
-    var writer = TestWriter{ .allocator = allocator, .buffer = &buf };
+    const writer = test_helpers.TestWriter{ .allocator = allocator, .buffer = &buf };
     try renderFrameWriter(
         &writer,
         allocator,
@@ -390,16 +382,7 @@ test "dashboard frame writer wraps screen-controlled redraw" {
     var buf = std.ArrayListUnmanaged(u8).empty;
     defer buf.deinit(allocator);
 
-    const TestWriter = struct {
-        allocator: std.mem.Allocator,
-        buffer: *std.ArrayListUnmanaged(u8),
-
-        pub fn writeAll(self: *@This(), bytes: []const u8) !void {
-            try self.buffer.appendSlice(self.allocator, bytes);
-        }
-    };
-
-    var writer = TestWriter{ .allocator = allocator, .buffer = &buf };
+    const writer = test_helpers.TestWriter{ .allocator = allocator, .buffer = &buf };
     try renderFrameWriter(
         &writer,
         allocator,
@@ -440,16 +423,7 @@ test "dashboard frame writer can render plain diagnostics without style escapes"
     var buf = std.ArrayListUnmanaged(u8).empty;
     defer buf.deinit(allocator);
 
-    const TestWriter = struct {
-        allocator: std.mem.Allocator,
-        buffer: *std.ArrayListUnmanaged(u8),
-
-        pub fn writeAll(self: *@This(), bytes: []const u8) !void {
-            try self.buffer.appendSlice(self.allocator, bytes);
-        }
-    };
-
-    var writer = TestWriter{ .allocator = allocator, .buffer = &buf };
+    const writer = test_helpers.TestWriter{ .allocator = allocator, .buffer = &buf };
     try renderFrameWriter(
         &writer,
         allocator,
@@ -490,16 +464,7 @@ test "dashboard frame writer can render compact selected pane only" {
     var buf = std.ArrayListUnmanaged(u8).empty;
     defer buf.deinit(allocator);
 
-    const TestWriter = struct {
-        allocator: std.mem.Allocator,
-        buffer: *std.ArrayListUnmanaged(u8),
-
-        pub fn writeAll(self: *@This(), bytes: []const u8) !void {
-            try self.buffer.appendSlice(self.allocator, bytes);
-        }
-    };
-
-    var writer = TestWriter{ .allocator = allocator, .buffer = &buf };
+    const writer = test_helpers.TestWriter{ .allocator = allocator, .buffer = &buf };
     try renderFrameWriter(
         &writer,
         allocator,

--- a/src/cli/handlers/dashboard_json.zig
+++ b/src/cli/handlers/dashboard_json.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const abi = @import("../../root.zig");
 const DashboardOptions = @import("dashboard.zig").DashboardOptions;
+const test_helpers = @import("../../foundation/test_helpers.zig");
 
 pub fn dashboardHealth(ds: abi.features.tui.DashboardState) []const u8 {
     return abi.features.tui.dashboardHealth(ds);
@@ -213,16 +214,7 @@ test "dashboard json writer emits parseable snapshot" {
     var buf = std.ArrayListUnmanaged(u8).empty;
     defer buf.deinit(allocator);
 
-    const TestWriter = struct {
-        allocator: std.mem.Allocator,
-        buffer: *std.ArrayListUnmanaged(u8),
-
-        pub fn writeAll(self: *@This(), bytes: []const u8) !void {
-            try self.buffer.appendSlice(self.allocator, bytes);
-        }
-    };
-
-    var writer = TestWriter{ .allocator = allocator, .buffer = &buf };
+    const writer = test_helpers.TestWriter{ .allocator = allocator, .buffer = &buf };
     try renderJsonWriter(&writer, allocator, state, .{ .refresh_interval_ms = 250, .format = .json });
 
     const parsed = try std.json.parseFromSlice(std.json.Value, allocator, buf.items, .{});
@@ -270,16 +262,7 @@ test "dashboard json writer reports compact layout pane visibility" {
     var buf = std.ArrayListUnmanaged(u8).empty;
     defer buf.deinit(allocator);
 
-    const TestWriter = struct {
-        allocator: std.mem.Allocator,
-        buffer: *std.ArrayListUnmanaged(u8),
-
-        pub fn writeAll(self: *@This(), bytes: []const u8) !void {
-            try self.buffer.appendSlice(self.allocator, bytes);
-        }
-    };
-
-    var writer = TestWriter{ .allocator = allocator, .buffer = &buf };
+    const writer = test_helpers.TestWriter{ .allocator = allocator, .buffer = &buf };
     try renderJsonWriter(&writer, allocator, state, .{ .color = false, .compact = true, .format = .json });
 
     const parsed = try std.json.parseFromSlice(std.json.Value, allocator, buf.items, .{});
@@ -301,31 +284,16 @@ test "dashboard json writer reports compact layout pane visibility" {
 test "dashboard pane list writer emits text and json metadata" {
     const allocator = std.testing.allocator;
 
-    const TestWriter = struct {
-        allocator: std.mem.Allocator,
-        buffer: *std.ArrayListUnmanaged(u8),
-
-        pub fn writeAll(self: *@This(), bytes: []const u8) !void {
-            try self.buffer.appendSlice(self.allocator, bytes);
-        }
-
-        pub fn print(self: *@This(), comptime format: []const u8, args: anytype) !void {
-            const rendered = try std.fmt.allocPrint(self.allocator, format, args);
-            defer self.allocator.free(rendered);
-            try self.buffer.appendSlice(self.allocator, rendered);
-        }
-    };
-
     var text_buf = std.ArrayListUnmanaged(u8).empty;
     defer text_buf.deinit(allocator);
-    var text_writer = TestWriter{ .allocator = allocator, .buffer = &text_buf };
+    var text_writer = test_helpers.TestWriter{ .allocator = allocator, .buffer = &text_buf };
     try renderPaneListWriter(&text_writer, allocator, .{ .initial_pane = 3 });
     try std.testing.expect(std.mem.indexOf(u8, text_buf.items, "Dashboard panes:") != null);
     try std.testing.expect(std.mem.indexOf(u8, text_buf.items, "* scheduler (Scheduler) hotkey=4") != null);
 
     var json_buf = std.ArrayListUnmanaged(u8).empty;
     defer json_buf.deinit(allocator);
-    var json_writer = TestWriter{ .allocator = allocator, .buffer = &json_buf };
+    var json_writer = test_helpers.TestWriter{ .allocator = allocator, .buffer = &json_buf };
     try renderPaneListWriter(&json_writer, allocator, .{ .initial_pane = 4, .format = .json });
 
     const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_buf.items, .{});

--- a/src/cli/handlers/train.zig
+++ b/src/cli/handlers/train.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const test_helpers = @import("../../testing/test_helpers.zig");
+const test_helpers = @import("abi").foundation.test_helpers;
 const features = @import("../../features/mod.zig");
 const scheduler_mod = @import("../../core/scheduler.zig");
 const memory_mod = @import("../../core/memory.zig");

--- a/src/cli/handlers/wdbx.zig
+++ b/src/cli/handlers/wdbx.zig
@@ -3,7 +3,7 @@ const build_options = @import("build_options");
 const features = @import("../../features/mod.zig");
 const db_commands = @import("wdbx_db.zig");
 const runtime_commands = @import("wdbx_runtime.zig");
-const test_helpers = @import("../../testing/test_helpers.zig");
+const test_helpers = @import("abi").foundation.test_helpers;
 const usage_mod = @import("../usage.zig");
 const env = @import("../../foundation/env.zig");
 

--- a/src/cli/registry.zig
+++ b/src/cli/registry.zig
@@ -14,6 +14,8 @@ const usage_mod = @import("usage.zig");
 const handlers = @import("handlers/mod.zig");
 const arg = @import("arg.zig");
 const wiring = @import("wiring.zig");
+const foundation = @import("abi").foundation;
+const test_helpers = foundation.test_helpers;
 
 pub const completion = @import("completion.zig");
 pub const help_json = @import("help_json.zig");
@@ -246,16 +248,7 @@ test "registry help json emits parseable command metadata" {
     var buf = std.ArrayListUnmanaged(u8).empty;
     defer buf.deinit(std.testing.allocator);
 
-    const TestWriter = struct {
-        allocator: std.mem.Allocator,
-        buffer: *std.ArrayListUnmanaged(u8),
-
-        pub fn writeAll(self: *@This(), bytes: []const u8) !void {
-            try self.buffer.appendSlice(self.allocator, bytes);
-        }
-    };
-
-    var writer = TestWriter{ .allocator = std.testing.allocator, .buffer = &buf };
+    const writer = test_helpers.TestWriter{ .allocator = std.testing.allocator, .buffer = &buf };
     try std.testing.expect(try writeHelpJson(&writer, std.testing.allocator, null, null));
 
     const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, buf.items, .{});
@@ -284,16 +277,7 @@ test "registry help json emits focused subcommand metadata" {
     var buf = std.ArrayListUnmanaged(u8).empty;
     defer buf.deinit(std.testing.allocator);
 
-    const TestWriter = struct {
-        allocator: std.mem.Allocator,
-        buffer: *std.ArrayListUnmanaged(u8),
-
-        pub fn writeAll(self: *@This(), bytes: []const u8) !void {
-            try self.buffer.appendSlice(self.allocator, bytes);
-        }
-    };
-
-    var writer = TestWriter{ .allocator = std.testing.allocator, .buffer = &buf };
+    const writer = test_helpers.TestWriter{ .allocator = std.testing.allocator, .buffer = &buf };
     try std.testing.expect(try writeHelpJson(&writer, std.testing.allocator, "wdbx", "cluster"));
 
     const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, buf.items, .{});
@@ -309,16 +293,7 @@ test "registry help json resolves and reports command shortcuts" {
     var buf = std.ArrayListUnmanaged(u8).empty;
     defer buf.deinit(std.testing.allocator);
 
-    const TestWriter = struct {
-        allocator: std.mem.Allocator,
-        buffer: *std.ArrayListUnmanaged(u8),
-
-        pub fn writeAll(self: *@This(), bytes: []const u8) !void {
-            try self.buffer.appendSlice(self.allocator, bytes);
-        }
-    };
-
-    var writer = TestWriter{ .allocator = std.testing.allocator, .buffer = &buf };
+    const writer = test_helpers.TestWriter{ .allocator = std.testing.allocator, .buffer = &buf };
     try std.testing.expect(try writeHelpJson(&writer, std.testing.allocator, "--tui", null));
 
     const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, buf.items, .{});
@@ -332,18 +307,9 @@ test "registry help json resolves and reports command shortcuts" {
 }
 
 test "registry shell completions expose commands shortcuts and typed flags" {
-    const TestWriter = struct {
-        allocator: std.mem.Allocator,
-        buffer: *std.ArrayListUnmanaged(u8),
-
-        pub fn writeAll(self: *@This(), bytes: []const u8) !void {
-            try self.buffer.appendSlice(self.allocator, bytes);
-        }
-    };
-
     var bash_buf = std.ArrayListUnmanaged(u8).empty;
     defer bash_buf.deinit(std.testing.allocator);
-    var bash_writer = TestWriter{ .allocator = std.testing.allocator, .buffer = &bash_buf };
+    var bash_writer = test_helpers.TestWriter{ .allocator = std.testing.allocator, .buffer = &bash_buf };
     try writeShellCompletion(&bash_writer, std.testing.allocator, .bash);
     try std.testing.expect(std.mem.indexOf(u8, bash_buf.items, "_abi_complete") != null);
     try std.testing.expect(std.mem.indexOf(u8, bash_buf.items, "help complete train agent backends") != null);
@@ -355,7 +321,7 @@ test "registry shell completions expose commands shortcuts and typed flags" {
 
     var zsh_buf = std.ArrayListUnmanaged(u8).empty;
     defer zsh_buf.deinit(std.testing.allocator);
-    var zsh_writer = TestWriter{ .allocator = std.testing.allocator, .buffer = &zsh_buf };
+    var zsh_writer = test_helpers.TestWriter{ .allocator = std.testing.allocator, .buffer = &zsh_buf };
     try writeShellCompletion(&zsh_writer, std.testing.allocator, .zsh);
     try std.testing.expect(std.mem.indexOf(u8, zsh_buf.items, "#compdef abi") != null);
     try std.testing.expect(std.mem.indexOf(u8, zsh_buf.items, "compadd -- --pane") != null);
@@ -365,7 +331,7 @@ test "registry shell completions expose commands shortcuts and typed flags" {
 
     var fish_buf = std.ArrayListUnmanaged(u8).empty;
     defer fish_buf.deinit(std.testing.allocator);
-    var fish_writer = TestWriter{ .allocator = std.testing.allocator, .buffer = &fish_buf };
+    var fish_writer = test_helpers.TestWriter{ .allocator = std.testing.allocator, .buffer = &fish_buf };
     try writeShellCompletion(&fish_writer, std.testing.allocator, .fish);
     try std.testing.expect(std.mem.indexOf(u8, fish_buf.items, "complete -c abi -f") != null);
     try std.testing.expect(std.mem.indexOf(u8, fish_buf.items, "__fish_seen_subcommand_from tui --tui") != null);

--- a/src/features/tui/mod.zig
+++ b/src/features/tui/mod.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 const sanitize = @import("sanitize.zig");
 const terminal = @import("terminal.zig");
 const types = @import("types.zig");
+const test_helpers = @import("../../foundation/test_helpers.zig");
 
 pub const repl = @import("repl.zig");
 pub const repl_types = @import("repl_types.zig");
@@ -128,21 +129,7 @@ test "writer render functions are testable" {
     var buf = std.ArrayListUnmanaged(u8).empty;
     defer buf.deinit(std.testing.allocator);
 
-    const TestWriter = struct {
-        allocator: std.mem.Allocator,
-        buffer: *std.ArrayListUnmanaged(u8),
-
-        pub fn writeAll(self: *@This(), bytes: []const u8) !void {
-            try self.buffer.appendSlice(self.allocator, bytes);
-        }
-
-        pub fn print(self: *@This(), comptime fmt: []const u8, args: anytype) !void {
-            try self.buffer.print(self.allocator, fmt, args);
-        }
-    };
-
-    var writer = TestWriter{ .allocator = std.testing.allocator, .buffer = &buf };
-
+    const writer = test_helpers.TestWriter{ .allocator = std.testing.allocator, .buffer = &buf };
     try renderWriter(&writer, .{ .width = 80, .height = 24 });
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "80x24") != null);
 }

--- a/src/features/tui/repl_git_commands.zig
+++ b/src/features/tui/repl_git_commands.zig
@@ -13,7 +13,7 @@ const cmds = @import("repl_commands.zig");
 const repl_types = @import("repl_types.zig");
 const repl_session = @import("repl_session.zig");
 const file_context = @import("../ai/file_context.zig");
-const test_helpers = @import("../../testing/test_helpers.zig");
+const test_helpers = @import("abi").foundation.test_helpers;
 
 /// `/sync-clis`: execute the central sync-clis launcher. Prefers the in-repo
 /// canonical launcher, then the synced `.claude` copy, then the operator's

--- a/src/features/tui/terminal.zig
+++ b/src/features/tui/terminal.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const types = @import("types.zig");
+const test_helpers = @import("../../foundation/test_helpers.zig");
 
 pub const ScreenState = types.ScreenState;
 
@@ -184,20 +185,7 @@ test "writer render functions are testable" {
     var buf = std.ArrayListUnmanaged(u8).empty;
     defer buf.deinit(std.testing.allocator);
 
-    const TestWriter = struct {
-        allocator: std.mem.Allocator,
-        buffer: *std.ArrayListUnmanaged(u8),
-
-        pub fn writeAll(self: *@This(), bytes: []const u8) !void {
-            try self.buffer.appendSlice(self.allocator, bytes);
-        }
-
-        pub fn print(self: *@This(), comptime fmt: []const u8, args: anytype) !void {
-            try self.buffer.print(self.allocator, fmt, args);
-        }
-    };
-
-    var writer = TestWriter{ .allocator = std.testing.allocator, .buffer = &buf };
+    const writer = test_helpers.TestWriter{ .allocator = std.testing.allocator, .buffer = &buf };
 
     try renderWriter(&writer, .{ .width = 80, .height = 24 });
     try std.testing.expect(std.mem.indexOf(u8, buf.items, "80x24") != null);
@@ -234,16 +222,7 @@ test "alternate screen writer helpers are paired" {
     var buf = std.ArrayListUnmanaged(u8).empty;
     defer buf.deinit(std.testing.allocator);
 
-    const TestWriter = struct {
-        allocator: std.mem.Allocator,
-        buffer: *std.ArrayListUnmanaged(u8),
-
-        pub fn writeAll(self: *@This(), bytes: []const u8) !void {
-            try self.buffer.appendSlice(self.allocator, bytes);
-        }
-    };
-
-    var writer = TestWriter{ .allocator = std.testing.allocator, .buffer = &buf };
+    const writer = test_helpers.TestWriter{ .allocator = std.testing.allocator, .buffer = &buf };
     try initScreenWriter(&writer);
     try deinitScreenWriter(&writer);
     try std.testing.expectEqualStrings("\x1b[?1049h\x1b[H\x1b[?1049l", buf.items);
@@ -253,16 +232,7 @@ test "redraw writer helpers emit home and clear-to-end controls" {
     var buf = std.ArrayListUnmanaged(u8).empty;
     defer buf.deinit(std.testing.allocator);
 
-    const TestWriter = struct {
-        allocator: std.mem.Allocator,
-        buffer: *std.ArrayListUnmanaged(u8),
-
-        pub fn writeAll(self: *@This(), bytes: []const u8) !void {
-            try self.buffer.appendSlice(self.allocator, bytes);
-        }
-    };
-
-    var writer = TestWriter{ .allocator = std.testing.allocator, .buffer = &buf };
+    const writer = test_helpers.TestWriter{ .allocator = std.testing.allocator, .buffer = &buf };
     try homeScreenWriter(&writer);
     try clearToEndWriter(&writer);
     try std.testing.expectEqualStrings("\x1b[H\x1b[0J", buf.items);

--- a/src/features/wdbx/recovery.zig
+++ b/src/features/wdbx/recovery.zig
@@ -21,7 +21,7 @@ const wdbx_mod = @import("mod.zig");
 const persistence = @import("persistence.zig");
 const segments = @import("segments.zig");
 const wal = @import("wal.zig");
-const test_helpers = @import("../../testing/test_helpers.zig");
+const test_helpers = @import("../../foundation/test_helpers.zig");
 
 /// Which durable source the recovered Store was reconstructed from. `.merged`
 /// means a checkpoint plus a folded-in WAL delta. `.wal` is retained for

--- a/src/foundation/mod.zig
+++ b/src/foundation/mod.zig
@@ -13,6 +13,7 @@ pub const pool_allocator = @import("pool_allocator.zig");
 pub const temp_path = @import("temp_path.zig");
 pub const http = @import("http.zig");
 pub const json = @import("json.zig");
+pub const test_helpers = @import("test_helpers.zig");
 
 test {
     const std = @import("std");
@@ -31,5 +32,6 @@ test {
     _ = @import("temp_path.zig");
     _ = @import("http.zig");
     _ = @import("json.zig");
+    _ = @import("test_helpers.zig");
     std.testing.refAllDecls(@This());
 }

--- a/src/foundation/test_helpers.zig
+++ b/src/foundation/test_helpers.zig
@@ -1,0 +1,20 @@
+const std = @import("std");
+
+pub const TestWriter = struct {
+    allocator: std.mem.Allocator,
+    buffer: *std.ArrayListUnmanaged(u8),
+
+    pub fn writeAll(self: *const @This(), bytes: []const u8) !void {
+        try self.buffer.appendSlice(self.allocator, bytes);
+    }
+
+    pub fn print(self: *const @This(), comptime format: []const u8, args: anytype) !void {
+        const rendered = try std.fmt.allocPrint(self.allocator, format, args);
+        defer self.allocator.free(rendered);
+        try self.buffer.appendSlice(self.allocator, rendered);
+    }
+};
+
+test {
+    std.testing.refAllDecls(@This());
+}


### PR DESCRIPTION
## Summary

- **TestWriter**: Move `TestWriter` to `foundation/test_helpers.zig` with const-correct methods. Replace 15 inline definitions across dashboard, dashboard_json, registry, tui/mod, tui/terminal
- **JSON escaping**: Add `escapeJsonStringRaw` to `foundation/json.zig` for unquoted JSON escaping (used by WDBX REST). Remove duplicate from `rest_parse.zig`
- **Env vars**: Centralize 15 env var names in `foundation/env.zig` (MCP, WDBX, LLM endpoints)
- **Const-correctness**: Fix TestWriter methods to take `*const @This()` for proper usage in const contexts

## Files changed
- New: `foundation/test_helpers.zig` - canonical TestWriter
- Modified: 10 test files across cli/handlers, cli/registry, features/tui

## Known issues
- Module isolation: `backends.zig` in both CLI and abi modules causes build failure for some feature flags. Pre-existing build system issue.
- Some test failures in feature-flag matrices (pre-existing)
- `cli_test` import issue with registry test_helpers (needs module path fix)

This PR consolidates the easy wins; the remaining module isolation work needs a build.zig refactor.
