### PR TITLE
feat(gpu): claim-honest backend reporting and stub honesty

### DIFF
--- a/src/cli/handlers/backends.zig
+++ b/src/cli/handlers/backends.zig
@@ -78,10 +78,15 @@ pub fn handleBackends() !u8 {
         if (native_gpu.linked) "\x1b[32mlinked\x1b[0m" else "\x1b[90mnot linked\x1b[0m",
         native_gpu.message,
     });
-    std.debug.print("  Accelerator     training \x1b[90m→\x1b[0m {s}  (gpu={s} native={s})\n", .{
+    std.debug.print("  Backend matrix  {d} declared backends (see capability report)\n", .{
+        features.gpu.backendMatrix().len,
+    });
+    std.debug.print("{s}\n", .{gpu_report});
+    std.debug.print("  Accelerator     training \x1b[90m→\x1b[0m {s}  (gpu={s} native={s} native_dispatch={s})\n", .{
         features.accelerator.backendName(training.selected_backend),
         if (training.gpu_available) "\x1b[32m✓\x1b[0m" else "\x1b[90m○\x1b[0m",
         if (training.native_available) "\x1b[32m✓\x1b[0m" else "\x1b[90m○\x1b[0m",
+        if (training.native_dispatch) "\x1b[32mtrue\x1b[0m" else "\x1b[90mfalse\x1b[0m",
     });
     std.debug.print("  Shaders         {s}  {s}\n", .{
         features.shaders.languageName(shader.language),

--- a/src/features/accelerator/mod.zig
+++ b/src/features/accelerator/mod.zig
@@ -71,6 +71,7 @@ pub fn selectBackend(workload: Workload) Selection {
 
 pub fn selectionReport(workload: Workload) SelectionReport {
     const gpu_status = gpu.detectBackend();
+    const native_kernels = gpu.nativeKernelStatus();
     if (gpu_status.available and gpu_status.accelerated) {
         const gpu_backend: Backend = switch (gpu_status.backend) {
             .simulated => .gpu_simulated,
@@ -85,10 +86,14 @@ pub fn selectionReport(workload: Workload) SelectionReport {
             .workload = workload,
             .selected_backend = gpu_backend,
             .fallback_backend = fallbackBackend(workload),
-            .native_available = true,
+            .native_available = native_kernels.linked,
+            .native_dispatch = false,
             .gpu_available = true,
             .gpu_accelerated = true,
-            .message = gpu_status.message,
+            .message = if (native_kernels.linked)
+                gpu_status.message
+            else
+                "GPU backend selected via feat-gpu; native accelerator dispatch is not linked in this module",
         };
     }
 
@@ -98,6 +103,7 @@ pub fn selectionReport(workload: Workload) SelectionReport {
             .selected_backend = .gpu_simulated,
             .fallback_backend = fallbackBackend(workload),
             .native_available = false,
+            .native_dispatch = false,
             .gpu_available = true,
             .gpu_accelerated = false,
             .message = gpu_status.message,
@@ -110,27 +116,30 @@ pub fn selectionReport(workload: Workload) SelectionReport {
             .selected_backend = .mlir,
             .fallback_backend = .cpu,
             .native_available = false,
+            .native_dispatch = false,
             .gpu_available = false,
             .gpu_accelerated = false,
-            .message = "MLIR textual lowering selected with CPU execution fallback",
+            .message = "MLIR textual lowering selected; native accelerator dispatch is not linked",
         },
         .shader_compile => .{
             .workload = workload,
             .selected_backend = .gpu_simulated,
             .fallback_backend = .cpu,
             .native_available = false,
+            .native_dispatch = false,
             .gpu_available = false,
             .gpu_accelerated = false,
-            .message = "Zig shader validation selected with deterministic GPU metadata",
+            .message = "Shader validation selected; external compiler toolchains are not linked",
         },
         .inference, .training => .{
             .workload = workload,
             .selected_backend = .gpu_simulated,
             .fallback_backend = .cpu,
             .native_available = false,
+            .native_dispatch = false,
             .gpu_available = false,
             .gpu_accelerated = false,
-            .message = "Vectorized CPU accelerator selected for deterministic execution",
+            .message = "Vectorized CPU accelerator selected; native CUDA/NPU/TPU dispatch is not linked",
         },
     };
 }
@@ -165,9 +174,30 @@ test "accelerator selection report exposes fallback and native status" {
     try std.testing.expect(backendName(report.selected_backend).len > 0);
     try std.testing.expect(backendName(report.fallback_backend).len > 0);
     try std.testing.expectEqualStrings("graph-lowering", workloadName(report.workload));
+    try std.testing.expect(!report.native_dispatch);
     if (report.native_available) {
         try std.testing.expect(isAccelerated(.{ .backend = report.selected_backend, .workload = report.workload, .message = report.message }));
     } else {
         try std.testing.expect(!report.gpu_accelerated);
     }
+}
+
+test "accelerator never claims native dispatch in this module" {
+    inline for (std.meta.fields(Workload)) |field| {
+        const workload: Workload = @enumFromInt(@intFromEnum(@field(Workload, field.name)));
+        const report = selectionReport(workload);
+        try std.testing.expect(!report.native_dispatch);
+        try std.testing.expect(report.message.len > 0);
+    }
+}
+
+test "accelerator shader and graph workloads disclose no linked toolchain when gpu fallback" {
+    const gpu_status = gpu.detectBackend();
+    if (gpu_status.available and gpu_status.accelerated) return;
+
+    const shader = selectionReport(.shader_compile);
+    try std.testing.expect(std.mem.indexOf(u8, shader.message, "not linked") != null);
+
+    const graph = selectionReport(.graph_lowering);
+    try std.testing.expect(std.mem.indexOf(u8, graph.message, "not linked") != null);
 }

--- a/src/features/accelerator/stub.zig
+++ b/src/features/accelerator/stub.zig
@@ -28,6 +28,7 @@ pub const SelectionReport = struct {
     selected_backend: Backend,
     fallback_backend: Backend,
     native_available: bool,
+    native_dispatch: bool,
     gpu_available: bool,
     gpu_accelerated: bool,
     message: []const u8,
@@ -71,9 +72,10 @@ pub fn selectionReport(workload: Workload) SelectionReport {
         .selected_backend = .cpu,
         .fallback_backend = .cpu,
         .native_available = false,
+        .native_dispatch = false,
         .gpu_available = false,
         .gpu_accelerated = false,
-        .message = "accelerator feature is disabled; using CPU",
+        .message = "accelerator feature is disabled; native_dispatch=false; using CPU",
     };
 }
 
@@ -93,7 +95,9 @@ test "accelerator stub reports explicit disabled fallback" {
     try std.testing.expectEqual(Backend.cpu, report.selected_backend);
     try std.testing.expectEqual(Backend.cpu, report.fallback_backend);
     try std.testing.expect(!report.native_available);
+    try std.testing.expect(!report.native_dispatch);
     try std.testing.expect(!report.gpu_available);
     try std.testing.expect(!report.gpu_accelerated);
     try std.testing.expectEqualStrings("training", workloadName(report.workload));
+    try std.testing.expect(std.mem.indexOf(u8, report.message, "native_dispatch=false") != null);
 }

--- a/src/features/gpu/compute_api.zig
+++ b/src/features/gpu/compute_api.zig
@@ -50,53 +50,24 @@ pub const BackendAvailability = struct {
 };
 
 /// Per-backend availability matrix — the truthful answer to "what actually runs
-/// here". Order is preference-descending for the native accelerators.
-pub fn backendMatrix() [6]BackendAvailability {
-    const on_macos = builtin.target.os.tag == .macos;
-    const metal_live = on_macos and metal.g_metal_context.initialized;
-    return .{
-        .{
-            .backend = .metal,
-            .available = on_macos,
-            .dispatches = metal_live,
-            .reason = if (metal_live)
-                "Metal compute pipelines initialized; dispatching on the GPU"
-            else if (on_macos)
-                "macOS detected; Metal context not yet initialized (call GpuCompute.init)"
-            else
-                "not macOS; Metal unavailable",
-        },
-        .{
-            .backend = .vulkan,
-            .available = false,
-            .dispatches = false,
-            .reason = "Vulkan needs a loader/ICD (e.g. MoltenVK on macOS) and SPIR-V shaders; not linked",
-        },
-        .{
-            .backend = .cuda,
-            .available = false,
-            .dispatches = false,
-            .reason = "CUDA needs the NVIDIA toolkit + an NVIDIA GPU; not linked",
-        },
-        .{
-            .backend = .opengl,
-            .available = false,
-            .dispatches = false,
-            .reason = "OpenGL compute needs >=4.3; macOS caps at 4.1 (no compute shaders); not linked",
-        },
-        .{
-            .backend = .webgpu,
-            .available = false,
-            .dispatches = false,
-            .reason = "WebGPU needs a wgpu/Dawn runtime; not linked",
-        },
-        .{
-            .backend = .simulated,
-            .available = true,
-            .dispatches = true,
-            .reason = "vectorized (@Vector) CPU path; always available",
-        },
-    };
+/// here". Order matches `backendCapabilitiesList()` for consistent reporting.
+pub fn backendMatrix() [7]BackendAvailability {
+    const caps = backends.backendCapabilitiesList();
+    var matrix: [7]BackendAvailability = undefined;
+    for (caps, 0..) |cap, i| {
+        const dispatches = switch (cap.backend) {
+            .simulated => true,
+            .metal => cap.native_kernels,
+            else => false,
+        };
+        matrix[i] = .{
+            .backend = cap.backend,
+            .available = cap.available,
+            .dispatches = dispatches,
+            .reason = cap.message,
+        };
+    }
+    return matrix;
 }
 
 /// Backend-agnostic compute handle. `init` selects the best backend that truly
@@ -215,10 +186,12 @@ pub const GpuCompute = struct {
 
 const testing = std.testing;
 
-test "compute_api: backend matrix is honest (cpu fallback always dispatches; vulkan/opengl gated)" {
+test "compute_api: backend matrix is honest (cpu fallback always dispatches; stubs gated)" {
     const m = backendMatrix();
+    try testing.expectEqual(@as(usize, 7), m.len);
     var saw_cpu_fallback = false;
     var saw_metal = false;
+    var saw_webgl2 = false;
     for (m) |entry| {
         switch (entry.backend) {
             .simulated => {
@@ -228,17 +201,27 @@ test "compute_api: backend matrix is honest (cpu fallback always dispatches; vul
             .metal => {
                 saw_metal = true;
                 // Metal only "dispatches" when actually initialized on macOS.
-                if (builtin.target.os.tag != .macos) try testing.expect(!entry.dispatches);
+                if (builtin.target.os.tag != .macos) {
+                    try testing.expect(!entry.available);
+                    try testing.expect(!entry.dispatches);
+                }
+            },
+            .webgl2 => {
+                saw_webgl2 = true;
+                try testing.expect(!entry.available);
+                try testing.expect(!entry.dispatches);
+                try testing.expect(entry.reason.len > 0);
             },
             .vulkan, .opengl, .cuda, .webgpu => {
                 // Declared but not dispatching here — must not claim execution.
+                try testing.expect(!entry.available);
                 try testing.expect(!entry.dispatches);
                 try testing.expect(entry.reason.len > 0);
             },
             else => {},
         }
     }
-    try testing.expect(saw_cpu_fallback and saw_metal);
+    try testing.expect(saw_cpu_fallback and saw_metal and saw_webgl2);
 }
 
 test "compute_api: reduce matches scalar reference on the active backend" {

--- a/src/features/gpu/mod.zig
+++ b/src/features/gpu/mod.zig
@@ -24,6 +24,9 @@ pub const backendCapabilitiesList = backends.backendCapabilitiesList;
 pub const detectBackend = backends.detectBackend;
 pub const nativeKernelStatus = backends.nativeKernelStatus;
 pub const threadsPerGroup = backends.threadsPerGroup;
+pub const preferredBackend = backends.preferredBackend;
+pub const PresenceProbe = backends.PresenceProbe;
+pub const presenceProbe = backends.presenceProbe;
 
 // ---- Function re-exports from vector_ops ----
 pub const VectorOps = vector_ops.VectorOps;
@@ -33,7 +36,6 @@ pub const vectorOps = vector_ops.vectorOps;
 // ---- Function re-exports from reporting ----
 pub const backendStatusReport = reporting.backendStatusReport;
 pub const isAvailable = reporting.isAvailable;
-pub const preferredBackend = reporting.preferredBackend;
 
 // Parent GPU compute API: one backend-agnostic facade (Metal-real + CPU
 // fallback) with an honest per-backend availability matrix.

--- a/src/features/gpu/reporting.zig
+++ b/src/features/gpu/reporting.zig
@@ -28,13 +28,7 @@ pub fn isAvailable() bool {
 }
 
 pub fn preferredBackend() backends.Backend {
-    if (builtin.target.os.tag == .macos) {
-        return .metal;
-    }
-    if (builtin.target.os.tag == .linux or builtin.target.os.tag == .windows) {
-        return .vulkan;
-    }
-    return .simulated;
+    return backends.preferredBackend();
 }
 
 test "gpu backend capability report covers all registered backends" {
@@ -43,8 +37,23 @@ test "gpu backend capability report covers all registered backends" {
     try std.testing.expectEqual(backends.Backend.simulated, caps[0].backend);
     const report = try backendStatusReport(std.testing.allocator);
     defer std.testing.allocator.free(report);
-    try std.testing.expect(std.mem.indexOf(u8, report, "cuda:") != null);
-    try std.testing.expect(std.mem.indexOf(u8, report, "webgpu:") != null);
+    for (.{ "cuda:", "webgpu:", "webgl2:", "vulkan:", "opengl:" }) |needle| {
+        try std.testing.expect(std.mem.indexOf(u8, report, needle) != null);
+    }
+    for (caps) |cap| {
+        switch (cap.backend) {
+            .vulkan, .cuda, .webgpu, .opengl, .webgl2 => {
+                try std.testing.expect(!cap.available);
+                try std.testing.expect(!cap.accelerated);
+                try std.testing.expect(!cap.native_kernels);
+            },
+            else => {},
+        }
+    }
+}
+
+test "preferred backend agrees with detectBackend" {
+    try std.testing.expectEqual(preferredBackend(), backends.detectBackend().backend);
 }
 
 test {

--- a/src/features/gpu/stub.zig
+++ b/src/features/gpu/stub.zig
@@ -166,6 +166,22 @@ pub fn preferredBackend() Backend {
     return .simulated;
 }
 
+pub const PresenceProbe = struct {
+    backend: Backend,
+    declared: bool,
+    native_linked: bool,
+    note: []const u8,
+};
+
+pub fn presenceProbe(backend: Backend) PresenceProbe {
+    return .{
+        .backend = backend,
+        .declared = true,
+        .native_linked = false,
+        .note = "GPU feature is disabled; native dispatch not linked",
+    };
+}
+
 pub fn executeKernel(spec: KernelSpec) !KernelResult {
     if (spec.name.len == 0) return error.InvalidKernelName;
     return .{
@@ -193,14 +209,15 @@ pub const BackendAvailability = struct {
     reason: []const u8,
 };
 
-pub fn backendMatrix() [6]BackendAvailability {
+pub fn backendMatrix() [7]BackendAvailability {
     return .{
+        .{ .backend = .simulated, .available = true, .dispatches = true, .reason = "GPU feature disabled; vectorized CPU path" },
         .{ .backend = .metal, .available = false, .dispatches = false, .reason = "GPU feature is disabled" },
         .{ .backend = .vulkan, .available = false, .dispatches = false, .reason = "GPU feature is disabled" },
         .{ .backend = .cuda, .available = false, .dispatches = false, .reason = "GPU feature is disabled" },
-        .{ .backend = .opengl, .available = false, .dispatches = false, .reason = "GPU feature is disabled" },
         .{ .backend = .webgpu, .available = false, .dispatches = false, .reason = "GPU feature is disabled" },
-        .{ .backend = .simulated, .available = true, .dispatches = true, .reason = "GPU feature disabled; vectorized CPU path" },
+        .{ .backend = .opengl, .available = false, .dispatches = false, .reason = "GPU feature is disabled" },
+        .{ .backend = .webgl2, .available = false, .dispatches = false, .reason = "GPU feature is disabled" },
     };
 }
 

--- a/src/features/mlir/mod.zig
+++ b/src/features/mlir/mod.zig
@@ -144,7 +144,11 @@ test "mlir lowering emits structured textual IR" {
     try std.testing.expect(std.mem.indexOf(u8, result.ir, "abi.name = \"matmul\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.ir, "abi.ops = 1") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.ir, "abi.checksum = \"") != null);
-    try std.testing.expect(!toolchainStatus().available);
+    const status = toolchainStatus();
+    try std.testing.expect(!status.available);
+    try std.testing.expectEqualStrings("textual-local", status.backend);
+    try std.testing.expect(std.mem.indexOf(u8, status.message, "not linked") != null);
+    try std.testing.expectEqualStrings("textual-local", result.target_backend);
 }
 
 test "mlir lowering validates symbols and escapes operation attributes" {

--- a/src/features/mlir/stub.zig
+++ b/src/features/mlir/stub.zig
@@ -108,6 +108,9 @@ test "mlir stub validates module shape before disabled lowering" {
     const result = try lower(std.testing.allocator, .{ .name = "train", .operations = &.{"matmul"} });
     defer result.deinit(std.testing.allocator);
     try std.testing.expectEqualStrings("disabled", result.target_backend);
+    const status = toolchainStatus();
+    try std.testing.expect(!status.available);
+    try std.testing.expectEqualStrings("disabled", status.backend);
     const analysis = try analyze(.{ .name = "train", .operations = &.{"matmul"} });
     try std.testing.expectEqual(@as(usize, 1), analysis.operation_count);
     try std.testing.expect(analysis.checksum != 0);

--- a/src/features/shaders/mod.zig
+++ b/src/features/shaders/mod.zig
@@ -148,7 +148,9 @@ test "shader compiler validates source" {
     try std.testing.expect(std.mem.indexOf(u8, artifact.bytes, "shader=copy") != null);
     try std.testing.expectEqualStrings("main", artifact.entry_point);
     try std.testing.expect(std.mem.indexOf(u8, artifact.bytes, "validated-local") != null);
-    try std.testing.expect(!compilerStatus().available);
+    const status = compilerStatus();
+    try std.testing.expect(!status.available);
+    try std.testing.expect(std.mem.indexOf(u8, status.message, "not linked") != null);
 }
 
 test "shader compiler reports entry point and checksum by language" {

--- a/src/features/shaders/stub.zig
+++ b/src/features/shaders/stub.zig
@@ -140,4 +140,7 @@ test "shader stub mirrors validation before disabled artifact" {
     defer artifact.deinit(std.testing.allocator);
     try std.testing.expectEqualStrings("disabled", artifact.backend);
     try std.testing.expectEqualStrings("main", artifact.entry_point);
+    const status = compilerStatus();
+    try std.testing.expect(!status.available);
+    try std.testing.expectEqualStrings("disabled", status.backend);
 }

--- a/tests/contracts/feature_modules.zig
+++ b/tests/contracts/feature_modules.zig
@@ -75,6 +75,7 @@ test "feature modules expose safe runtime contracts" {
     try std.testing.expect(features.accelerator.backendName(accelerator_report.selected_backend).len > 0);
     try std.testing.expect(features.accelerator.backendName(accelerator_report.fallback_backend).len > 0);
     try std.testing.expect(accelerator_report.message.len > 0);
+    try std.testing.expect(!accelerator_report.native_dispatch);
     if (accelerator_report.native_available) {
         try std.testing.expect(features.accelerator.isAccelerated(accelerator_selection));
     } else {
@@ -82,6 +83,7 @@ test "feature modules expose safe runtime contracts" {
     }
 
     try std.testing.expect(features.shaders.compilerStatus().message.len > 0);
+    try std.testing.expect(!features.shaders.compilerStatus().available);
     try std.testing.expect(@hasDecl(features.shaders, "ValidationReport"));
     try std.testing.expect(@hasDecl(features.shaders, "validateDetailed"));
     const shader_report = try features.shaders.validateDetailed(.{ .name = "contract", .source = "fn main() void {}" });
@@ -91,6 +93,7 @@ test "feature modules expose safe runtime contracts" {
     try std.testing.expectError(error.UnbalancedShaderDelimiters, features.shaders.validate(.{ .name = "contract", .source = "fn main() void {" }));
 
     try std.testing.expect(features.mlir.toolchainStatus().message.len > 0);
+    try std.testing.expect(!features.mlir.toolchainStatus().available);
     try std.testing.expect(@hasDecl(features.mlir, "ModuleAnalysis"));
     try std.testing.expect(@hasDecl(features.mlir, "analyze"));
     const mlir_analysis = try features.mlir.analyze(.{ .name = "contract", .operations = &.{ "matmul", "relu" } });
@@ -290,6 +293,7 @@ test "disabled feature modules expose explicit degraded behavior" {
         try std.testing.expectEqual(features.accelerator.Backend.cpu, report.selected_backend);
         try std.testing.expectEqual(features.accelerator.Backend.cpu, report.fallback_backend);
         try std.testing.expect(!report.native_available);
+        try std.testing.expect(!report.native_dispatch);
         try std.testing.expect(!report.gpu_available);
         try std.testing.expect(!report.gpu_accelerated);
     }


### PR DESCRIPTION
## Summary
- Unify `backendMatrix` with `backendCapabilitiesList` so all seven declared backends report consistently.
- Surface `native_dispatch=false` in accelerator selection reports, `abi backends` CLI, and feature-module contracts.
- Keep CUDA/Vulkan/WebGPU/OpenGL/WebGL2 as disclosed non-dispatch stubs (no fake native linking).
- Metal batch-cosine kernel remains Proposed (not in this PR).

## Test plan
- [ ] `./build.sh test -Dtest-filter="gpu"`
- [ ] `./build.sh check-parity`
- [ ] `./build.sh check` (optional full gate)
- [ ] `abi backends` shows matrix + `native_dispatch=false`


Made with [Cursor](https://cursor.com)