### PR TITLE
fix(gpu): repair PR #692 merge compile gaps on main

### DIFF
--- a/src/features/accelerator/mod.zig
+++ b/src/features/accelerator/mod.zig
@@ -32,6 +32,7 @@ pub const SelectionReport = struct {
     selected_backend: Backend,
     fallback_backend: Backend,
     native_available: bool,
+    native_dispatch: bool,
     gpu_available: bool,
     gpu_accelerated: bool,
     message: []const u8,

--- a/src/features/gpu/backends.zig
+++ b/src/features/gpu/backends.zig
@@ -70,6 +70,23 @@ fn preferredBackendForTarget() Backend {
     return .simulated;
 }
 
+pub const PresenceProbe = struct {
+    backend: Backend,
+    declared: bool,
+    native_linked: bool,
+    note: []const u8,
+};
+
+pub fn presenceProbe(backend: Backend) PresenceProbe {
+    const caps = backendCapabilities(backend);
+    return .{
+        .backend = backend,
+        .declared = true,
+        .native_linked = caps.native_kernels,
+        .note = caps.message,
+    };
+}
+
 pub fn threadsPerGroup(backend: Backend) usize {
     return switch (backend) {
         .simulated => 4,

--- a/src/features/gpu/compute_api.zig
+++ b/src/features/gpu/compute_api.zig
@@ -218,7 +218,6 @@ test "compute_api: backend matrix is honest (cpu fallback always dispatches; stu
                 try testing.expect(!entry.dispatches);
                 try testing.expect(entry.reason.len > 0);
             },
-            else => {},
         }
     }
     try testing.expect(saw_cpu_fallback and saw_metal and saw_webgl2);

--- a/src/features/gpu/reporting.zig
+++ b/src/features/gpu/reporting.zig
@@ -37,7 +37,8 @@ test "gpu backend capability report covers all registered backends" {
     try std.testing.expectEqual(backends.Backend.simulated, caps[0].backend);
     const report = try backendStatusReport(std.testing.allocator);
     defer std.testing.allocator.free(report);
-    for (.{ "cuda:", "webgpu:", "webgl2:", "vulkan:", "opengl:" }) |needle| {
+    const needles = [_][]const u8{ "cuda:", "webgpu:", "webgl2:", "vulkan:", "opengl:" };
+    for (needles) |needle| {
         try std.testing.expect(std.mem.indexOf(u8, report, needle) != null);
     }
     for (caps) |cap| {


### PR DESCRIPTION
## Summary
- Add missing `native_dispatch` field to `accelerator` `SelectionReport` (struct field was dropped while call sites/tests from #692 remained).
- Export `preferredBackend`, `PresenceProbe`, and `presenceProbe` from `gpu/backends.zig` to match `gpu/mod.zig` re-exports and stub parity.
- Remove unreachable `else` in `compute_api` backend-matrix test and fix Zig 0.17 comptime loop in `gpu/reporting.zig`.

## Context
Main CI at `fa815e4e` (squash merge of #692) is red on both `check` and `cross-compile smoke`. Local reproduction shows deterministic compile errors, not flakes.

## Test plan
- [x] `./build.sh test -Dtest-filter="gpu"`
- [x] `./build.sh check-parity`
- [x] `./build.sh check`
- [ ] CI green on this branch


Made with [Cursor](https://cursor.com)