### PR TITLE
fix(ai): canonical model metadata and agent contract tests

### DIFF
--- a/src/features/accelerator/mod.zig
+++ b/src/features/accelerator/mod.zig
@@ -32,6 +32,7 @@ pub const SelectionReport = struct {
     selected_backend: Backend,
     fallback_backend: Backend,
     native_available: bool,
+    native_dispatch: bool,
     gpu_available: bool,
     gpu_accelerated: bool,
     message: []const u8,

--- a/src/features/ai/completion.zig
+++ b/src/features/ai/completion.zig
@@ -215,7 +215,7 @@ fn completionMetadataJson(
     errdefer out.deinit(allocator);
 
     try out.appendSlice(allocator, "{\"kind\":\"completion\",\"model\":");
-    try appendMetadataJsonString(&out, allocator, request.model);
+    try appendMetadataJsonString(&out, allocator, result.model);
     try out.appendSlice(allocator, ",\"profile\":");
     try appendMetadataJsonString(&out, allocator, result.selected_profile.label());
     const audit_passed = if (result.audit.passed) "true" else "false";
@@ -309,17 +309,39 @@ test "metadata JSON includes the escore and veto fields" {
 
 test "metadata JSON escapes model and profile fields" {
     var result = types.CompletionResult{
-        .model = "m",
+        .model = "m\"x",
         .selected_profile = .abbey,
         .output = try std.testing.allocator.dupe(u8, "out"),
         .audit = constitution.AuditResult.init(),
     };
     defer result.deinit(std.testing.allocator);
 
-    const metadata = try completionMetadataJson(std.testing.allocator, .{ .input = "in", .model = "m\"x" }, result, 1, 2);
+    const metadata = try completionMetadataJson(std.testing.allocator, .{ .input = "in", .model = "ignored-alias" }, result, 1, 2);
     defer std.testing.allocator.free(metadata);
     try std.testing.expect(std.mem.indexOf(u8, metadata, "\"model\":\"m\\\"x\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, metadata, "\"profile\":\"abbey\"") != null);
+}
+
+test "complete persists canonical model id in result and metadata" {
+    if (!build_options.feat_wdbx) return;
+    const allocator = std.testing.allocator;
+
+    var store = wdbx.Store.init(allocator);
+    defer store.deinit();
+
+    const result = try completeWithStore(allocator, &store, .{
+        .input = "catalog alias smoke",
+        .model = "fable-5",
+        .store_result = true,
+    });
+    defer result.deinit(allocator);
+
+    try std.testing.expectEqualStrings(models.fable5, result.model);
+
+    const key = try completionMetadataKey(allocator, result.query_vector_id);
+    defer allocator.free(key);
+    const metadata = store.get(key) orelse return error.TestUnexpectedResult;
+    try std.testing.expect(std.mem.indexOf(u8, metadata, "\"model\":\"claude-fable-5\"") != null);
 }
 
 test "completeWithStore tracks transient persistence memory and frees it" {

--- a/src/features/ai/orchestration.zig
+++ b/src/features/ai/orchestration.zig
@@ -319,6 +319,16 @@ test "parse worker specs without hints frees safely" {
     try std.testing.expectEqual(@as(usize, 0), specs[0].tool_hints.len);
 }
 
+test "parse worker specs rejects fan-out above max_worker_count" {
+    var segments: std.ArrayListUnmanaged(u8) = .empty;
+    defer segments.deinit(std.testing.allocator);
+    for (0..max_worker_count + 1) |i| {
+        if (i > 0) try segments.append(std.testing.allocator, ';');
+        try segments.writer(std.testing.allocator).print("w{d}|instructions", .{i});
+    }
+    try std.testing.expectError(error.InvalidWorkerSpec, parseWorkerSpecs(std.testing.allocator, segments.items));
+}
+
 test "browser orchestration stays dry-run honest" {
     var plan = try planBrowserOrchestration(std.testing.allocator, "open docs", "https://example.com", false);
     defer plan.deinit(std.testing.allocator);

--- a/src/features/ai/router.zig
+++ b/src/features/ai/router.zig
@@ -337,6 +337,14 @@ test "selectBestProfile picks highest weight" {
     try std.testing.expectEqual(types.AgentProfile.abi, selectBestProfile(weights3));
 }
 
+test "selectBestProfile tie-break order is abbey then aviva then abi" {
+    const three_way = ProfileWeights{ .w_abbey = 0.34, .w_aviva = 0.33, .w_abi = 0.33 };
+    try std.testing.expectEqual(types.AgentProfile.abbey, selectBestProfile(three_way));
+
+    const aviva_abi = ProfileWeights{ .w_abbey = 0.2, .w_aviva = 0.4, .w_abi = 0.4 };
+    try std.testing.expectEqual(types.AgentProfile.aviva, selectBestProfile(aviva_abi));
+}
+
 test "routeInput returns response from selected profile" {
     const allocator = std.testing.allocator;
     const result = try routeInput(allocator, "analyze the logical structure");

--- a/src/features/gpu/backends.zig
+++ b/src/features/gpu/backends.zig
@@ -70,6 +70,23 @@ fn preferredBackendForTarget() Backend {
     return .simulated;
 }
 
+pub const PresenceProbe = struct {
+    backend: Backend,
+    declared: bool,
+    native_linked: bool,
+    note: []const u8,
+};
+
+pub fn presenceProbe(backend: Backend) PresenceProbe {
+    const caps = backendCapabilities(backend);
+    return .{
+        .backend = backend,
+        .declared = true,
+        .native_linked = caps.native_kernels,
+        .note = caps.message,
+    };
+}
+
 pub fn threadsPerGroup(backend: Backend) usize {
     return switch (backend) {
         .simulated => 4,

--- a/src/features/gpu/compute_api.zig
+++ b/src/features/gpu/compute_api.zig
@@ -218,7 +218,6 @@ test "compute_api: backend matrix is honest (cpu fallback always dispatches; stu
                 try testing.expect(!entry.dispatches);
                 try testing.expect(entry.reason.len > 0);
             },
-            else => {},
         }
     }
     try testing.expect(saw_cpu_fallback and saw_metal and saw_webgl2);

--- a/src/features/gpu/reporting.zig
+++ b/src/features/gpu/reporting.zig
@@ -37,7 +37,8 @@ test "gpu backend capability report covers all registered backends" {
     try std.testing.expectEqual(backends.Backend.simulated, caps[0].backend);
     const report = try backendStatusReport(std.testing.allocator);
     defer std.testing.allocator.free(report);
-    for (.{ "cuda:", "webgpu:", "webgl2:", "vulkan:", "opengl:" }) |needle| {
+    const needles = [_][]const u8{ "cuda:", "webgpu:", "webgl2:", "vulkan:", "opengl:" };
+    for (needles) |needle| {
         try std.testing.expect(std.mem.indexOf(u8, report, needle) != null);
     }
     for (caps) |cap| {


### PR DESCRIPTION
## Summary

- Adds canonical AI model metadata and agent contract tests from the self-improve AI agent work.
- **Includes** `fix(gpu): repair PR #692 merge compile gaps on main` (`d5cfd1f2`) as the first commit on this branch — same change as open draft PR #693 (`cursor/fix-gpu-merge-compile`).
- Prefer merging **this PR** over #693 if you want GPU compile repair + AI fixes in one pass; after merge, **#693 can be closed** as superseded (identical GPU commit, no unique tip on #693).

## Relation to #693

- #693: GPU-only (`d5cfd1f2` on `cursor/fix-gpu-merge-compile`).
- This branch: `d5cfd1f2` + `97af441a` (AI metadata + contract tests).
- Not merged here — GitHub Actions may be billing-locked; wait for CI when available.

## Test plan

- [ ] `./build.sh check` (or at least `./build.sh test -Dtest-filter` for new agent contract tests) when CI/billing allows
- [ ] Confirm GPU compile paths still pass cross-smoke expectations from `d5cfd1f2`
- [ ] Review AI model metadata / contract test diffs for claim-honest scope


Made with [Cursor](https://cursor.com)