### PR TITLE
refactor: simplify docs-validate gate docs and Claude launch configs

### DIFF
--- a/.agents/skills/docs-validate/SKILL.md
+++ b/.agents/skills/docs-validate/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: docs-validate
-description: Validate the Mintlify docs site (docs/docs.json + docs/**/*.mdx) via `npx mint@latest validate`, plus a stale-.md-reference scan. Use as a pre-push gate after editing docs/ — this is the one surface ./build.sh check and CI do NOT cover, so broken config/pages otherwise only surface on push. User-invocable only.
+description: Validate the Mintlify docs site (docs/docs.json + docs/**/*.mdx) via `npx mint@latest validate`, plus a stale-.md-reference scan. Local pre-push gate; CI job docs (mint validate) runs the same script on push/PR. Not part of ./build.sh check. User-invocable only.
 disable-model-invocation: true
 ---
 
-# docs-validate — pre-push gate for the Mintlify docs site
+# docs-validate — Mintlify docs gate
 
 Driver: **`.agents/skills/docs-validate/validate.sh`** (paths relative to repo root).
 Runs `npx mint@latest validate` against `docs/docs.json` + `docs/**/*.mdx`, then
@@ -17,12 +17,16 @@ is the `RESULT:` line.
 ```
 Prints `RESULT: PASS` (exit 0) or `RESULT: FAIL` (exit 1) with the validator output.
 
-## Why this exists
-`./build.sh check` and `.github/workflows/ci.yml` do **not** validate the docs site —
-Mintlify builds/hosts via its GitHub app on push, so a broken `docs/docs.json` or
-`.mdx` page is only caught *after* it lands. This skill closes that gap as a local
-pre-push check. It is `disable-model-invocation: true` (user-only) because it's a
-validation action that shells out to `npx` (network + package fetch).
+## Gates
+| Gate | Covers docs? |
+|------|----------------|
+| `./build.sh check` | No (Zig primary gate stays separate) |
+| CI job **docs (mint validate)** (Node 22) | Yes — runs this script on push/PR |
+| Local `validate.sh` | Yes — run after editing `docs/` before push |
+
+Mintlify also builds the hosted site via its GitHub app. This skill is
+`disable-model-invocation: true` (user-only) because it shells out to `npx`
+(network + package fetch).
 
 ## Gotchas
 - ⚠️ **mintlify needs an LTS node — it hard-fails on node 25+.** On a too-new node
@@ -33,9 +37,6 @@ validation action that shells out to `npx` (network + package fetch).
   run. Offline → it fails at fetch (a tooling/env failure, not a docs failure).
 - **Mintlify config is `docs/docs.json`** — the driver `cd`s into `docs/`; run it
   from anywhere in the repo.
-- **Not wired into `./build.sh` on purpose** — primary Zig gate stays separate.
-  CI runs this script as job **docs (mint validate)** (Node 22) on push/PR.
-  Still run it locally after any change under `docs/` before pushing.
 - The stale-`.md` scan is a heuristic (nav/link entries ending in `.md`); treat hits
   as "verify these resolve," not hard failures — the `mint validate` result is authoritative.
 

--- a/.agents/skills/docs-validate/validate.sh
+++ b/.agents/skills/docs-validate/validate.sh
@@ -14,8 +14,7 @@ cd "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || {
 
 # Mintlify config lives under docs/.
 if [ -f docs/docs.json ]; then cd docs
-elif [ -f docs.json ]; then :
-else echo "RESULT: FAIL (no docs.json found — is this the docs site?)"; exit 1; fi
+else echo "RESULT: FAIL (no docs/docs.json found — is this the abi repo?)"; exit 1; fi
 
 command -v npx >/dev/null 2>&1 || { echo "RESULT: FAIL (npx not on PATH — install Node/npm)"; exit 1; }
 

--- a/.agents/skills/sync-clis/SKILL.md
+++ b/.agents/skills/sync-clis/SKILL.md
@@ -11,7 +11,7 @@ This skill is backed by `launch.sh` in this directory (run via Grok skill system
 - **Canonical source:** repo `.agents/skills/<name>/`
 - **Targets (if present):** repo `.claude/skills/`, repo `.grok/`
 - **Per skill (creates the target dir if missing):**
-  - `SKILL.md`
+  - `SKILL.md` (rewrites `Base directory for this skill:` to the target path)
   - `references/` (when present at source)
   - `examples/` (when present at source)
 - **Not copied:** launcher `.sh` scripts, other skill payloads, skills on the skip list.

--- a/.agents/skills/sync-clis/SKILL.md
+++ b/.agents/skills/sync-clis/SKILL.md
@@ -10,11 +10,11 @@ This skill is backed by `launch.sh` in this directory (run via Grok skill system
 
 - **Canonical source:** repo `.agents/skills/<name>/`
 - **Targets (if present):** repo `.claude/skills/`, repo `.grok/`
-- **Per skill that already exists at the target:**
+- **Per skill (creates the target dir if missing):**
   - `SKILL.md`
   - `references/` (when present at source)
   - `examples/` (when present at source)
-- **Not copied:** launcher `.sh` scripts, other skill payloads, skills on the skip list, skills that do not already exist under the target.
+- **Not copied:** launcher `.sh` scripts, other skill payloads, skills on the skip list.
 
 Skip list (not synced by this launcher): `abi-doc-claims-sync`, `abi-goal-orchestrator`, `check-work`, `code-review`, `create-skill`, `docx`, `help`, `imagine`, `pptx`, `sl`, `sync-clis`, `xlsx`.
 

--- a/.agents/skills/sync-clis/launch.sh
+++ b/.agents/skills/sync-clis/launch.sh
@@ -29,16 +29,27 @@ TARGETS=()
 
 say() { printf '\n=== %s ===\n' "$*"; }
 
+# Print would-msg under --dry-run; otherwise run the command and print done-msg.
+run_or_echo() {
+    local would_msg="$1" done_msg="$2"
+    shift 2
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "  $would_msg"
+    else
+        "$@"
+        echo "  $done_msg"
+    fi
+}
+
 sync_skills() {
     local src="$1" dst="$2"
-    local name label="$3"
+    local label="$3"
 
-    # Sync only ABI-specific skills (those with .sh scripts or shared by all)
+    # Skip universal skills listed below; sync the rest (create target dirs if missing).
     for skill_dir in "$src"/*/; do
         local skill_name
         skill_name=$(basename "$skill_dir")
 
-        # Skip universal/cross-platform skills that are only in .agents/
         case "$skill_name" in
             abi-doc-claims-sync|abi-goal-orchestrator|check-work|code-review|create-skill|docx|help|imagine|pptx|sl|sync-clis|xlsx)
                 continue
@@ -46,22 +57,14 @@ sync_skills() {
         esac
 
         if [ ! -d "$dst/$skill_name" ]; then
-            if [ "$DRY_RUN" -eq 1 ]; then
-                echo "  would create: $label/$skill_name/"
-            else
+            run_or_echo "would create: $label/$skill_name/" "created: $label/$skill_name/" \
                 mkdir -p "$dst/$skill_name"
-                echo "  created: $label/$skill_name/"
-            fi
         fi
 
         # Sync SKILL.md (text content only, not the .sh scripts)
         if [ -f "$src/$skill_name/SKILL.md" ]; then
-            if [ "$DRY_RUN" -eq 1 ]; then
-                echo "  would sync: $label/$skill_name/SKILL.md"
-            else
+            run_or_echo "would sync: $label/$skill_name/SKILL.md" "synced: $label/$skill_name/SKILL.md" \
                 cp "$src/$skill_name/SKILL.md" "$dst/$skill_name/SKILL.md"
-                echo "  synced: $label/$skill_name/SKILL.md"
-            fi
         fi
         # Companion docs skills may load; non-destructive (overwrite/add, no delete)
         for sub in references examples; do

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,29 @@
       "name": "abi-mcp",
       "runtimeExecutable": "bash",
       "runtimeArgs": ["-c", "./build.sh mcp && ./mcp/launcher.sh stdio"],
-      "port": 8080
+      "port": 8080,
+      "autoPort": true
+    },
+    {
+      "name": "wdbx-api",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["-c", "./build.sh cli && ./zig-out/bin/abi wdbx api serve $PORT"],
+      "port": 8091,
+      "autoPort": true
+    },
+    {
+      "name": "wdbx-cluster",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["-c", "./build.sh cli && ./zig-out/bin/abi wdbx cluster serve $PORT"],
+      "port": 8092,
+      "autoPort": true
+    },
+    {
+      "name": "docs",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["-c", "cd docs && npx mint dev --port $PORT"],
+      "port": 3000,
+      "autoPort": true
     }
   ]
 }

--- a/.claude/skills/docs-validate/SKILL.md
+++ b/.claude/skills/docs-validate/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: docs-validate
-description: Validate the Mintlify docs site (docs/docs.json + docs/**/*.mdx) via `npx mint@latest validate`, plus a stale-.md-reference scan. Use as a pre-push gate after editing docs/ — this is the one surface ./build.sh check and CI do NOT cover, so broken config/pages otherwise only surface on push. User-invocable only.
+description: Validate the Mintlify docs site (docs/docs.json + docs/**/*.mdx) via `npx mint@latest validate`, plus a stale-.md-reference scan. Local pre-push gate; CI job docs (mint validate) runs the same script on push/PR. Not part of ./build.sh check. User-invocable only.
 disable-model-invocation: true
 ---
 
-# docs-validate — pre-push gate for the Mintlify docs site
+# docs-validate — Mintlify docs gate
 
 Driver: **`.agents/skills/docs-validate/validate.sh`** (paths relative to repo root).
 Runs `npx mint@latest validate` against `docs/docs.json` + `docs/**/*.mdx`, then
@@ -17,12 +17,16 @@ is the `RESULT:` line.
 ```
 Prints `RESULT: PASS` (exit 0) or `RESULT: FAIL` (exit 1) with the validator output.
 
-## Why this exists
-`./build.sh check` and `.github/workflows/ci.yml` do **not** validate the docs site —
-Mintlify builds/hosts via its GitHub app on push, so a broken `docs/docs.json` or
-`.mdx` page is only caught *after* it lands. This skill closes that gap as a local
-pre-push check. It is `disable-model-invocation: true` (user-only) because it's a
-validation action that shells out to `npx` (network + package fetch).
+## Gates
+| Gate | Covers docs? |
+|------|----------------|
+| `./build.sh check` | No (Zig primary gate stays separate) |
+| CI job **docs (mint validate)** (Node 22) | Yes — runs this script on push/PR |
+| Local `validate.sh` | Yes — run after editing `docs/` before push |
+
+Mintlify also builds the hosted site via its GitHub app. This skill is
+`disable-model-invocation: true` (user-only) because it shells out to `npx`
+(network + package fetch).
 
 ## Gotchas
 - ⚠️ **mintlify needs an LTS node — it hard-fails on node 25+.** On a too-new node
@@ -33,8 +37,6 @@ validation action that shells out to `npx` (network + package fetch).
   run. Offline → it fails at fetch (a tooling/env failure, not a docs failure).
 - **Mintlify config is `docs/docs.json`** — the driver `cd`s into `docs/`; run it
   from anywhere in the repo.
-- **Not wired into `./build.sh` or CI on purpose** — this is a manual gate. Run it
-  after any change under `docs/` and before pushing docs edits.
 - The stale-`.md` scan is a heuristic (nav/link entries ending in `.md`); treat hits
   as "verify these resolve," not hard failures — the `mint validate` result is authoritative.
 

--- a/.claude/skills/docs-validate/validate.sh
+++ b/.claude/skills/docs-validate/validate.sh
@@ -1,61 +1,6 @@
 #!/usr/bin/env bash
-# docs-validate — validate the Mintlify docs site (docs/docs.json + docs/**/*.mdx).
-#
-# This is the one surface `./build.sh check` and CI do NOT cover: broken docs.json
-# or .mdx pages only surface on push (Mintlify builds via its GitHub app). Run this
-# as a pre-push gate after touching docs/. Requires network (npx fetches mint).
-set -uo pipefail
-
-SCRIPT_PATH=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/$(basename -- "${BASH_SOURCE[0]}")
-
-cd "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || {
-  echo "RESULT: FAIL (run from inside the abi repo)"; exit 1; }
-
-# Mintlify config lives under docs/.
-if [ -f docs/docs.json ]; then cd docs
-elif [ -f docs.json ]; then :
-else echo "RESULT: FAIL (no docs.json found — is this the docs site?)"; exit 1; fi
-
-command -v npx >/dev/null 2>&1 || { echo "RESULT: FAIL (npx not on PATH — install Node/npm)"; exit 1; }
-
-# mintlify requires an LTS node and hard-fails on node 25+. Detect early and give
-# an actionable message instead of a confusing validator error (this is an env
-# issue, not a docs problem).
-node_major="$(node -v 2>/dev/null | sed 's/^v//; s/[.].*//')"
-if [ -n "$node_major" ] && [ "$node_major" -ge 25 ] 2>/dev/null; then
-  fallback_node_bin="${ABI_DOCS_VALIDATE_NODE_BIN:-$HOME/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin}"
-  fallback_node="$fallback_node_bin/node"
-  if [ "${ABI_DOCS_VALIDATE_NODE_FALLBACK:-0}" != "1" ] && [ -x "$fallback_node" ]; then
-    fallback_major="$("$fallback_node" -v 2>/dev/null | sed 's/^v//; s/[.].*//')"
-    if [ -n "$fallback_major" ] && [ "$fallback_major" -lt 25 ] 2>/dev/null; then
-      echo "node $(node -v) unsupported; retrying with bundled node $("$fallback_node" -v)."
-      PATH="$fallback_node_bin:$PATH" ABI_DOCS_VALIDATE_NODE_FALLBACK=1 exec "$SCRIPT_PATH" "$@"
-    fi
-  fi
-  echo "RESULT: SKIP (node $(node -v) unsupported — mintlify needs an LTS node, fails on 25+)."
-  echo "  Select an LTS node (nvm/fnm) and re-run; this is not a docs error."
-  exit 3
-fi
-
-echo "[1/2] mint validate (config + pages) in $(pwd) ..."
-if npx --yes mint@latest validate; then
-  vfail=0
-else
-  vfail=1
-fi
-
-# Extra guard: catch the .md->.mdx link rot that bit PR #651 — internal links or
-# nav entries pointing at .md files that no longer exist after the Mintlify cutover.
-echo "[2/2] scanning for stale .md references in nav/pages ..."
-stale="$(grep -rInE '"[^"]+\.md"|\]\([^)]+\.md[)#]' docs.json ./*.mdx 2>/dev/null | grep -v '\.mdx' || true)"
-if [ -n "$stale" ]; then
-  echo "  ! possible stale .md references (verify these still resolve):"
-  printf '%s\n' "$stale" | sed 's/^/    /'
-fi
-
-if [ "$vfail" -eq 0 ]; then
-  echo "RESULT: PASS — Mintlify config + pages valid"
-  exit 0
-fi
-echo "RESULT: FAIL — see 'mint validate' output above"
-exit 1
+# Thin wrapper — canonical driver is .agents/skills/docs-validate/validate.sh
+# (sync-clis does not copy .sh launchers).
+set -euo pipefail
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../.." && pwd)
+exec "$ROOT/.agents/skills/docs-validate/validate.sh" "$@"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,7 @@ jobs:
       - name: zig build cross-smoke
         run: zig build cross-smoke
 
-  # Mintlify hosts the docs site (not gh-pages). This job is the CI gate that
-  # `./build.sh check` intentionally omits — broken docs.json/.mdx otherwise
-  # only fail after push when Mintlify builds. Node must be LTS (<25).
+  # Docs gate omitted from ./build.sh check — see .agents/skills/docs-validate/validate.sh
   docs-validate:
     name: docs (mint validate)
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Canonical instruction file. If this conflicts with `build.zig`, `tools/build.sh`
 | `./build.sh test-cli`/`test-plugins`/`test-contracts`/`test-mcp-contracts`/`test-mcp-server`/`test-integration`/`test-feature-contracts` | Focused suites |
 | `./build.sh check-parity` | Verify mod/stub public-decl parity (run after any public API change) |
 | `./build.sh lint`/`fix` | Check/apply formatting |
-| `npx mint@latest validate` | Docs validation (not in CI) |
+| `.agents/skills/docs-validate/validate.sh` | Docs validation (CI job `docs (mint validate)`) |
 
 ## Feature flags
 15 flags, all default `true` (see `build.zig` lines 9–23): `feat-ai`, `feat-gpu`, `feat-tui`, `feat-accelerator`, `feat-shader`, `feat-mlir`, `feat-mobile`, `feat-wdbx`, `feat-os-control`, `feat-hash`, `feat-metrics`, `feat-telemetry`, `feat-nn`, `feat-sea`, `feat-foundationmodels`. Each selects a real `mod.zig` vs a `stub.zig` (declared in `src/features/mod.zig`). **Honest stubs** (`available=false`/`native_dispatch=false` in source): `accelerator`, `shaders`, `mlir`, `mobile` — selection/report only, no linked native toolchain.

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -50,10 +50,7 @@ Prefer links to canonical contracts over repeating the frozen 13-command CLI or
 .agents/skills/docs-validate/validate.sh
 ```
 
-CI runs the same Mintlify check as job **docs (mint validate)** on every push
-and PR (Node 22 LTS). The published site is **Mintlify-hosted** from `docs/`;
-there is no separate `gh-pages` artifact. Layout and what belongs in navigation:
-[`docs/README.md`](https://github.com/donaldfilimon/abi/blob/main/docs/README.md).
+Layout, hosting, and CI: [Docs layout](./README.md).
 
 If public APIs changed, also run `zig build check-parity`. For runtime-facing
 documentation, exercise the real binaries with

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -79,12 +79,10 @@ On macOS/Darwin, prefer `./build.sh ...` for project validation even when plain 
 - [GEMINI.md](../GEMINI.md) — Gemini-oriented conventions
 - [CHANGELOG.md](../CHANGELOG.md) — release notes
 
-Repo docs layout (what is published vs working drafts): see the `docs/README.md`
-in the repository root `docs/` tree. Working plans under `superpowers/` stay out
-of Mintlify navigation by design.
+Published vs working drafts: [Docs layout](./README.md). Plans under
+[`superpowers/`](./superpowers/README.md) stay out of Mintlify navigation.
 
 ## Historical / archived
 
-Superpowers-era plans and the master spec live under `superpowers/archive/` for context only. They are **not** listed in Mintlify `docs.json` navigation and are not sources of truth. Prefer `docs/spec/*.mdx`, `docs/contracts/*.mdx`, and executable sources.
-
-See the [archive index](superpowers/archive/README.md).
+See the [archive index](superpowers/archive/README.md) — historical only, not
+sources of truth. Prefer `docs/spec/*.mdx`, `docs/contracts/*.mdx`, and executable sources.

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -9,8 +9,8 @@ Working and historical planning docs for agent workflows. **Not** listed in
 | [`specs/`](specs/) | Design drafts pending review or landing |
 | [`archive/`](archive/) | Superseded plans/specs — historical only |
 
-Active product board: `tasks/todo.md`. Executable truth: `src/`, `build.zig`,
-`./build.sh check`. Published claims: `docs/contracts/` + `docs/spec/`.
+Published layout and claim boundaries: [Docs layout](../README.md). Active board:
+`tasks/todo.md`.
 
 ## Adding a plan or design draft
 


### PR DESCRIPTION
## Summary
- Align docs-validate / AGENTS / Mintlify prose on one CI gate story; thin-wrap the Claude `validate.sh` copy to the canonical script
- Collapse sync-clis dry-run duplication via `run_or_echo`; document create-if-missing skill dirs
- Add Claude Desktop launch entries for `wdbx-api`, `wdbx-cluster`, and Mintlify docs preview (`autoPort`)

## Test plan
- [ ] Confirm PR diff vs `main` is only the intended simplify + launch.json extras (rebase/merge if GitHub reports conflicts with #696)
- [ ] `bash -n .agents/skills/sync-clis/launch.sh` and `.agents/skills/docs-validate/validate.sh`
- [ ] `.agents/skills/sync-clis/launch.sh --dry-run` prints would-create/would-sync lines
- [ ] CI `docs (mint validate)` still green on this branch
- [ ] Optional: open Claude launch configs for wdbx-api / docs and confirm autoPort behavior


Made with [Cursor](https://cursor.com)