### PR TITLE
Test WDBX cluster helper convergence

### DIFF
--- a/src/features/wdbx/cluster.zig
+++ b/src/features/wdbx/cluster.zig
@@ -285,6 +285,55 @@ test "cluster: loses availability without a quorum" {
     try std.testing.expectError(error.NoLeader, c.replicate("c"));
 }
 
+test "cluster: startElection/replicate match applyVote/applyAppend driven directly" {
+    const allocator = std.testing.allocator;
+
+    // Cluster A: driven entirely through the public API under test.
+    var via_api = try Cluster.init(allocator, 3);
+    defer via_api.deinit();
+    try std.testing.expect(try via_api.startElection(0));
+    _ = try via_api.replicate("hello");
+
+    // Cluster B: identical topology, driven by calling the shared free
+    // functions directly in the same order startElection/replicate use
+    // internally. Divergence from Cluster A indicates a behavior change in
+    // the shared helper path.
+    var via_primitives = try Cluster.init(allocator, 3);
+    defer via_primitives.deinit();
+
+    const cand = &via_primitives.nodes[0];
+    cand.term = 1;
+    cand.role = .candidate;
+    cand.voted_for = 0;
+    var votes: usize = 1; // candidate votes for itself
+    for (via_primitives.nodes[1..]) |*peer| {
+        if (applyVote(peer, 1, 0)) votes += 1;
+    }
+    try std.testing.expect(votes >= via_primitives.quorum());
+    cand.role = .leader;
+
+    // The leader appends its own entry directly, not via applyAppend:
+    // applyAppend unconditionally sets role = .follower, so the leader's own
+    // write stays distinct from the follower path.
+    const owned = try allocator.dupe(u8, "hello");
+    try cand.log.append(allocator, .{ .term = 1, .data = owned });
+
+    for (via_primitives.nodes[1..]) |*peer| {
+        _ = try applyAppend(peer, allocator, 1, "hello");
+    }
+
+    for (via_api.nodes, via_primitives.nodes) |a, b| {
+        try std.testing.expectEqual(a.term, b.term);
+        try std.testing.expectEqual(a.voted_for, b.voted_for);
+        try std.testing.expectEqual(a.role, b.role);
+        try std.testing.expectEqual(a.log.items.len, b.log.items.len);
+        for (a.log.items, b.log.items) |a_entry, b_entry| {
+            try std.testing.expectEqual(a_entry.term, b_entry.term);
+            try std.testing.expectEqualStrings(a_entry.data, b_entry.data);
+        }
+    }
+}
+
 test {
     std.testing.refAllDecls(@This());
 }


### PR DESCRIPTION
## Summary

- extract the clean WDBX convergence test from the superseded SDD branch onto current `main`
- compare public `startElection`/`replicate` state with direct `applyVote`/`applyAppend` helper execution
- preserve the leader/follower append distinction and assert replicated log term and payload equality

## Validation

- focused cluster filter: 239/239 tests passed
- `./build.sh check`: 40/40 steps; 1058/1060 tests passed, 2 skipped
- `git diff --check`: pass

This PR intentionally excludes the old branch tree and its superseded pre-#705 plans.