### PR TITLE
fix(skills): correct TUI slash-command paths and goals boundaries

### DIFF
--- a/.agents/skills/abi-claims-validator/SKILL.md
+++ b/.agents/skills/abi-claims-validator/SKILL.md
@@ -1,27 +1,25 @@
 ---
 name: abi-claims-validator
-description: ABI external claims validator. Validates docs/collateral against repo source, tests, and external-claims-audit.mdx. Prevents unsupported claims in public artifacts.
+description: Validate ABI docs and external collateral against repo evidence and docs/contracts/external-claims-audit.mdx. Use when auditing claims, scanning docs for unsupported QPS/sharding/FHE/AES language, checking one claim before publish, or re-confirming the external-claims audit. Agent procedure only — not a CLI or slash command. Pair with abi-doc-claims-sync when editing docs.
 ---
 
 # ABI Claims Validator
 
-Validates documentation, collateral, and public claims against the repository source of truth (`build.zig`, `src/`, contract tests, `docs/contracts/external-claims-audit.mdx`). Use before publishing any external artifact.
+Agent-side procedure to validate documentation, collateral, and public claims
+against the repository source of truth (`build.zig`, `src/`, contract tests,
+`docs/contracts/external-claims-audit.mdx`). Use before publishing any external
+artifact. There is **no** `/abi-claims-validator` binary or slash command — follow
+the steps below (or dispatch the `external-claims-auditor` subagent).
 
-## Usage
+For *editing* docs to stay claim-honest, prefer `abi-doc-claims-sync`.
 
-```
-/abi-claims-validator scan [--path docs/] [--strict]
-/abi-claims-validator check-claim "<claim text>"
-/abi-claims-validator audit [--output claims-audit.md]
-```
-
-## Actions
+## Procedure (agent actions)
 
 ### scan
-Scan Markdown/MDX files for claim patterns and cross-reference with repo evidence:
-```
-/abi-claims-validator scan --path docs/
-```
+1. Open the target tree (default `docs/`, plus README/AGENTS/CHANGELOG/walkthrough as needed).
+2. Search for claim patterns (table below) with ripgrep or equivalent.
+3. For each hit, cross-reference source/tests/`external-claims-audit.mdx`.
+4. In `--strict` mode, treat any unproven number or deployment claim as a fail.
 
 Detects:
 - Performance numbers (QPS, latency, throughput, accuracy)
@@ -33,18 +31,13 @@ Detects:
 - Energy/GPU speedup claims
 
 ### check-claim
-Validate a specific claim against repo evidence:
-```
-/abi-claims-validator check-claim "WDBX achieves 12,000 QPS"
-```
-
-Returns: `SUPPORTED` | `UNSUPPORTED` | `PARTIAL` + evidence path
+Given one claim string, return `SUPPORTED` | `UNSUPPORTED` | `PARTIAL` plus the
+evidence path (source, test, or audit section). Prefer executable evidence over prose.
 
 ### audit
-Generate full claims audit report:
-```
-/abi-claims-validator audit --output claims-audit.md
-```
+Produce a short markdown report of flagged claims vs evidence. The durable
+ledger lives in `docs/contracts/external-claims-audit.mdx` — update that file
+when the audit changes reality, do not invent a parallel truth source.
 
 ## Source of Truth Hierarchy
 
@@ -76,14 +69,11 @@ From `docs/contracts/external-claims-audit.mdx` §Reusable Delta:
 
 ## Integration
 
-Run as pre-publish gate:
+Pre-publish gate (agent runs the scan procedure after code gates):
 ```bash
-# In CI or local
-zig build check-parity --summary all
+./build.sh check-parity
 ./build.sh check
-/abi-claims-validator scan --path docs/ --strict
+# then: scan docs/ + collateral per Procedure above (--strict)
 ```
 
-## Feature Gates
-
-No feature gates — runs as standalone validation tool against source.
+No feature gates — procedural validation against source.

--- a/.agents/skills/abi-goal-orchestrator/SKILL.md
+++ b/.agents/skills/abi-goal-orchestrator/SKILL.md
@@ -1,26 +1,28 @@
 ---
 name: abi-goal-orchestrator
-description: Plan and execute ABI repo work from current TODOs, roadmap/spec docs, Zig 0.17 constraints, and validation gates. Use when the user asks to find all ABI todos/roadmaps, compile ABI goals/specs, organize a large ABI implementation goal, or decide the next safe work slice in ~/abi.
+description: Plan and execute ABI repo work from the TODO board, roadmap/spec docs, Zig 0.17 constraints, and validation gates. Use when the user asks to find ABI todos/roadmaps, organize a large implementation from tasks/todo.md, or decide the next safe work slice. Distinct from the goals skill — that skill owns the persistent ledger tasks/goals.md; this skill plans from the active board and north-star specs.
 ---
 
 # ABI Goal Orchestrator
 
 Use this skill to turn ABI's active board and long-horizon specs into a concrete implementation plan grounded in current repo files.
 
+**Boundary:** `goals` owns `tasks/goals.md` (user intentions / goal-to-slice ledger). This skill plans from `tasks/todo.md` + `docs/spec/wdbx-north-star.mdx`. When the user names a durable goal, capture/update it via the `goals` skill; use this skill for board/spec-driven slice selection.
+
 ## Workflow
 
 1. Start in `/Users/donaldfilimon/abi` unless the user gives another ABI checkout.
 2. Inspect `git status --short --branch` before edits; preserve unrelated dirty work.
-3. Read `AGENTS.md`, `tasks/todo.md`, and `tasks/lessons.md`.
+3. Read `AGENTS.md`, `tasks/todo.md`, and `tasks/lessons.md`. Optionally skim `tasks/goals.md` for in-progress user intentions (do not treat it as the working list).
 4. Optional: refresh the inventory with `abi_inventory.py --repo /Users/donaldfilimon/abi` if available (ships with the codex `abi-mega` plugin, not this repo); skip when absent.
 5. Optional: load `references/current-goals.md` if present alongside this skill (codex plugin copies carry it; the canonical repo copy does not) — otherwise derive the source map from `tasks/todo.md` + `docs/spec/wdbx-north-star.mdx`.
 6. Derive a small executable slice. Prefer changes that make one TODO, roadmap gap, doc mismatch, or validation gap measurably more true.
-7. Keep claims honest: source/build/tests override prose.
+7. Keep claims honest: source/build/tests override prose. Do not fake-complete stubs.
 8. Verify with the narrow command that proves the slice, then the broader gate when the blast radius justifies it.
 
 ## Goal Rules
 
-- Treat `tasks/todo.md` as the active board and `docs/spec/wdbx-north-star.mdx` as the Current/Partial/Proposed map.
+- Treat `tasks/todo.md` as the active board and `docs/spec/wdbx-north-star.mdx` as the Current/Partial/Proposed map. Leave coarse user intentions in `tasks/goals.md` (via the `goals` skill).
 - Do not convert disclosed stubs into fake completions. Native dispatch, production clustering, production FHE, and learned-compression claims need real source/tests/artifacts.
 - Do not add legacy CLI names. Preserve the frozen top-level command set and MCP 12-tool contract.
 - When changing public feature APIs, update real and stub modules and run `zig build check-parity`.

--- a/.agents/skills/abi-goal-orchestrator/SKILL.md
+++ b/.agents/skills/abi-goal-orchestrator/SKILL.md
@@ -25,7 +25,7 @@ Use this skill to turn ABI's active board and long-horizon specs into a concrete
 - Treat `tasks/todo.md` as the active board and `docs/spec/wdbx-north-star.mdx` as the Current/Partial/Proposed map. Leave coarse user intentions in `tasks/goals.md` (via the `goals` skill).
 - Do not convert disclosed stubs into fake completions. Native dispatch, production clustering, production FHE, and learned-compression claims need real source/tests/artifacts.
 - Do not add legacy CLI names. Preserve the frozen top-level command set and MCP 12-tool contract.
-- When changing public feature APIs, update real and stub modules and run `zig build check-parity`.
+- When changing public feature APIs, update real and stub modules and run `./build.sh check-parity`.
 - When changing docs, run `.agents/skills/docs-validate/validate.sh` in addition to code gates.
 
 ## Useful Commands
@@ -33,7 +33,7 @@ Use this skill to turn ABI's active board and long-horizon specs into a concrete
 ```bash
 abi_inventory.py --repo /Users/donaldfilimon/abi   # optional; codex abi-mega plugin only
 zig version
-zig build check-parity --summary all
+./build.sh check-parity
 ./build.sh check
 ```
 

--- a/.agents/skills/abi-superpower-tui/SKILL.md
+++ b/.agents/skills/abi-superpower-tui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: abi-superpower-tui
-description: TUI/dashboard superpower. Launch interactive REPL, dashboard panes, split views, and slash commands.
+description: TUI/dashboard superpower. Launch interactive agent REPL, diagnostics dashboard panes, and slash commands via real abi CLI paths. Use when working on abi tui / dashboard / agent tui. There is no /abi-superpower-tui binary.
 superpower:
   command: "execute"
   parameters:
@@ -18,30 +18,48 @@ superpower:
 
 # ABI Superpower: TUI
 
-Exposes the interactive TUI and dashboard as a superpower.
+Exposes the interactive TUI and dashboard as a superpower. There is **no**
+`/abi-superpower-tui` binary or slash command — map actions to the real CLI
+paths below (or the `run-tui` / `dashboard-smoke` drivers).
 
 ## Actions
 
 ### repl
-Launch agent REPL with slash commands:
-```
-/abi-superpower-tui repl
+Launch the agent REPL (slash commands live here):
+```bash
+./zig-out/bin/abi agent tui
 ```
 
 ### dashboard
-Show diagnostics dashboard:
+Show the diagnostics dashboard (`abi tui` is an alias of `abi dashboard`):
+```bash
+./zig-out/bin/abi dashboard --pane system
+./zig-out/bin/abi dashboard --pane plugins --once --json
+./zig-out/bin/abi tui --compact --pane scheduler
 ```
-/abi-superpower-tui dashboard --pane system
-/abi-superpower-tui dashboard --pane plugins --once --json
+
+Interactive pty smoke (tmux driver):
+```bash
+.agents/skills/run-tui/tui.sh              # drives `abi dashboard`
+.agents/skills/run-tui/tui.sh tui          # drives `abi tui`
+```
+
+Headless one-shot smoke:
+```bash
+.agents/skills/dashboard-smoke/dashboard.sh
 ```
 
 ### pane
-Switch focus between split panes (Tab key in interactive):
-```
-/abi-superpower-tui pane --focus agent_output
+Select the initial diagnostics pane with `--pane` (system, plugins, storage/wdbx,
+scheduler, memory, or 1–5). In the interactive refresh loop, switch panes with
+hotkeys / Tab — there is no separate `pane --focus` CLI.
+
+```bash
+./zig-out/bin/abi dashboard --list-panes
+./zig-out/bin/abi dashboard --pane memory
 ```
 
-## Slash Commands (in REPL)
+## Slash Commands (in `abi agent tui` REPL)
 
 - `/open <path>` - Load file into context
 - `/diff` - Git diff
@@ -57,9 +75,11 @@ Switch focus between split panes (Tab key in interactive):
 ## Implementation
 
 Maps to:
-- `src/features/tui/repl.zig` - REPL with line editor
-- `src/features/tui/dashboard.zig` - Split-pane dashboard
+- `src/features/tui/repl.zig` - REPL with line editor (`abi agent tui`)
+- `src/features/tui/dashboard.zig` - Split-pane dashboard (`abi tui` / `abi dashboard`)
 - `src/features/tui/line_editor.zig` - CSI decode, cursor, history
+- `.agents/skills/run-tui/tui.sh` - Interactive pty driver
+- `.agents/skills/dashboard-smoke/dashboard.sh` - Headless one-shot smoke
 
 ## Feature Gate
 

--- a/.agents/skills/dashboard-smoke/SKILL.md
+++ b/.agents/skills/dashboard-smoke/SKILL.md
@@ -48,5 +48,6 @@ One-liner by hand:
 | looks like a crash (errno/tcgetattr) | Regression in the non-TTY fallback; inspect `src/features/tui/mod.zig`. |
 | a panel missing | Inspect `src/cli/handlers/dashboard.zig`; use the `tui-navigation-guide` subagent for the render loop. |
 
-Historical verification: **PASS** on Zig master `0.17.0-dev.1099` — one-shot render
-of all 5 panels, exit 0.
+Historical verification: **PASS** on the pin in `.zigversion` — one-shot render
+of all 5 panels, exit 0. Do not hardcode a Zig nightly in this skill; read
+`.zigversion` for the live pin.

--- a/.agents/skills/goals/SKILL.md
+++ b/.agents/skills/goals/SKILL.md
@@ -51,7 +51,7 @@ to the bottom or mark `done`.
 - Do not add legacy CLI names. Preserve the frozen top-level command set and the
   MCP 12-tool contract.
 - When changing public feature APIs, update both the real and stub modules and run
-  `zig build check-parity`.
+  `./build.sh check-parity`.
 - When changing docs, run `.agents/skills/docs-validate/validate.sh` in addition to
   code gates.
 - Goals are user intentions, not tasks — keep `tasks/goals.md` coarse and let
@@ -63,9 +63,10 @@ Prove the slice with the narrow command first, then broaden when the blast radiu
 justifies it:
 
 ```bash
-zig build check-parity --summary all
+./build.sh check-parity
 ./build.sh check
 ```
+
 
 Feature-off parity (each must compile cleanly):
 

--- a/.agents/skills/opencode/plugins/tui/SKILL.md
+++ b/.agents/skills/opencode/plugins/tui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tui
-description: TUI/dashboard superpower. Launch interactive REPL, dashboard panes, split views, and slash commands.
+description: TUI/dashboard OpenCode plugin. Launch interactive agent REPL, diagnostics dashboard panes, and slash commands via real abi CLI paths. There is no /abi-superpower-tui binary.
 superpower:
   command: "execute"
   parameters:
@@ -18,11 +18,13 @@ superpower:
 
 # TUI Superpower Plugin
 
-Core TUI capabilities for OpenCode within the ABI framework.
+Core TUI capabilities for OpenCode within the ABI framework. There is **no**
+`/abi-superpower-tui` binary or slash command — map actions to the real CLI
+paths below (or the `run-tui` / `dashboard-smoke` drivers).
 
 ## Capabilities
 
-- TUI subsystem integration (dashboard, REPL, line editor)
+- TUI subsystem integration (dashboard, agent REPL, line editor)
 - Plugin framework registration
 - Runtime lifecycle management
 - Configuration and settings management
@@ -30,7 +32,7 @@ Core TUI capabilities for OpenCode within the ABI framework.
 
 ## Integration Points
 
-- ABI's TUI subsystem integration
+- ABI's TUI subsystem (`abi tui` / `abi dashboard` / `abi agent tui`)
 - OpenCode plugin framework integration
 - Runtime lifecycle management
 - Configuration and settings management
@@ -38,25 +40,41 @@ Core TUI capabilities for OpenCode within the ABI framework.
 ## Actions
 
 ### repl
-Launch agent REPL with slash commands:
-```
-/abi-superpower-tui repl
+Launch the agent REPL (slash commands live here):
+```bash
+./zig-out/bin/abi agent tui
 ```
 
 ### dashboard
-Show diagnostics dashboard:
+Show the diagnostics dashboard (`abi tui` is an alias of `abi dashboard`):
+```bash
+./zig-out/bin/abi dashboard --pane system
+./zig-out/bin/abi dashboard --pane plugins --once --json
+./zig-out/bin/abi tui --compact --pane scheduler
 ```
-/abi-superpower-tui dashboard --pane system
-/abi-superpower-tui dashboard --pane plugins --once --json
+
+Interactive pty smoke (tmux driver):
+```bash
+.agents/skills/run-tui/tui.sh              # drives `abi dashboard`
+.agents/skills/run-tui/tui.sh tui          # drives `abi tui`
+```
+
+Headless one-shot smoke:
+```bash
+.agents/skills/dashboard-smoke/dashboard.sh
 ```
 
 ### pane
-Switch focus between split panes (Tab key in interactive):
-```
-/abi-superpower-tui pane --focus agent_output
+Select the initial diagnostics pane with `--pane` (system, plugins, storage/wdbx,
+scheduler, memory, or 1–5). In the interactive refresh loop, switch panes with
+hotkeys / Tab — there is no separate `pane --focus` CLI.
+
+```bash
+./zig-out/bin/abi dashboard --list-panes
+./zig-out/bin/abi dashboard --pane memory
 ```
 
-## Slash Commands (in REPL)
+## Slash Commands (in `abi agent tui` REPL)
 
 - `/open <path>` - Load file into context
 - `/diff` - Git diff
@@ -72,9 +90,11 @@ Switch focus between split panes (Tab key in interactive):
 ## Implementation
 
 Maps to:
-- `src/features/tui/repl.zig` - REPL with line editor
-- `src/features/tui/dashboard.zig` - Split-pane dashboard
+- `src/features/tui/repl.zig` - REPL with line editor (`abi agent tui`)
+- `src/features/tui/dashboard.zig` - Split-pane dashboard (`abi tui` / `abi dashboard`)
 - `src/features/tui/line_editor.zig` - CSI decode, cursor, history
+- `.agents/skills/run-tui/tui.sh` - Interactive pty driver
+- `.agents/skills/dashboard-smoke/dashboard.sh` - Headless one-shot smoke
 
 ## Feature Gate
 

--- a/.agents/skills/run-tui/SKILL.md
+++ b/.agents/skills/run-tui/SKILL.md
@@ -27,8 +27,10 @@ and there's **no** `errno 19`/`tcgetattr`/panic. Sends `q` (the quit key —
 To eyeball it yourself: `tmux capture-pane -pt <session>` shows the System pane
 (GPU backend, accelerated, native-linked) and the Plugins pane (16 registered).
 
-Historical verification: **PASS** on Zig master `0.17.0-dev.1099` — dashboard box +
+Historical verification: **PASS** on the pin in `.zigversion` — dashboard box +
 System + Plugins panes render under the pty; `q` quits; session cleaned up.
+Do not hardcode a Zig nightly in this skill; read `.zigversion` for the live pin.
+
 
 ## Gotchas (battle scars)
 - ⚠️ **Do NOT prepend `/opt/homebrew/bin` to PATH.** Homebrew ships a `zig`

--- a/.agents/skills/tui/SKILL.md
+++ b/.agents/skills/tui/SKILL.md
@@ -14,13 +14,17 @@ Routes:
 | Non-interactive one-shot `abi dashboard` smoke (CI/headless) | `dashboard-smoke` |
 | Deep-dive the TUI superpower (panes, slash commands) | `abi-superpower-tui` |
 
-## Slash commands backed by skills (`.opencode.json` `slash_commands`)
-`/open`→file-context-loader, `/diff`→git-diff-integration,
-`/commit`→git-commit-integration, `/context`→context-state-reporter,
-`/features`→feature-flag-display, `/learn`→sea-learning-controller,
-`/save`→session-persister, `/load`→session-restorer,
-`/status`→agent-status-reporter, `/reset`→context-resetter. Plugin-provided
-commands come from `abi-plugin.json` `commands`.
+## REPL slash commands (agent TUI, not OpenCode config)
+
+Implemented in `src/features/tui/repl*.zig` (see `abi-superpower-tui`). Companion
+skills document the agent-side helpers: `/open`→file-context-loader,
+`/diff`→git-diff-integration, `/commit`→git-commit-integration,
+`/context`→context-state-reporter, `/features`→feature-flag-display,
+`/learn`→sea-learning-controller, `/save`→session-persister,
+`/load`→session-restorer, `/status`→agent-status-reporter,
+`/reset`→context-resetter. Plugin-provided commands come from
+`abi-plugin.json` `commands`. Repo OpenCode config is `opencode.json` (no
+`slash_commands` key).
 
 ## Gotchas
 - `dashboard-smoke` reads stdin from `/dev/null` to force the non-interactive

--- a/.claude/skills/abi-claims-validator/SKILL.md
+++ b/.claude/skills/abi-claims-validator/SKILL.md
@@ -1,27 +1,25 @@
 ---
 name: abi-claims-validator
-description: ABI external claims validator. Validates docs/collateral against repo source, tests, and external-claims-audit.mdx. Prevents unsupported claims in public artifacts.
+description: Validate ABI docs and external collateral against repo evidence and docs/contracts/external-claims-audit.mdx. Use when auditing claims, scanning docs for unsupported QPS/sharding/FHE/AES language, checking one claim before publish, or re-confirming the external-claims audit. Agent procedure only — not a CLI or slash command. Pair with abi-doc-claims-sync when editing docs.
 ---
 
 # ABI Claims Validator
 
-Validates documentation, collateral, and public claims against the repository source of truth (`build.zig`, `src/`, contract tests, `docs/contracts/external-claims-audit.mdx`). Use before publishing any external artifact.
+Agent-side procedure to validate documentation, collateral, and public claims
+against the repository source of truth (`build.zig`, `src/`, contract tests,
+`docs/contracts/external-claims-audit.mdx`). Use before publishing any external
+artifact. There is **no** `/abi-claims-validator` binary or slash command — follow
+the steps below (or dispatch the `external-claims-auditor` subagent).
 
-## Usage
+For *editing* docs to stay claim-honest, prefer `abi-doc-claims-sync`.
 
-```
-/abi-claims-validator scan [--path docs/] [--strict]
-/abi-claims-validator check-claim "<claim text>"
-/abi-claims-validator audit [--output claims-audit.md]
-```
-
-## Actions
+## Procedure (agent actions)
 
 ### scan
-Scan Markdown/MDX files for claim patterns and cross-reference with repo evidence:
-```
-/abi-claims-validator scan --path docs/
-```
+1. Open the target tree (default `docs/`, plus README/AGENTS/CHANGELOG/walkthrough as needed).
+2. Search for claim patterns (table below) with ripgrep or equivalent.
+3. For each hit, cross-reference source/tests/`external-claims-audit.mdx`.
+4. In `--strict` mode, treat any unproven number or deployment claim as a fail.
 
 Detects:
 - Performance numbers (QPS, latency, throughput, accuracy)
@@ -33,18 +31,13 @@ Detects:
 - Energy/GPU speedup claims
 
 ### check-claim
-Validate a specific claim against repo evidence:
-```
-/abi-claims-validator check-claim "WDBX achieves 12,000 QPS"
-```
-
-Returns: `SUPPORTED` | `UNSUPPORTED` | `PARTIAL` + evidence path
+Given one claim string, return `SUPPORTED` | `UNSUPPORTED` | `PARTIAL` plus the
+evidence path (source, test, or audit section). Prefer executable evidence over prose.
 
 ### audit
-Generate full claims audit report:
-```
-/abi-claims-validator audit --output claims-audit.md
-```
+Produce a short markdown report of flagged claims vs evidence. The durable
+ledger lives in `docs/contracts/external-claims-audit.mdx` — update that file
+when the audit changes reality, do not invent a parallel truth source.
 
 ## Source of Truth Hierarchy
 
@@ -76,14 +69,11 @@ From `docs/contracts/external-claims-audit.mdx` §Reusable Delta:
 
 ## Integration
 
-Run as pre-publish gate:
+Pre-publish gate (agent runs the scan procedure after code gates):
 ```bash
-# In CI or local
-zig build check-parity --summary all
+./build.sh check-parity
 ./build.sh check
-/abi-claims-validator scan --path docs/ --strict
+# then: scan docs/ + collateral per Procedure above (--strict)
 ```
 
-## Feature Gates
-
-No feature gates — runs as standalone validation tool against source.
+No feature gates — procedural validation against source.

--- a/.claude/skills/abi-superpower-tui/SKILL.md
+++ b/.claude/skills/abi-superpower-tui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: abi-superpower-tui
-description: TUI/dashboard superpower. Launch interactive REPL, dashboard panes, split views, and slash commands.
+description: TUI/dashboard superpower. Launch interactive agent REPL, diagnostics dashboard panes, and slash commands via real abi CLI paths. Use when working on abi tui / dashboard / agent tui. There is no /abi-superpower-tui binary.
 superpower:
   command: "execute"
   parameters:
@@ -18,30 +18,48 @@ superpower:
 
 # ABI Superpower: TUI
 
-Exposes the interactive TUI and dashboard as a superpower.
+Exposes the interactive TUI and dashboard as a superpower. There is **no**
+`/abi-superpower-tui` binary or slash command — map actions to the real CLI
+paths below (or the `run-tui` / `dashboard-smoke` drivers).
 
 ## Actions
 
 ### repl
-Launch agent REPL with slash commands:
-```
-/abi-superpower-tui repl
+Launch the agent REPL (slash commands live here):
+```bash
+./zig-out/bin/abi agent tui
 ```
 
 ### dashboard
-Show diagnostics dashboard:
+Show the diagnostics dashboard (`abi tui` is an alias of `abi dashboard`):
+```bash
+./zig-out/bin/abi dashboard --pane system
+./zig-out/bin/abi dashboard --pane plugins --once --json
+./zig-out/bin/abi tui --compact --pane scheduler
 ```
-/abi-superpower-tui dashboard --pane system
-/abi-superpower-tui dashboard --pane plugins --once --json
+
+Interactive pty smoke (tmux driver):
+```bash
+.agents/skills/run-tui/tui.sh              # drives `abi dashboard`
+.agents/skills/run-tui/tui.sh tui          # drives `abi tui`
+```
+
+Headless one-shot smoke:
+```bash
+.agents/skills/dashboard-smoke/dashboard.sh
 ```
 
 ### pane
-Switch focus between split panes (Tab key in interactive):
-```
-/abi-superpower-tui pane --focus agent_output
+Select the initial diagnostics pane with `--pane` (system, plugins, storage/wdbx,
+scheduler, memory, or 1–5). In the interactive refresh loop, switch panes with
+hotkeys / Tab — there is no separate `pane --focus` CLI.
+
+```bash
+./zig-out/bin/abi dashboard --list-panes
+./zig-out/bin/abi dashboard --pane memory
 ```
 
-## Slash Commands (in REPL)
+## Slash Commands (in `abi agent tui` REPL)
 
 - `/open <path>` - Load file into context
 - `/diff` - Git diff
@@ -57,9 +75,11 @@ Switch focus between split panes (Tab key in interactive):
 ## Implementation
 
 Maps to:
-- `src/features/tui/repl.zig` - REPL with line editor
-- `src/features/tui/dashboard.zig` - Split-pane dashboard
+- `src/features/tui/repl.zig` - REPL with line editor (`abi agent tui`)
+- `src/features/tui/dashboard.zig` - Split-pane dashboard (`abi tui` / `abi dashboard`)
 - `src/features/tui/line_editor.zig` - CSI decode, cursor, history
+- `.agents/skills/run-tui/tui.sh` - Interactive pty driver
+- `.agents/skills/dashboard-smoke/dashboard.sh` - Headless one-shot smoke
 
 ## Feature Gate
 

--- a/.claude/skills/dashboard-smoke/SKILL.md
+++ b/.claude/skills/dashboard-smoke/SKILL.md
@@ -48,5 +48,6 @@ One-liner by hand:
 | looks like a crash (errno/tcgetattr) | Regression in the non-TTY fallback; inspect `src/features/tui/mod.zig`. |
 | a panel missing | Inspect `src/cli/handlers/dashboard.zig`; use the `tui-navigation-guide` subagent for the render loop. |
 
-Historical verification: **PASS** on Zig master `0.17.0-dev.1099` — one-shot render
-of all 5 panels, exit 0.
+Historical verification: **PASS** on the pin in `.zigversion` — one-shot render
+of all 5 panels, exit 0. Do not hardcode a Zig nightly in this skill; read
+`.zigversion` for the live pin.

--- a/.claude/skills/goals/SKILL.md
+++ b/.claude/skills/goals/SKILL.md
@@ -51,7 +51,7 @@ to the bottom or mark `done`.
 - Do not add legacy CLI names. Preserve the frozen top-level command set and the
   MCP 12-tool contract.
 - When changing public feature APIs, update both the real and stub modules and run
-  `zig build check-parity`.
+  `./build.sh check-parity`.
 - When changing docs, run `.agents/skills/docs-validate/validate.sh` in addition to
   code gates.
 - Goals are user intentions, not tasks — keep `tasks/goals.md` coarse and let
@@ -63,9 +63,10 @@ Prove the slice with the narrow command first, then broaden when the blast radiu
 justifies it:
 
 ```bash
-zig build check-parity --summary all
+./build.sh check-parity
 ./build.sh check
 ```
+
 
 Feature-off parity (each must compile cleanly):
 

--- a/.claude/skills/run-tui/SKILL.md
+++ b/.claude/skills/run-tui/SKILL.md
@@ -27,8 +27,10 @@ and there's **no** `errno 19`/`tcgetattr`/panic. Sends `q` (the quit key —
 To eyeball it yourself: `tmux capture-pane -pt <session>` shows the System pane
 (GPU backend, accelerated, native-linked) and the Plugins pane (16 registered).
 
-Historical verification: **PASS** on Zig master `0.17.0-dev.1099` — dashboard box +
+Historical verification: **PASS** on the pin in `.zigversion` — dashboard box +
 System + Plugins panes render under the pty; `q` quits; session cleaned up.
+Do not hardcode a Zig nightly in this skill; read `.zigversion` for the live pin.
+
 
 ## Gotchas (battle scars)
 - ⚠️ **Do NOT prepend `/opt/homebrew/bin` to PATH.** Homebrew ships a `zig`

--- a/.claude/skills/tui/SKILL.md
+++ b/.claude/skills/tui/SKILL.md
@@ -14,13 +14,17 @@ Routes:
 | Non-interactive one-shot `abi dashboard` smoke (CI/headless) | `dashboard-smoke` |
 | Deep-dive the TUI superpower (panes, slash commands) | `abi-superpower-tui` |
 
-## Slash commands backed by skills (`.opencode.json` `slash_commands`)
-`/open`→file-context-loader, `/diff`→git-diff-integration,
-`/commit`→git-commit-integration, `/context`→context-state-reporter,
-`/features`→feature-flag-display, `/learn`→sea-learning-controller,
-`/save`→session-persister, `/load`→session-restorer,
-`/status`→agent-status-reporter, `/reset`→context-resetter. Plugin-provided
-commands come from `abi-plugin.json` `commands`.
+## REPL slash commands (agent TUI, not OpenCode config)
+
+Implemented in `src/features/tui/repl*.zig` (see `abi-superpower-tui`). Companion
+skills document the agent-side helpers: `/open`→file-context-loader,
+`/diff`→git-diff-integration, `/commit`→git-commit-integration,
+`/context`→context-state-reporter, `/features`→feature-flag-display,
+`/learn`→sea-learning-controller, `/save`→session-persister,
+`/load`→session-restorer, `/status`→agent-status-reporter,
+`/reset`→context-resetter. Plugin-provided commands come from
+`abi-plugin.json` `commands`. Repo OpenCode config is `opencode.json` (no
+`slash_commands` key).
 
 ## Gotchas
 - `dashboard-smoke` reads stdin from `/dev/null` to force the non-interactive

--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,167 @@
+# the name by which the project can be referenced within Serena/when chatting with the LLM.
+project_name: "abi"
+
+# list of languages for which language servers are started (LSP backend only); choose from:
+#   ada                 al                  angular             ansible             bash
+#   bsl                 clojure             cpp                 cpp_ccls            crystal
+#   csharp              csharp_omnisharp    cue                 dart                elixir
+#   elm                 erlang              fortran             fsharp              gdscript
+#   go                  groovy              haskell             haxe                hlsl
+#   html                java                json                julia               kotlin
+#   latex               lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        php_phpantom        powershell
+#   python              python_jedi         python_pyrefly      python_ty           r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   scss                solidity            svelte              swift               systemverilog
+#   terraform           toml                typescript          typescript_vts      vue
+#   yaml                zig
+#   (This list may be outdated; generated with scripts/print_language_list.py;
+#   For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py)
+# For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- zig
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# optional shell command to run before the language backend (LSP or JetBrains) is initialised.
+# the command runs in the project root directory and is only executed if the project is trusted
+# (see trusted_project_path_patterns in the global configuration).
+# serena waits for the command to exit: a non-zero exit code is logged as an error but does not
+# abort activation. a per-project timeout (activation_command_timeout, default 180s) is the safety
+# backstop for non-terminating commands; on expiry the process is killed and activation continues.
+# example: activation_command: "npx nx run-many -t build"
+activation_command:
+
+# maximum time in seconds to wait for activation_command to complete before killing it (default 180s).
+# must be a positive number.
+activation_command_timeout: 180.0
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# The settings are considered only if the project is trusted (see global configuration to define trusted projects).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#language-server-specific-settings
+ls_specific_settings: {}
+
+# list of workspace folder paths (LSP backend only).
+# These folders will be used to build up Serena's symbol index.
+# Paths must be within the project root and should thus be relative to the project root.
+# Furthermore, the paths should not be filtered by ignore settings.
+# Default setting: The entire project root folder (".") is considered.
+# In (large) monorepos, this can be used to index only subfolders of the project root, e.g.
+#   ls_workspace_folders:
+#     - "./subproject1"
+#     - "./subproject2"
+ls_workspace_folders:
+- "."
+
+# list of additional workspace folder paths for cross-package reference support.
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries, but these folders are not indexed by Serena,
+# i.e. the respective symbols will not be found using Serena's symbol search tools.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+ls_additional_workspace_folders: []
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Important: quote patterns that start with `*`, otherwise YAML treats them as aliases.
+# Example:
+#   ignored_paths:
+#     - "examples/**"
+#     - ".worktrees/**"
+#     - "**/bin/**"
+#     - "**/obj/**"
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
+fixed_tools: []
+
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+default_modes:
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ Canonical instruction file. If this conflicts with `build.zig`, `tools/build.sh`
 - `pub fn main(init: std.process.Init) !void`; `ArrayListUnmanaged(T).empty`; `std.mem.trimEnd`/`splitScalar`/`splitAny`/`splitSequence`; `foundation.time.unixMs()`.
 - Tests: inline `test {}`, end modules with `std.testing.refAllDecls(@This())`.
 - No silent `catch {}` in data/inference/persistence paths. `build_options.feat_*` for conditional compilation. Explicit `std.mem.Allocator` (no global).
-- MemoryTracker: track owned-and-freed scratch as `trackAllocNoTag`/`trackFreeNoTag` pairs; never track escaping buffers at the alloc site. `getTotalFreed() > 0` proves a balanced transient pair fired.
+- **MemoryTracker**: track owned-and-freed scratch as `trackAllocNoTag`/`trackFreeNoTag` pairs; never track escaping buffers at the alloc site. `getTotalFreed() > 0` proves a balanced transient pair fired.
 
 ## Claims discipline
 No unproven claims (production FHE/AES/RBAC, multi-host sharding, QPS/latency/accuracy, K8s/H100, external stacks). WDBX demo modules (`compression`, `entropy`, `ans`, `neural_compress`, `crypto_he`, `fhe`) are reference-grade, not production. Audit: `docs/contracts/external-claims-audit.mdx`.


### PR DESCRIPTION
Fixes skill-doc errors:

- TUI superpower now maps to real abi CLI paths (src/features/tui/repl*.zig, not opencode.json slash_commands)
- Goals/claims boundaries clarified in abi-goal-orchestrator and abi-claims-validator
- Dashboard-smoke, run-tui, tui skill docs updated

Also includes trivial AGENTS.md bold formatting fix.