### PR TITLE
fix(ci): explicitly select pinned Zig on the self-hosted runner PATH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
         target: [check, cross-smoke]
     steps:
       - uses: actions/checkout@v4
+      - name: Select pinned Zig
+        # The self-hosted runner's ambient PATH is not guaranteed to point at
+        # the pin (zvm's mutable "master" channel can and does drift ahead of
+        # it — see AGENTS.md). Prepend the pinned install explicitly instead
+        # of trusting whatever `zig` the runner's shell profile resolves.
+        run: echo "$HOME/.zvm/${{ env.ZIG_VERSION }}" >> "$GITHUB_PATH"
       - name: Verify pinned Zig on runner PATH
         run: ./tools/check_zigversion.sh --github-actions
       - name: zig build ${{ matrix.target }}


### PR DESCRIPTION
## Summary
- The self-hosted CI \`check\` job's PATH resolves \`zig\` to zvm's \`master\` channel (currently 0.17.0-dev.1442) instead of the pin (0.17.0-dev.1398+cb5635714) — same pin-drift class as the build.zig/hook fixes in #716, now caught in CI itself: \`zig build check\`'s fmt step flagged pinned-syntax files as needing reformatting to master-only builtins, failing the gate.
- \`tools/check_zigversion.sh\` only *warns* on active-vs-pin mismatch by design (local PATH legitimately varies during dev), so it didn't block this.
- Fix: prepend the pinned install to \`$GITHUB_PATH\` explicitly before the build steps, so the self-hosted job no longer depends on the runner's ambient zvm default.

## Test plan
- [x] Diagnosed directly from the failing run's logs (\`failed command: /Users/donaldfilimon/.zvm/master/zig fmt --check ...\`) — this is a one-line PATH fix for a self-hosted-runner-only environment issue, not independently testable outside that runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164z7bhWzcMdW5boChHYZGz