### PR TITLE
fix(security,wdbx): close loopback-exemption bypass; atomic manifest writes

### DIFF
--- a/src/connectors/http.zig
+++ b/src/connectors/http.zig
@@ -140,16 +140,27 @@ fn mapHttpStatus(status: std.http.Status) ConnectorError!void {
     };
 }
 
+/// True if `s` starts with `prefix` (case-insensitively) and the prefix ends
+/// at a real host-name boundary — end of string, or a `:`/`/` separator.
+/// A bare prefix match would let `http://127.0.0.1.evil.com` or
+/// `http://127.0.0.1@evil.com` slip through as if they were loopback.
+fn hasHostPrefix(s: []const u8, prefix: []const u8) bool {
+    if (s.len < prefix.len or !std.ascii.eqlIgnoreCase(s[0..prefix.len], prefix)) return false;
+    if (s.len == prefix.len) return true;
+    return switch (s[prefix.len]) {
+        ':', '/' => true,
+        else => false,
+    };
+}
+
 /// Live connector base URLs must use HTTPS so API keys are never sent over
 /// cleartext HTTP (TM-007). Loopback URLs (http://127.0.0.1 / http://localhost)
 /// are exempted so local integration tests and loopback services work without TLS.
 pub fn requireHttpsBaseUrl(base_url: []const u8) ConnectorError!void {
     const https_prefix = "https://";
     if (base_url.len >= https_prefix.len and std.ascii.eqlIgnoreCase(base_url[0..https_prefix.len], https_prefix)) return;
-    const loopback_http = "http://127.0.0.1";
-    if (base_url.len >= loopback_http.len and std.ascii.eqlIgnoreCase(base_url[0..loopback_http.len], loopback_http)) return;
-    const localhost_http = "http://localhost";
-    if (base_url.len >= localhost_http.len and std.ascii.eqlIgnoreCase(base_url[0..localhost_http.len], localhost_http)) return;
+    if (hasHostPrefix(base_url, "http://127.0.0.1")) return;
+    if (hasHostPrefix(base_url, "http://localhost")) return;
     return ConnectorError.InsecureBaseUrl;
 }
 
@@ -330,6 +341,25 @@ test "requireHttpsBaseUrl accepts https and rejects cleartext schemes" {
     try std.testing.expectError(error.InsecureBaseUrl, requireHttpsBaseUrl("ftp://example.com"));
     try std.testing.expectError(error.InsecureBaseUrl, requireHttpsBaseUrl(""));
     try std.testing.expectError(error.InsecureBaseUrl, requireHttpsBaseUrl("https:/bad"));
+}
+
+test "requireHttpsBaseUrl loopback exemption checks a real host boundary" {
+    // Legitimate loopback forms must still pass.
+    try requireHttpsBaseUrl("http://127.0.0.1");
+    try requireHttpsBaseUrl("http://127.0.0.1:8080");
+    try requireHttpsBaseUrl("http://127.0.0.1/v1");
+    try requireHttpsBaseUrl("http://localhost");
+    try requireHttpsBaseUrl("http://localhost:11434");
+    try requireHttpsBaseUrl("HTTP://LOCALHOST/v1");
+
+    // A bare prefix match must not exempt a spoofed non-loopback host — these
+    // all start with the loopback prefix but resolve to an attacker host and
+    // must be rejected as insecure, not silently treated as loopback.
+    try std.testing.expectError(error.InsecureBaseUrl, requireHttpsBaseUrl("http://127.0.0.1.evil.com"));
+    try std.testing.expectError(error.InsecureBaseUrl, requireHttpsBaseUrl("http://127.0.0.1@evil.com"));
+    try std.testing.expectError(error.InsecureBaseUrl, requireHttpsBaseUrl("http://127.0.0.10"));
+    try std.testing.expectError(error.InsecureBaseUrl, requireHttpsBaseUrl("http://localhost.evil.com"));
+    try std.testing.expectError(error.InsecureBaseUrl, requireHttpsBaseUrl("http://localhost@evil.com"));
 }
 
 test "joinUrl requires https and joins path segments" {

--- a/src/features/wdbx/segments.zig
+++ b/src/features/wdbx/segments.zig
@@ -88,6 +88,19 @@ pub const SegmentStore = struct {
                 }
             }
         }
+
+        // `flush` always appends the pre-increment `next_epoch` as the new
+        // (and therefore highest) active epoch, and `reclaim` never drops the
+        // highest epoch — so `max(active) + 1 == next_epoch` holds after every
+        // successful write. A torn/truncated write can still parse as a valid
+        // manifest (a shorter-but-well-formed `active=` list) while violating
+        // this invariant; catching it here turns silent stale-checkpoint
+        // recovery into a loud, honest failure instead.
+        if (m.active.items.len > 0) {
+            var max: u64 = m.active.items[0];
+            for (m.active.items) |e| max = @max(max, e);
+            if (max + 1 != m.next_epoch) return SegmentError.InvalidManifest;
+        }
         return m;
     }
 
@@ -104,7 +117,18 @@ pub const SegmentStore = struct {
 
         const mp = try self.manifestPath();
         defer self.allocator.free(mp);
-        try std.Io.Dir.cwd().writeFile(self.io, .{ .sub_path = mp, .data = out.written() });
+        // Write-then-rename rather than truncate-in-place: a crash or partial
+        // write mid-truncate can leave a manifest that still parses (a valid
+        // prefix of the old content) but silently understates `active`,
+        // pointing recovery at a stale epoch instead of failing loudly or
+        // falling back to the legacy mirror. Rename is atomic on the
+        // filesystems this store targets, so readers only ever see the old
+        // manifest or the fully-written new one, never a torn one.
+        const tmp = try std.fmt.allocPrint(self.allocator, "{s}.tmp", .{mp});
+        defer self.allocator.free(tmp);
+        const cwd = std.Io.Dir.cwd();
+        try cwd.writeFile(self.io, .{ .sub_path = tmp, .data = out.written() });
+        try cwd.rename(tmp, cwd, mp, self.io);
     }
 
     /// Checkpoint `store` as a new immutable segment; returns its epoch.
@@ -440,11 +464,44 @@ test "segments: readManifest rejects corrupt manifests rather than mis-parsing" 
         "# BOGUS HEADER\n", // wrong/missing header
         MANIFEST_HEADER ++ "\nnext_epoch=abc\n", // non-numeric next_epoch
         MANIFEST_HEADER ++ "\nnext_epoch=1\nactive=0,xx\n", // non-numeric active token
+        // A well-formed-but-truncated `active=` list (as a torn/partial write
+        // could produce): syntactically valid, but understates the live
+        // epochs relative to `next_epoch`. Must fail loudly, not silently
+        // recover a stale checkpoint while orphaning newer segments on disk.
+        MANIFEST_HEADER ++ "\nnext_epoch=3\nactive=0\n",
     };
     for (corrupt) |bad| {
         try std.Io.Dir.cwd().writeFile(testing.io, .{ .sub_path = mp, .data = bad });
         try testing.expectError(SegmentError.InvalidManifest, ss.latestEpoch());
     }
+}
+
+test "segments: writeManifest survives a killed write via rename, never a torn file" {
+    const allocator = testing.allocator;
+    const base = "zig-out/wdbx-seg-atomic";
+    cleanup(base);
+    defer cleanup(base);
+
+    var ss = SegmentStore.init(allocator, testing.io, base);
+
+    var s0 = wdbx_mod.Store.init(allocator);
+    _ = try s0.appendBlock("abbey", 0, 0, "{\"t\":1}");
+    _ = try ss.flush(&s0);
+    s0.deinit();
+
+    var s1 = wdbx_mod.Store.init(allocator);
+    _ = try s1.appendBlock("abbey", 0, 0, "{\"t\":1}");
+    _ = try s1.appendBlock("aviva", 0, 0, "{\"t\":2}");
+    _ = try ss.flush(&s1);
+    s1.deinit();
+
+    // No leftover `.manifest.tmp` after a normal write sequence.
+    const mp = base ++ ".manifest";
+    const tmp = mp ++ ".tmp";
+    try testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(testing.io, tmp, .{}));
+
+    // The committed manifest reflects the final state, not a torn intermediate.
+    try testing.expectEqual(@as(?u64, 1), try ss.latestEpoch());
 }
 
 test {


### PR DESCRIPTION
## Summary
Two bugs surfaced by a parallel 8-agent codebase review (connector-validator and wdbx-explorer passes, one agent per independent subsystem):

- **`src/connectors/http.zig`** — \`requireHttpsBaseUrl\`'s loopback exemption (TM-007) used a bare prefix match with no host-boundary check, so \`http://127.0.0.1.evil.com\`, \`http://127.0.0.1@evil.com\`, and the \`localhost\` equivalents were treated as loopback and exempted from the HTTPS requirement, which would send Authorization headers in cleartext to an attacker-controlled host. Not reachable today (every live connector hardcodes its own \`base_url\`), but the check is supposed to be a hard guarantee. Fixed by requiring the byte after the prefix to be a real boundary (\`:\`, \`/\`, or end-of-string).
- **\`src/features/wdbx/segments.zig\`** — \`writeManifest\` truncated the manifest file in place with no rename and no fsync, despite \`recovery.zig\` documenting the manifest write as "the atomic commit point" for crash-safe recovery. A torn write that truncates a valid \`active=\` list (e.g. \`0,1,2\` → \`0\`) still parses as well-formed, so \`openCheckpoint\` silently recovers a stale epoch instead of the latest one, orphaning newer segments with no error — **reproduced empirically**: \`db verify\` exits 0 reporting the stale epoch's block count while newer segments sit orphaned on disk. Fixed by write-to-\`.tmp\`-then-rename, plus a \`readManifest\` invariant check (\`max(active)+1 == next_epoch\`, which provably holds after every successful \`flush\`/\`reclaim\`) that turns any remaining torn-write case into a loud \`SegmentError.InvalidManifest\` instead of silent stale recovery.

## Test plan
- [x] New regression tests: loopback-boundary bypass cases in \`http.zig\` (both positive — legit loopback URLs still pass — and negative — spoofed hosts now rejected)
- [x] New regression tests: truncated-\`active=\`-list case added to \`segments.zig\`'s existing corrupt-manifest test, plus a dedicated write/rename-cycle test confirming no leftover \`.tmp\` file and correct final state
- [x] \`~/.zvm/0.17.0-dev.1398+cb5635714/zig build check\` passes clean (build + tests + lint + parity + feature-off stubs + CLI contract smoke) against the actual pinned compiler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164z7bhWzcMdW5boChHYZGz