### PR TITLE
docs: surface Abbey identity on Mintlify / GitHub Pages hub

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,17 +1,21 @@
-# Docs layout (Mintlify)
+# Docs layout (Mintlify / GitHub Pages hub)
 
 ABI's published documentation lives under this directory and is configured by
-[`docs.json`](docs.json). Hosting is **Mintlify** (GitHub app / linked project),
-not a custom `gh-pages` static tree. GitHub Actions validates the site on every
-push/PR (`docs-validate` job in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml)).
+[`docs.json`](docs.json). The public site is served by **Mintlify** (GitHub app /
+linked project that publishes from this tree). It is **not** a custom static
+`gh-pages` tree for the main docs. Separately, optional benchmark dashboards may
+use the `gh-pages` branch via [`.github/workflows/benchmarks-gh-pages.yml`](../.github/workflows/benchmarks-gh-pages.yml).
+GitHub Actions validates the Mintlify site on every push/PR (`docs-validate`
+job in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml)).
 
 ## Tree
 
 | Path | Role | In Mintlify nav? |
 | ---- | ---- | ---------------- |
-| [`index.mdx`](index.mdx) | Hub (Cards → contracts / architecture) | Yes |
+| [`index.mdx`](index.mdx) | Hub (Cards → contracts / identity / architecture) | Yes |
 | [`contributing.mdx`](contributing.mdx) | Doc contribution + claim rules | Yes |
 | [`contracts/*.mdx`](contracts/) | Frozen public surfaces + external claims audit | Yes |
+| [`spec/abbey-core-identity.mdx`](spec/abbey-core-identity.mdx) | Canonical Abbey / Aviva / ABI / WDBX identity + evidence map | Yes |
 | [`spec/*.mdx`](spec/) | Architecture / north-star / ops (Current/Partial/Proposed) | Yes |
 | [`superpowers/`](superpowers/) | Working plans/specs + archive — **not** public contracts | No |
 | [`tutorials/`](tutorials/) | How-to guides (not in Mintlify nav) | No |
@@ -20,7 +24,11 @@ push/PR (`docs-validate` job in [`.github/workflows/ci.yml`](../.github/workflow
 ## Source of truth
 
 When prose disagrees with code, trust `build.zig`, `src/`, `tests/contracts/`, and
-`./build.sh check`. Claim boundaries: [`contracts/external-claims-audit.mdx`](contracts/external-claims-audit.mdx).
+`./build.sh check`. Claim boundaries:
+[`contracts/external-claims-audit.mdx`](contracts/external-claims-audit.mdx).
+Persona / product identity direction:
+[`spec/abbey-core-identity.mdx`](spec/abbey-core-identity.mdx) and
+`src/features/ai/identity.zig`.
 
 ## Local validation
 

--- a/docs/contracts/public-api.mdx
+++ b/docs/contracts/public-api.mdx
@@ -48,6 +48,25 @@ The WDBX store contract exposes key-value counts, vector counts, block counts, s
 
 This contract does not prove distributed sharding, AES-256 encryption, RBAC, Swift/Python/TensorFlow implementations, Kubernetes/H100 deployments, regulatory certifications, production QPS/latency/accuracy, energy-use, or comparative model-benchmark claims. Keep those out of public collateral unless they are backed by new executable tests, benchmark artifacts, or implementation files.
 
+## AI identity and multi-persona surface
+
+`abi.features.ai.identity` (`src/features/ai/identity.zig`) is the executable
+mirror of the Abbey Core Identity contract:
+
+- Abbey is the only `primary_user_facing` profile; Aviva is the direct expert
+  mode; ABI is the orchestration/governance profile.
+- Default routing prior is Abbey-primary (`DEFAULT_ABBEY_WEIGHT` /
+  `DEFAULT_AVIVA_WEIGHT` / `DEFAULT_ABI_WEIGHT`); keyword evidence may still
+  select Aviva or ABI.
+- `primary_declaration` is product direction, not proof that every named
+  capability is Current.
+- `capability_claims` map areas such as visual generation, distributed AI, and
+  empirical benchmarks to Current / Partial / Proposed with explicit boundaries.
+
+Human-readable companion: `docs/spec/abbey-core-identity.mdx`. Local profile
+responses remain deterministic templates via `incremental.zig` /
+`router.zig` — not live model quality or distributed multi-host claims.
+
 ## AI/WDBX completion contract
 
 `abi.features.ai.CompletionRequest.store_result` defaults to `false`. `completeWithStore()` must not mutate WDBX when storage is not requested, when input is invalid, or when WDBX is disabled.

--- a/docs/contributing.mdx
+++ b/docs/contributing.mdx
@@ -19,10 +19,18 @@ Use the narrowest executable source for each claim:
 - Public feature APIs: paired `mod.zig` / `stub.zig` modules and
   `zig build check-parity`
 - Current, Partial, and Proposed capability wording:
-  `contracts/external-claims-audit.mdx` and `spec/wdbx-north-star.mdx`
+  `contracts/external-claims-audit.mdx`, `spec/wdbx-north-star.mdx`, and
+  `spec/abbey-core-identity.mdx` (with executable mirror
+  `src/features/ai/identity.zig`)
+- Abbey / Aviva / ABI / WDBX roles and operating protocol:
+  `spec/abbey-core-identity.mdx`, `spec/multi-persona-technical.mdx`,
+  `src/features/ai/identity.zig`, `src/features/ai/router.zig`
 
 When prose disagrees with these sources, update the prose to match the
 executable behavior. Do not change code merely to preserve stale documentation.
+Do not promote Primary Declaration aspirational wording (distributed AI, embedded
+visual generation, perfect WDBX memory, unpublished benchmarks) to Current without
+source + tests.
 
 ## Claim-safe writing
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -23,15 +23,15 @@
       {
         "group": "Architecture",
         "pages": [
+          "spec/abbey-core-identity",
+          "spec/multi-persona-technical",
           "spec/wdbx-north-star",
           "spec/agent-wdbx-architecture",
           "spec/abi-refactor-design",
-          "spec/abbey-core-identity",
-          "spec/multi-persona-technical",
+          "spec/wdbx-multiway",
           "spec/non-loopback-rest-threat-review",
           "spec/cluster-mtls-ops",
-          "spec/phase-d-cutover-plan",
-          "spec/wdbx-multiway"
+          "spec/phase-d-cutover-plan"
         ]
       },
       {

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -3,13 +3,22 @@ title: "ABI Framework Documentation Hub"
 description: "Welcome to the ABI framework documentation. This hub provides central access to architecture, onboarding, and development guides for the ABI multi-AI…"
 ---
 
-Welcome to the ABI multi-AI orchestration framework documentation. ABI is implemented in Zig 0.17; this hub points at contracts, architecture specs, and build guides without re-stating frozen CLI or MCP surfaces.
+Welcome to the ABI multi-AI orchestration framework documentation. ABI is
+implemented in Zig 0.17; this hub points at contracts, architecture specs, and
+build guides without re-stating frozen CLI or MCP surfaces.
+
+**Primary identity:** Abbey (empathetic polymath), with Aviva (direct expert),
+ABI (orchestration), and WDBX (knowledge/memory substrate). See the
+[Abbey Core Identity](spec/abbey-core-identity) contract for product direction
+and the claim-honest Current / Partial / Proposed evidence map.
 
 <Note type="warning">
   **Source wins.** When docs disagree with `build.zig`, `src/cli/usage.zig`,
   `src/mcp/handlers.zig`, or `tests/contracts/`, trust the executable sources
   and `./build.sh check`. Claim boundaries:
-  [External Claims Audit](contracts/external-claims-audit).
+  [External Claims Audit](contracts/external-claims-audit). Local persona
+  output is deterministic template generation, not a model-quality or
+  distributed-AI claim.
 </Note>
 
 ## Contracts
@@ -27,9 +36,16 @@ Frozen public surfaces and honest external wording. Prefer these over re-listing
 
 ## Architecture / roadmap
 
-Design and north-star docs for agents, WDBX, and multi-persona routing.
+Design and north-star docs for Abbey identity, agents, WDBX, and multi-persona
+routing.
 
 <CardGroup cols={2}>
+  <Card title="Abbey Core Identity" href="spec/abbey-core-identity">
+    Canonical Abbey / Aviva / ABI / WDBX identity, operating protocol, and evidence map.
+  </Card>
+  <Card title="Multi-Persona Technical Overview" href="spec/multi-persona-technical">
+    Deterministic local routing, templates, and runtime wiring.
+  </Card>
   <Card title="WDBX North-Star" href="spec/wdbx-north-star">
     Vision and roadmap — Current vs. Proposed.
   </Card>
@@ -39,8 +55,8 @@ Design and north-star docs for agents, WDBX, and multi-persona routing.
   <Card title="ABI Refactor Design" href="spec/abi-refactor-design">
     Refactor design and module boundaries.
   </Card>
-  <Card title="Multi-Persona Technical Overview" href="spec/multi-persona-technical">
-    Multi-persona routing and technical overview.
+  <Card title="WDBX Multiway" href="spec/wdbx-multiway">
+    Multiway experiment surface and claim boundaries.
   </Card>
   <Card title="Non-loopback REST Threat Review" href="spec/non-loopback-rest-threat-review">
     Ops guidance for exposing REST/MCP HTTP beyond loopback — not a hardened-expose claim.

--- a/docs/spec/abbey-core-identity.mdx
+++ b/docs/spec/abbey-core-identity.mdx
@@ -8,12 +8,17 @@ Organization: **The Donald Company**
 Primary system: **Abbey**  
 Supporting layers: **Aviva, ABI, and WDBX**
 
-This is the canonical product and behavior specification. It contains both
-normative direction (what Abbey should be) and a repository-evidence mapping
-(what the current Zig implementation actually proves). Source, tests, and
+This is the canonical product and behavior specification published on the Mintlify
+docs hub. It contains both normative direction (what Abbey should be) and a
+repository-evidence mapping (what the current Zig implementation actually proves).
+Executable mirror: `src/features/ai/identity.zig`. Source, tests, and
 `docs/contracts/external-claims-audit.mdx` remain authoritative for capability
 claims. Aspirational wording in the Primary Declaration is preserved; it does
 not promote a Partial or Proposed capability to Current.
+
+Related pages: [Multi-Persona Technical Overview](./multi-persona-technical),
+[Agent and WDBX Architecture](./agent-wdbx-architecture),
+[External Claims Audit](../contracts/external-claims-audit).
 
 ## 1. Identity and mission
 

--- a/docs/spec/agent-wdbx-architecture.mdx
+++ b/docs/spec/agent-wdbx-architecture.mdx
@@ -5,10 +5,16 @@ description: "Source-backed overview of how the ABI agent layer composes with WD
 
 ABI is a local AI runtime with two tightly coupled layers:
 
-- **ABI Agent layer**: routing, completion, training, scheduling, CLI/MCP exposure, plugins, connector boundaries, and constitution checks.
+- **ABI Agent layer**: Abbey/Aviva/ABI persona routing, completion, training, scheduling, CLI/MCP exposure, plugins, connector boundaries, and constitution checks.
 - **WDBX layer**: in-process key/value, vector, block, spatial, temporal/causal retrieval, snapshot/WAL/segment persistence, and reference-scoped runtime demos.
 
 The useful mental model is: **ABI is the control plane; WDBX is the memory plane.** The agent layer decides how a request is routed, validated, scheduled, and optionally persisted. WDBX stores the records, vectors, metadata, linked blocks, and retrieval graph that make later local recall possible.
+
+Product identity and claim-honest role boundaries for Abbey (primary), Aviva
+(direct expert), ABI (orchestration), and WDBX (memory substrate) live in
+[`abbey-core-identity.mdx`](./abbey-core-identity) and
+`src/features/ai/identity.zig`. Runtime routing detail is in
+[`multi-persona-technical.mdx`](./multi-persona-technical).
 
 This page describes current repo-backed behavior. When this overview disagrees with `build.zig`, `src/`, `tests/contracts/`, or the build gates, the executable source wins.
 

--- a/docs/spec/multi-persona-technical.mdx
+++ b/docs/spec/multi-persona-technical.mdx
@@ -54,6 +54,8 @@ graph TD
 | Area | Source | Current role |
 | --- | --- | --- |
 | Public root | `src/root.zig` | Exposes the `abi` module namespace. |
+| Identity contract | `src/features/ai/identity.zig` | Profiles, default routing prior, operating protocol, capability claim map, Primary Declaration (product direction). |
+| Persona templates | `src/features/ai/incremental.zig` | Iterative local template generation; prefix/suffix from `identity.profileContract`. |
 | AI module | `src/features/ai/mod.zig` | Completion, training metadata acceptance, WDBX persistence integration, fixed-trio multi-agent entrypoint. |
 | Orchestration | `src/features/ai/orchestration.zig` | Custom worker specs, background scheduler batch, browser local dry-run plan (`embedded_browser=false`). |
 | AI router | `src/features/ai/router.zig` | Keyword-weighted routing, profile selection, optional EMA smoothing. |
@@ -64,11 +66,15 @@ graph TD
 | CLI | `src/cli/` | Frozen command surface and handlers. |
 | MCP | `src/mcp/` | JSON-RPC 2.0 stdio and optional loopback HTTP/SSE tool surface. |
 
+Canonical product identity (roles, privacy, epistemic discipline, evidence map):
+[`abbey-core-identity.mdx`](./abbey-core-identity).
+
 ## 3. Persona Routing
 
-Routing is deterministic and local. `src/features/ai/router.zig` starts with an
-Abbey-primary prior (`0.40 / 0.30 / 0.30`) and adjusts it when keyword patterns
-are found in the input. A neutral input therefore selects Abbey.
+Routing is deterministic and local. `src/features/ai/router.zig` starts from
+`identity.DEFAULT_*_WEIGHT` (currently Abbey-primary
+`0.40 / 0.30 / 0.30`) and adjusts when keyword patterns are found in the input.
+A neutral input therefore selects Abbey.
 
 Current examples from the router keyword table include:
 


### PR DESCRIPTION
## Summary

- Hub (`docs/index.mdx`) leads with Abbey identity and adds cards for Core Identity, Multi-Persona, and WDBX Multiway.
- Nav (`docs/docs.json`) prioritizes `abbey-core-identity` and `multi-persona-technical`.
- Align multi-persona, public-api, agent-wdbx-architecture, contributing, and docs README with `identity.zig` and claim-honest product direction.

## Validation

- [x] `.agents/skills/docs-validate/validate.sh` PASS
- [x] public docs contract filters green