### PR TITLE
fix(ai,sea): explicit persona routing + SEA evidence trust/order

### DIFF
--- a/docs/spec/multi-persona-technical.mdx
+++ b/docs/spec/multi-persona-technical.mdx
@@ -76,6 +76,12 @@ Routing is deterministic and local. `src/features/ai/router.zig` starts from
 `0.40 / 0.30 / 0.30`) and adjusts when keyword patterns are found in the input.
 A neutral input therefore selects Abbey.
 
+An exact leading persona address overrides the heuristic: for example,
+`Aviva, be direct.` selects Aviva and `ABI, orchestrate this.` selects ABI.
+Selection requires a complete leading name token, so `abi` embedded inside a
+larger word does not select the ABI profile. Explicit selection also takes
+precedence over adaptive EMA and optional soul-network blending for that turn.
+
 Current examples from the router keyword table include:
 
 - Abbey-oriented terms include analytical, explanatory, creative, empathetic,
@@ -121,8 +127,12 @@ Profile responses are currently deterministic local strings, not live network mo
 The metadata labels generated completions as `authority=inferred` and
 `epistemic_status=generated_output`, records that persistence came from the
 explicit `store_result` switch, and omits raw prompt/response text. SEA recall
-uses explicit authority as a trust-weighted ranking signal and defaults missing
-or unknown authority to `inferred` rather than promoting it.
+parses exact top-level JSON fields. Generic WDBX key/value metadata is
+self-asserted, so its authority is always downgraded to `inferred`; nested
+fields, textual spoofs, malformed JSON, and unrecognized values cannot promote
+a record. Higher authority requires a separately trusted ingestion boundary.
+Every returned evidence set is sorted by its final score, with vector id as a
+deterministic tie-breaker.
 
 When WDBX is disabled, storage paths return explicit disabled-feature behavior rather than fabricating persistence success.
 

--- a/src/features/ai/completion.zig
+++ b/src/features/ai/completion.zig
@@ -21,9 +21,12 @@ pub fn complete(allocator: std.mem.Allocator, request: types.CompletionRequest) 
 
 pub fn completeAdaptive(allocator: std.mem.Allocator, store: *wdbx.Store, request: types.CompletionRequest) !types.CompletionResult {
     if (request.input.len == 0) return error.InvalidCompletionInput;
+    // Persona routing uses the raw user utterance when callers (SEA learn-loop)
+    // pass evidence-augmented text as `input`. Generation still sees `input`.
+    const route_text = request.routing_input orelse request.input;
     var modulator = router.AdaptiveModulator.loadWeights(store);
-    modulator.update(router.analyzeSentiment(request.input));
-    const selected = router.selectBestProfile(modulator.weights());
+    modulator.update(router.analyzeSentiment(route_text));
+    const selected = router.explicitProfileSelector(route_text) orelse router.selectBestProfile(modulator.weights());
     return completeWithSelectedProfile(
         allocator,
         request,
@@ -293,6 +296,41 @@ test "complete surfaces the weighted E-score and emits per-turn governance telem
     try std.testing.expect(result.audit.escore >= 0.0 and result.audit.escore <= 1.0);
     // The turn was counted exactly once through the existing telemetry path.
     try std.testing.expectEqual(before + 1, telemetry.counterValue("ai.constitution.evaluated"));
+}
+
+test "adaptive completion honors explicit profile selector over persisted EMA" {
+    if (!build_options.feat_wdbx) return;
+    const allocator = std.testing.allocator;
+    var store = wdbx.Store.init(allocator);
+    defer store.deinit();
+
+    try store.store("modulator:weights", "0.990000,0.005000,0.005000,42,0.300000");
+    var result = try completeAdaptive(allocator, &store, .{ .input = "Aviva, be direct." });
+    defer result.deinit(allocator);
+
+    try std.testing.expectEqual(types.AgentProfile.aviva, result.selected_profile);
+}
+
+test "adaptive completion routes on routing_input when input is SEA-augmented" {
+    if (!build_options.feat_wdbx) return;
+    const allocator = std.testing.allocator;
+    var store = wdbx.Store.init(allocator);
+    defer store.deinit();
+
+    try store.store("modulator:weights", "0.990000,0.005000,0.005000,42,0.300000");
+    const augmented =
+        \\[SEA evidence]
+        \\- (vec 1, abbey, authority=inferred): {"kind":"completion"}
+        \\[query]
+        \\Aviva, be direct.
+    ;
+    var result = try completeAdaptive(allocator, &store, .{
+        .input = augmented,
+        .routing_input = "Aviva, be direct.",
+    });
+    defer result.deinit(allocator);
+
+    try std.testing.expectEqual(types.AgentProfile.aviva, result.selected_profile);
 }
 
 test "metadata JSON includes the escore and veto fields" {

--- a/src/features/ai/orchestration.zig
+++ b/src/features/ai/orchestration.zig
@@ -4,6 +4,7 @@
 const std = @import("std");
 const scheduler_mod = @import("../../core/scheduler.zig");
 const types = @import("types.zig");
+const identity = @import("identity.zig");
 
 pub const AgentConfig = types.AgentConfig;
 pub const AgentResult = types.AgentResult;
@@ -155,9 +156,9 @@ pub fn freeWorkerSpecs(allocator: std.mem.Allocator, specs: []AgentWorkerSpec) v
 
 pub fn defaultTrioSpecs() [3]AgentWorkerSpec {
     return .{
-        .{ .name = "abbey", .instructions = "Analytical review and structured safety analysis.", .profile_override = .abbey, .tool_hints = &.{.plan} },
-        .{ .name = "aviva", .instructions = "Creative exploration and alternative perspectives.", .profile_override = .aviva, .tool_hints = &.{.explore} },
-        .{ .name = "abi", .instructions = "Concise action-oriented execution plan.", .profile_override = .abi, .tool_hints = &.{.plan} },
+        .{ .name = "abbey", .instructions = identity.profileContract(.abbey).description, .profile_override = .abbey, .tool_hints = &.{ .explore, .plan } },
+        .{ .name = "aviva", .instructions = identity.profileContract(.aviva).description, .profile_override = .aviva, .tool_hints = &.{.plan} },
+        .{ .name = "abi", .instructions = identity.profileContract(.abi).description, .profile_override = .abi, .tool_hints = &.{.plan} },
     };
 }
 
@@ -310,6 +311,24 @@ test "parse worker specs and tool hints" {
     try std.testing.expectEqualStrings("scout", specs[0].name);
     try std.testing.expectEqual(@as(usize, 2), specs[0].tool_hints.len);
     try std.testing.expect(specs[0].tool_hints[1] == .browser);
+}
+
+test "default trio role text matches canonical identity contracts" {
+    const specs = defaultTrioSpecs();
+    try std.testing.expectEqualStrings("abbey", specs[0].name);
+    try std.testing.expectEqualStrings(identity.profileContract(.abbey).description, specs[0].instructions);
+    try std.testing.expect(std.mem.indexOf(u8, specs[0].instructions, "Primary user-facing personality") != null);
+    try std.testing.expectEqual(AgentProfile.abbey, specs[0].profile_override.?);
+
+    try std.testing.expectEqualStrings("aviva", specs[1].name);
+    try std.testing.expectEqualStrings(identity.profileContract(.aviva).description, specs[1].instructions);
+    try std.testing.expect(std.mem.indexOf(u8, specs[1].instructions, "Focused response mode") != null);
+    try std.testing.expectEqual(AgentProfile.aviva, specs[1].profile_override.?);
+
+    try std.testing.expectEqualStrings("abi", specs[2].name);
+    try std.testing.expectEqualStrings(identity.profileContract(.abi).description, specs[2].instructions);
+    try std.testing.expect(std.mem.indexOf(u8, specs[2].instructions, "Orchestration, reasoning, policy") != null);
+    try std.testing.expectEqual(AgentProfile.abi, specs[2].profile_override.?);
 }
 
 test "parse worker specs without hints frees safely" {

--- a/src/features/ai/router.zig
+++ b/src/features/ai/router.zig
@@ -65,6 +65,37 @@ pub const SENTIMENT_KEYWORDS = [_]SentimentKeyword{
     .{ .word = "pattern", .abbey_score = 0.85, .aviva_score = 0.5, .abi_score = 0.3 },
 };
 
+/// Recognize an explicit leading persona address such as `Aviva, be direct.`
+/// or `ABI: orchestrate this.`. Only an exact ASCII name token at the beginning
+/// of the request is accepted; profile names embedded inside larger words or
+/// mentioned later in prose do not become selectors.
+pub fn explicitProfileSelector(input: []const u8) ?types.AgentProfile {
+    var remaining = std.mem.trim(u8, input, " \t\r\n");
+    if (remaining.len > 0 and remaining[0] == '@') remaining = remaining[1..];
+
+    var name_end: usize = 0;
+    while (name_end < remaining.len and std.ascii.isAlphabetic(remaining[name_end])) : (name_end += 1) {}
+    if (name_end == 0) return null;
+    if (name_end < remaining.len) {
+        const separator = remaining[name_end];
+        if (!std.ascii.isWhitespace(separator) and separator != ',' and separator != ':' and separator != '-') return null;
+    }
+
+    const name = remaining[0..name_end];
+    if (std.ascii.eqlIgnoreCase(name, "abbey")) return .abbey;
+    if (std.ascii.eqlIgnoreCase(name, "aviva")) return .aviva;
+    if (std.ascii.eqlIgnoreCase(name, "abi")) return .abi;
+    return null;
+}
+
+fn explicitProfileWeights(profile: types.AgentProfile) ProfileWeights {
+    return switch (profile) {
+        .abbey => .{ .w_abbey = 1, .w_aviva = 0, .w_abi = 0 },
+        .aviva => .{ .w_abbey = 0, .w_aviva = 1, .w_abi = 0 },
+        .abi => .{ .w_abbey = 0, .w_aviva = 0, .w_abi = 1 },
+    };
+}
+
 pub const abbey = struct {
     pub fn processInput(allocator: std.mem.Allocator, input: []const u8) ![]u8 {
         std.log.info("Abbey processing: {s}", .{input});
@@ -228,6 +259,8 @@ pub const AdaptiveModulator = struct {
 };
 
 pub fn analyzeSentiment(input: []const u8) ProfileWeights {
+    if (explicitProfileSelector(input)) |profile| return explicitProfileWeights(profile);
+
     var weights_val = ProfileWeights{
         .w_abbey = identity.DEFAULT_ABBEY_WEIGHT,
         .w_aviva = identity.DEFAULT_AVIVA_WEIGHT,
@@ -291,6 +324,10 @@ pub fn routeInputWithSoul(
     blend_alpha: f32,
     input: []const u8,
 ) ![]u8 {
+    if (explicitProfileSelector(input)) |profile| {
+        return routeToProfile(allocator, profile, input);
+    }
+
     const keyword_weights = analyzeSentiment(input);
     // Start from the keyword decision so a missing network or rejected output
     // shape/value preserves the documented fallback regardless of blend_alpha.
@@ -404,6 +441,35 @@ test "analyzeSentiment favors ABI only for orchestration and governance input" {
     const weights_val = analyzeSentiment("orchestrate routing governance policy profile");
     try std.testing.expect(weights_val.w_abi > weights_val.w_abbey);
     try std.testing.expect(weights_val.w_abi > weights_val.w_aviva);
+}
+
+test "explicit leading profile requests override heuristic routing" {
+    try std.testing.expectEqual(types.AgentProfile.aviva, explicitProfileSelector("Aviva, be direct.").?);
+    try std.testing.expectEqual(types.AgentProfile.abi, explicitProfileSelector("ABI, orchestrate this.").?);
+    try std.testing.expectEqual(types.AgentProfile.abbey, explicitProfileSelector("  @Abbey: explain this warmly.").?);
+
+    try std.testing.expectEqual(types.AgentProfile.aviva, selectBestProfile(analyzeSentiment("Aviva, explain this creatively.")));
+    try std.testing.expectEqual(types.AgentProfile.abi, selectBestProfile(analyzeSentiment("ABI, help me brainstorm.")));
+}
+
+test "explicit profile requests override one-shot and soul routing" {
+    const allocator = std.testing.allocator;
+
+    const aviva_result = try routeInput(allocator, "Aviva, be direct.");
+    defer allocator.free(aviva_result);
+    try std.testing.expect(std.mem.startsWith(u8, aviva_result, identity.profileContract(.aviva).response_prefix));
+
+    const abi_result = try routeInputWithSoul(allocator, null, 1.0, "ABI, orchestrate this.");
+    defer allocator.free(abi_result);
+    try std.testing.expect(std.mem.startsWith(u8, abi_result, identity.profileContract(.abi).response_prefix));
+}
+
+test "explicit profile selector rejects embedded and incidental names" {
+    try std.testing.expect(explicitProfileSelector("habitual orchestration") == null);
+    try std.testing.expect(explicitProfileSelector("stability review") == null);
+    try std.testing.expect(explicitProfileSelector("avivacious idea") == null);
+    try std.testing.expect(explicitProfileSelector("Please ask Aviva to review this") == null);
+    try std.testing.expect(explicitProfileSelector("ABI2, orchestrate this") == null);
 }
 
 test "neutral input defaults to primary Abbey profile" {

--- a/src/features/ai/stub_profile.zig
+++ b/src/features/ai/stub_profile.zig
@@ -39,6 +39,25 @@ pub const abbey = DisabledProfile;
 pub const aviva = DisabledProfile;
 pub const abi_profile = DisabledProfile;
 
+pub fn explicitProfileSelector(input: []const u8) ?types.AgentProfile {
+    var remaining = std.mem.trim(u8, input, " \t\r\n");
+    if (remaining.len > 0 and remaining[0] == '@') remaining = remaining[1..];
+
+    var name_end: usize = 0;
+    while (name_end < remaining.len and std.ascii.isAlphabetic(remaining[name_end])) : (name_end += 1) {}
+    if (name_end == 0) return null;
+    if (name_end < remaining.len) {
+        const separator = remaining[name_end];
+        if (!std.ascii.isWhitespace(separator) and separator != ',' and separator != ':' and separator != '-') return null;
+    }
+
+    const name = remaining[0..name_end];
+    if (std.ascii.eqlIgnoreCase(name, "abbey")) return .abbey;
+    if (std.ascii.eqlIgnoreCase(name, "aviva")) return .aviva;
+    if (std.ascii.eqlIgnoreCase(name, "abi")) return .abi;
+    return null;
+}
+
 pub fn analyzeSentiment(input: []const u8) ProfileWeights {
     _ = input;
     return .{};
@@ -92,7 +111,11 @@ pub const AdaptiveModulator = struct {
 
     pub fn serialize(self: *const AdaptiveModulator, allocator: std.mem.Allocator) ![]u8 {
         _ = self;
-        return try allocator.dupe(u8, "0.40,0.30,0.30,0,0.3");
+        return try std.fmt.allocPrint(
+            allocator,
+            "{d:.6},{d:.6},{d:.6},0,0.300000",
+            .{ identity.DEFAULT_ABBEY_WEIGHT, identity.DEFAULT_AVIVA_WEIGHT, identity.DEFAULT_ABI_WEIGHT },
+        );
     }
 
     pub fn deserialize(data: []const u8) AdaptiveModulator {

--- a/src/features/ai/stub_types.zig
+++ b/src/features/ai/stub_types.zig
@@ -147,6 +147,8 @@ pub const CompletionRequest = struct {
     /// Mirrors the real explicit-consent persistence switch. Disabled AI never
     /// persists a completion regardless of this value.
     store_result: bool = false,
+    /// Mirrors real `routing_input` (persona routing text when `input` is augmented).
+    routing_input: ?[]const u8 = null,
     stream_callback: ?StreamCallback = null,
     stream_ctx: ?*anyopaque = null,
 };

--- a/src/features/ai/types.zig
+++ b/src/features/ai/types.zig
@@ -87,6 +87,10 @@ pub const CompletionRequest = struct {
     /// minimal provenance/audit metadata, and a linked block — not raw prompt or
     /// response text in the completion metadata record.
     store_result: bool = false,
+    /// Optional text used only for persona routing (explicit selector + sentiment
+    /// / EMA update). When null, `input` is used. SEA learn-loop passes the raw
+    /// user utterance here while `input` carries the evidence-augmented prompt.
+    routing_input: ?[]const u8 = null,
     /// Optional streaming callback. When set, persona/template generation emits
     /// word/token deltas **during** iterative generation (`stream=incremental`).
     /// This is not a neural LM sampler; live SSE paths remain separate.

--- a/src/features/sea/evidence.zig
+++ b/src/features/sea/evidence.zig
@@ -56,28 +56,49 @@ pub const EvidenceContext = struct {
     }
 };
 
-/// Map a parsed metadata `profile` value onto a borrowed static label so the
-/// item never owns it. Unrecognized values collapse to `unknown`.
-fn staticProfileLabel(metadata: []const u8) []const u8 {
-    for (known_profile_labels) |label| {
-        // Match the JSON `"profile":"<label>"` field without a full parse.
-        var needle_buf: [32]u8 = undefined;
-        const needle = std.fmt.bufPrint(&needle_buf, "\"profile\":\"{s}\"", .{label}) catch continue;
-        if (std.mem.indexOf(u8, metadata, needle) != null) return label;
-    }
-    return unknown_profile_label;
-}
+const ParsedStoredMetadata = struct {
+    profile_label: []const u8 = unknown_profile_label,
+    authority: sea_types.Authority = .inferred,
+};
 
-/// Resolve persisted provenance onto the SEA trust ladder. Missing or unknown
-/// authority is treated as inferred, the least-trusted rung, rather than being
-/// silently promoted.
-fn staticAuthority(metadata: []const u8) sea_types.Authority {
-    for (std.meta.tags(sea_types.Authority)) |authority| {
-        var needle_buf: [48]u8 = undefined;
-        const needle = std.fmt.bufPrint(&needle_buf, "\"authority\":\"{s}\"", .{authority.text()}) catch continue;
-        if (std.mem.indexOf(u8, metadata, needle) != null) return authority;
+/// Parse only exact top-level JSON fields from generic WDBX completion
+/// metadata. Generic key/value storage is not a trusted provenance boundary:
+/// callers can write arbitrary bytes, so even a syntactically valid
+/// `authority` claim cannot promote itself above `inferred`. A future trusted
+/// ingestion path must carry independently verified provenance rather than
+/// adding another self-asserted JSON marker here.
+fn parseStoredMetadata(allocator: std.mem.Allocator, metadata: []const u8) ParsedStoredMetadata {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, metadata, .{}) catch return .{};
+    defer parsed.deinit();
+
+    const object = switch (parsed.value) {
+        .object => |object| object,
+        else => return .{},
+    };
+
+    var result = ParsedStoredMetadata{};
+    if (object.get("profile")) |value| {
+        const profile = switch (value) {
+            .string => |profile| profile,
+            else => "",
+        };
+        for (known_profile_labels) |label| {
+            if (std.mem.eql(u8, profile, label)) {
+                result.profile_label = label;
+                break;
+            }
+        }
     }
-    return .inferred;
+
+    // Parse the field structurally so nested/textual spoofs cannot affect the
+    // result, then deliberately keep generic-store authority at the least-
+    // trusted rung. This read also documents that a valid claim was observed
+    // but was not accepted as verified provenance.
+    if (object.get("authority")) |value| switch (value) {
+        .string => |authority| _ = sea_types.Authority.parse(authority),
+        else => {},
+    };
+    return result;
 }
 
 /// Gather evidence relevant to `input` from a durable store.
@@ -104,7 +125,8 @@ pub fn gatherEvidence(
 /// Task-awareness: when `plan.exact_recall` is set (e.g. a `project_recall`
 /// task), each hit's semantic score is blended with its lexical keyword overlap
 /// against the query and the results are re-sorted, so exact-wording matches
-/// outrank fuzzy ones. Other plans keep the store's semantic ordering unchanged.
+/// outrank fuzzy ones. Every plan is sorted by its final score with vector id as
+/// a deterministic tie-breaker.
 pub fn gatherEvidenceWithPlan(
     allocator: std.mem.Allocator,
     store: *wdbx.Store,
@@ -145,23 +167,24 @@ pub fn gatherEvidenceWithPlan(
         const snippet = try allocator.dupe(u8, metadata);
         errdefer allocator.free(snippet);
 
-        // Under exact_recall, blend the semantic score with lexical overlap so
-        // exact-wording matches are favored; otherwise keep the pure semantic
-        // score and the store's existing ordering.
-        const authority = staticAuthority(metadata);
+        // Under exact_recall, blend semantic score with lexical overlap;
+        // otherwise relevance is the pure semantic hit score. Final item order
+        // is always re-sorted below by authority-weighted score (+ vector-id ties).
+        const parsed_metadata = parseStoredMetadata(allocator, metadata);
+        const authority = parsed_metadata.authority;
         const relevance = if (plan.exact_recall)
             (1.0 - EXACT_RECALL_KEYWORD_WEIGHT) * hit.score +
                 EXACT_RECALL_KEYWORD_WEIGHT * keywordOverlap(input, metadata)
         else
             hit.score;
-        // Provenance participates in ranking. Unlabeled/generated records stay
-        // on the least-trusted rung; tool/file/system evidence is promoted only
-        // when its metadata explicitly carries that authority.
+        // Generic-store authority is forced to least-trusted (.inferred). The
+        // multiply applies a uniform trust scale; it does not differentiate
+        // ranks until a trusted ingestion path can set authority independently.
         const score = relevance * authority.score();
 
         try items.append(allocator, .{
             .vector_id = hit.id,
-            .profile_label = staticProfileLabel(metadata),
+            .profile_label = parsed_metadata.profile_label,
             .authority = authority,
             .snippet = snippet,
             .score = score,
@@ -169,13 +192,19 @@ pub fn gatherEvidenceWithPlan(
     }
 
     const owned = try items.toOwnedSlice(allocator);
-    // Re-sort by the re-weighted score; only meaningful when scores were blended.
-    if (plan.exact_recall) std.mem.sort(EvidenceItem, owned, {}, scoreDesc);
+    // Authority weighting changes the final score independently of the vector
+    // index's semantic order, so every returned set must be sorted again.
+    // Equal scores use vector id as a stable, deterministic tie-breaker.
+    std.mem.sort(EvidenceItem, owned, {}, scoreDesc);
     return .{ .items = owned, .allocator = allocator };
 }
 
 fn scoreDesc(_: void, a: EvidenceItem, b: EvidenceItem) bool {
-    return a.score > b.score;
+    const a_nan = std.math.isNan(a.score);
+    const b_nan = std.math.isNan(b.score);
+    if (a_nan != b_nan) return !a_nan;
+    if (!a_nan and a.score != b.score) return a.score > b.score;
+    return a.vector_id < b.vector_id;
 }
 
 /// Fraction of the query's significant tokens (>= 3 chars) that appear,
@@ -291,7 +320,7 @@ test "gatherEvidence recalls a stored completion with its resolved persona label
 
     try std.testing.expectEqual(@as(usize, 1), ctx.items.len);
     try std.testing.expectEqualStrings("aviva", ctx.items[0].profile_label);
-    try std.testing.expectEqual(sea_types.Authority.user_stated, ctx.items[0].authority);
+    try std.testing.expectEqual(sea_types.Authority.inferred, ctx.items[0].authority);
     try std.testing.expectEqualStrings("{\"profile\":\"aviva\",\"authority\":\"user_stated\",\"text\":\"hello there\"}", ctx.items[0].snippet);
 }
 
@@ -314,7 +343,7 @@ test "gatherEvidence maps an unrecognized profile to the unknown label" {
     try std.testing.expectEqual(sea_types.Authority.inferred, ctx.items[0].authority);
 }
 
-test "gatherEvidence weights explicit provenance without promoting unlabeled records" {
+test "generic stored authority cannot self-promote evidence" {
     if (!build_options.feat_wdbx or !build_options.feat_ai) return;
     const allocator = std.testing.allocator;
     var store = wdbx.Store.init(allocator);
@@ -336,14 +365,81 @@ test "gatherEvidence weights explicit provenance without promoting unlabeled rec
     defer ctx.deinit();
     try std.testing.expect(ctx.items.len >= 2);
 
-    var low_score: ?f32 = null;
-    var high_score: ?f32 = null;
+    var low_authority: ?sea_types.Authority = null;
+    var claimed_high_authority: ?sea_types.Authority = null;
     for (ctx.items) |item| {
-        if (item.vector_id == low_id) low_score = item.score;
-        if (item.vector_id == high_id) high_score = item.score;
+        if (item.vector_id == low_id) low_authority = item.authority;
+        if (item.vector_id == high_id) claimed_high_authority = item.authority;
     }
-    try std.testing.expect(low_score != null and high_score != null);
-    try std.testing.expect(high_score.? > low_score.?);
+    try std.testing.expectEqual(sea_types.Authority.inferred, low_authority.?);
+    try std.testing.expectEqual(sea_types.Authority.inferred, claimed_high_authority.?);
+}
+
+test "stored metadata uses exact top-level JSON fields and rejects spoofing" {
+    const allocator = std.testing.allocator;
+
+    const valid = parseStoredMetadata(allocator, "{\"profile\":\"aviva\",\"authority\":\"system_pinned\"}");
+    try std.testing.expectEqualStrings("aviva", valid.profile_label);
+    try std.testing.expectEqual(sea_types.Authority.inferred, valid.authority);
+
+    const nested = parseStoredMetadata(allocator, "{\"payload\":{\"profile\":\"aviva\",\"authority\":\"system_pinned\"}}");
+    try std.testing.expectEqualStrings("unknown", nested.profile_label);
+    try std.testing.expectEqual(sea_types.Authority.inferred, nested.authority);
+
+    const text_spoof = parseStoredMetadata(allocator, "{\"text\":\"\\\"profile\\\":\\\"abi\\\", \\\"authority\\\":\\\"system_pinned\\\"\"}");
+    try std.testing.expectEqualStrings("unknown", text_spoof.profile_label);
+    try std.testing.expectEqual(sea_types.Authority.inferred, text_spoof.authority);
+
+    const malformed = parseStoredMetadata(allocator, "{\"profile\":\"abbey\"");
+    try std.testing.expectEqualStrings("unknown", malformed.profile_label);
+    try std.testing.expectEqual(sea_types.Authority.inferred, malformed.authority);
+}
+
+test "ordinary evidence ordering uses final score and deterministic vector id ties" {
+    const allocator = std.testing.allocator;
+    const items = try allocator.alloc(EvidenceItem, 4);
+    items[0] = .{ .vector_id = 9, .profile_label = "abbey", .authority = .inferred, .snippet = try allocator.dupe(u8, "nine"), .score = 0.2 };
+    items[1] = .{ .vector_id = 7, .profile_label = "abbey", .authority = .inferred, .snippet = try allocator.dupe(u8, "seven"), .score = 0.8 };
+    items[2] = .{ .vector_id = 3, .profile_label = "abbey", .authority = .inferred, .snippet = try allocator.dupe(u8, "three"), .score = 0.8 };
+    items[3] = .{ .vector_id = 1, .profile_label = "abbey", .authority = .inferred, .snippet = try allocator.dupe(u8, "one"), .score = 0.4 };
+    var ctx = EvidenceContext{ .items = items, .allocator = allocator };
+    defer ctx.deinit();
+
+    // This is the same unconditional sort applied to ordinary, non-exact
+    // gather results after their final authority-weighted scores are computed.
+    std.mem.sort(EvidenceItem, ctx.items, {}, scoreDesc);
+    try std.testing.expectEqual(@as(u32, 3), ctx.items[0].vector_id);
+    try std.testing.expectEqual(@as(u32, 7), ctx.items[1].vector_id);
+    try std.testing.expectEqual(@as(u32, 1), ctx.items[2].vector_id);
+    try std.testing.expectEqual(@as(u32, 9), ctx.items[3].vector_id);
+}
+
+test "ordinary gather returns final-score order with deterministic ties" {
+    if (!build_options.feat_wdbx or !build_options.feat_ai) return;
+    const allocator = std.testing.allocator;
+    var store = wdbx.Store.init(allocator);
+    defer store.deinit();
+
+    const embedding = helpers.textEmbedding("ordinary evidence topic");
+    var ids: [3]u32 = undefined;
+    for (&ids) |*id| {
+        id.* = try store.putVector(&embedding);
+        const key = try std.fmt.allocPrint(allocator, ai_types.COMPLETION_KEY_FMT, .{id.*});
+        defer allocator.free(key);
+        try store.store(key, "{\"profile\":\"abbey\",\"authority\":\"system_pinned\"}");
+    }
+
+    const plan = query_plan.infer("ordinary evidence topic");
+    try std.testing.expect(!plan.exact_recall);
+    var ctx = try gatherEvidenceWithPlan(allocator, &store, plan.query, ids.len, plan);
+    defer ctx.deinit();
+
+    try std.testing.expectEqual(ids.len, ctx.items.len);
+    for (ctx.items[0 .. ctx.items.len - 1], ctx.items[1..]) |current, next| {
+        try std.testing.expect(current.score >= next.score);
+        if (current.score == next.score) try std.testing.expect(current.vector_id < next.vector_id);
+        try std.testing.expectEqual(sea_types.Authority.inferred, current.authority);
+    }
 }
 
 test "keywordOverlap counts significant query tokens present in text" {

--- a/src/features/sea/learn_loop.zig
+++ b/src/features/sea/learn_loop.zig
@@ -75,6 +75,9 @@ pub fn runLearnLoop(
 
     var completion = try ai.completeWithStoreAdaptive(allocator, store, .{
         .input = augmented,
+        // Route on the raw user text so explicit "Aviva, ..." / "ABI, ..." and
+        // keyword sentiment are not blocked by the SEA evidence preamble.
+        .routing_input = input,
         .model = model,
         .store_result = config.persist,
         .stream_callback = config.stream_callback,

--- a/tests/contracts/surface.zig
+++ b/tests/contracts/surface.zig
@@ -198,6 +198,10 @@ test "nested feature public surfaces are frozen across feature flags" {
     try std.testing.expect(@hasDecl(ai.profile.ProfileWeights, "normalize"));
     try std.testing.expect(@hasDecl(ai.profile, "SentimentKeyword"));
     try std.testing.expect(@hasDecl(ai.profile, "SENTIMENT_KEYWORDS"));
+    try std.testing.expect(@hasDecl(ai.profile, "explicitProfileSelector"));
+    try std.testing.expectEqual(ai.AgentProfile.aviva, ai.profile.explicitProfileSelector("Aviva, be direct.").?);
+    try std.testing.expectEqual(ai.AgentProfile.abi, ai.profile.explicitProfileSelector("ABI, orchestrate this.").?);
+    try std.testing.expect(ai.profile.explicitProfileSelector("stability") == null);
     try std.testing.expect(@hasDecl(ai, "identity"));
     try std.testing.expect(@hasDecl(ai.identity, "primary_declaration"));
     try std.testing.expect(@hasDecl(ai.identity, "capability_claims"));


### PR DESCRIPTION
## Summary

Force code-review of merged #720 found residual issues; this PR fixes them:

1. **Explicit persona address** (`Aviva, …` / `ABI, …` / `@Abbey:`) now overrides heuristics, soul blend, and adaptive EMA for that turn.
2. **SEA learn-loop** passes raw user text as `routing_input` so the evidence preamble does not block explicit/keyword routing.
3. **SEA evidence**: always re-sort by final score; generic WDBX metadata cannot self-promote authority; comments match code.
4. **Multi-agent trio** instructions come from `identity.profileContract` (no stale creative/action labels).

## Test plan

- [x] `./build.sh test -Dtest-filter="explicit"`
- [x] `./build.sh test -Dtest-filter="adaptive completion"`
- [x] `./build.sh test -Dtest-filter="ordinary evidence"` / `generic stored authority`
- [x] `./build.sh check-parity`
- [ ] CI