### PR TITLE
docs+build: P0-1 audit table, bench regression gate, multiway/octtree docs refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -248,6 +248,9 @@ test_imports3
 /src_next/
 .zls.json
 
+# SDD session scratch (progress ledgers, review packages, salvage patches)
+/.superpowers/
+
 # ── Markdown allowlist ─────────────────────────────────────────────────
 *.md
 
@@ -263,7 +266,8 @@ test_imports3
 # GitHub Actions runner ops (self-hosted security + day-2)
 !/.github/self-hosted-runner.md
 
-# Example walkthroughs
+# Example walkthroughs (each new examples/*/README.md needs its own entry)
+!/examples/multiway/README.md
 !/examples/wdbx_3d_hybrid/README.md
 
 # Documentation tree

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,9 @@ No unproven claims (production FHE/AES/RBAC, multi-host sharding, QPS/latency/ac
 - **`abi` binary can get overwritten by feature-stub smoke.** `./build.sh check` runs `tools/check_feature_stubs.sh`, which builds `abi` with feature flags disabled and installs it over `zig-out/bin/abi`. Re-run `zig build cli` (or `./build.sh cli`) afterward to restore the full-featured binary (otherwise e.g. `wdbx` shows disabled in `abi backends`).
 
 ## Linux / non-macOS note
-Cross-compiles link cleanly for `x86_64-linux-gnu` / `aarch64-linux-gnu` / `windows-gnu` (exe + all test modules set `link_libc=true`; `metal_shared.zig` gates objc externs to macOS via `comptime`). Ambient WDBX persist EBADF is **fixed** (`ensureOwnerOnlyDir` opens with `iterate=true` so Linux `fchmod` works). Execution of cross binaries still needs a Linux/Windows host (CI `cross-smoke`); this macOS host cannot run them. Green native suites on macOS: full `./build.sh check`. Feature-stub smoke in `check` overwrites `zig-out/bin/abi` — re-run `./build.sh cli` to restore it.
+Cross-compiles link cleanly for `x86_64-linux-gnu` / `aarch64-linux-gnu` / `windows-gnu` (exe + all test modules set `link_libc=true`; `metal_shared.zig` gates objc externs to macOS via `comptime`). Ambient WDBX persist EBADF is **fixed** (`ensureOwnerOnlyDir` opens with `iterate=true` so Linux `fchmod` works). Execution of cross binaries still needs a Linux/Windows host (CI `cross-smoke`); this macOS host cannot run them. Green native suites on macOS: full `./build.sh check`. Feature-stub smoke in `check` overwrites `zig-out/bin/abi` — re-run `./build.sh cli` to restore it. `tools/cross_smoke.sh` covers both the CLI and the WDBX 3D-hybrid example (`example-3d-hybrid` compile-only step) per target.
+
+Gitignore gotcha: a global `*.md` markdown allowlist is in effect — every new `examples/*/README.md` (and any other tracked-markdown location) needs an explicit `!` entry in `.gitignore` or it is silently untracked.
 
 ## Learned User Preferences
 - Prefer feature branches named with the `cursor/` prefix from `origin/main`; do not commit or push directly to `main`; never force-push `main`.

--- a/build.zig
+++ b/build.zig
@@ -515,10 +515,15 @@ pub fn build(b: *std.Build) void {
     check_step.dependOn(&fmt_check.step);
     check_step.dependOn(&parity_check.step);
 
-    const full_check_step = b.step("full-check", "Run check, integration tests, benchmarks, dashboard smoke, example smoke, and agent TUI smoke");
+    // Benchmark regression gate: runs the suite (best-of-N) and fails on a
+    // >5% slowdown vs tools/bench_baseline.json. Replaces a plain bench_step
+    // dependency here -- the script invokes `zig build benchmarks` itself.
+    const bench_regress = b.addSystemCommand(&.{ "bash", "tools/bench_regress.sh" });
+
+    const full_check_step = b.step("full-check", "Run check, integration tests, bench regression gate, dashboard smoke, example smoke, and agent TUI smoke");
     full_check_step.dependOn(check_step);
     full_check_step.dependOn(test_integration_step);
-    full_check_step.dependOn(bench_step);
+    full_check_step.dependOn(&bench_regress.step);
     full_check_step.dependOn(example_3d_hybrid_step);
     full_check_step.dependOn(&tui_smoke.step);
 

--- a/docs/spec/agent-wdbx-architecture.mdx
+++ b/docs/spec/agent-wdbx-architecture.mdx
@@ -112,7 +112,8 @@ WDBX is a composite in-process memory substrate, not just a vector index. The cu
 | Vectors | `mod.zig`, `hnsw.zig`, `hnsw_storage.zig`, `hnsw_distance.zig` | Fixed-capacity padded vectors and HNSW-style cosine search. | Current |
 | Conversation blocks | `chain.zig` | SHA-256-linked blocks with profile, query/response vector ids, metadata, snapshots, and verification. | Current |
 | Temporal/causal graph | `temporal.zig`, `retrieval.zig` | Recency decay, causal proximity, and persona-weighted hybrid ranking. | Current |
-| Spatial records | `spatial_3d.zig` | In-memory 3D records with distance search surfaces exposed through store stats/contracts. | Current |
+| Spatial records | `spatial_3d.zig` | In-memory 3D records; kNN/radius search octree-accelerated for euclidean/manhattan at >= 64 points (linear-scan fallback below and for cosine), oracle-tested against the linear path. | Current |
+| Hybrid spatial retrieval | `retrieval.zig` | `hybridSpatialSearch` blends embedding cosine similarity with 3D proximity (weight edge cases test-covered); runnable via `zig build run-example-3d-hybrid`. | Current |
 | JSONL snapshots | `persistence.zig`, `persistence_parse.zig` | Checkpoint serialization and restoration with a trailing SHA-256 integrity line. | Current |
 | WAL | `wal.zig` | CRC32-framed append-only mutation records with replay and corruption detection. | Current |
 | Segment checkpoints | `segments.zig` | Manifest-backed immutable checkpoint epochs, latest-epoch loading, reset, and compaction. | Current |

--- a/examples/multiway/README.md
+++ b/examples/multiway/README.md
@@ -1,0 +1,34 @@
+# Multiway simulator examples
+
+Example configurations for `abi wdbx simulate` — the bounded multiway
+string-rewriting simulator. See `docs/spec/wdbx-multiway.mdx` for the full
+scope, scientific-boundary discipline, and metric definitions.
+
+> These are bounded slices of computational rule space. Nothing here simulates
+> "the ruliad" or makes any physics claim.
+
+| File | System | Notes |
+|------|--------|-------|
+| `reference.rules` | `A->AB`, `A->BA`, `BB->A` | The reference regression rule set (rules-file form). |
+| `branching.json`  | Same rules, JSON config | Growing/branching with a shrinking rule; rule families + weights. |
+| `convergent.json` | `A->C`, `B->C` | Distinct branches converge onto shared canonical states. |
+| `cyclic.json`     | `A->B`, `B->A` | Two-state cycle; converges to 2 states, frontier exhausts. |
+
+## Running
+
+```bash
+# Reference experiment (canonical JSON export)
+abi wdbx simulate --initial A --rules-file examples/multiway/reference.rules \
+  --depth 5 --max-states 500 --max-events 5000 \
+  --format json --output experiment.json --verbose
+
+# From a JSON config; flags override file values
+abi wdbx simulate --config examples/multiway/branching.json
+
+# Persist into a WDBX checkpoint, then resume deeper
+abi wdbx simulate --config examples/multiway/convergent.json --store convergent.wdbx.jsonl
+abi wdbx simulate --config examples/multiway/convergent.json --depth 8 --resume-wdbx convergent.wdbx.jsonl
+
+# Graphviz DOT
+abi wdbx simulate --config examples/multiway/cyclic.json --format dot --output cyclic.dot
+```

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -116,6 +116,20 @@ Full detail: `git log` + `CHANGELOG.md`. Keep this list short.
 
 ---
 
+## P0-1 lock-across-I/O audit (2026-07-23)
+
+Scope: every lock site in WDBX network-facing paths (`rest.zig`, `rest_handlers.zig`, `cluster.zig`, `cluster_rpc.zig`, `runtime.zig`, `durable_store.zig`, `remote_compute.zig`) and MCP HTTP (`src/mcp/http_transport.zig`). Method: `grep -rn "Mutex|\.lock\(\)|\.lockShared|\.tryLock"` over `src/`, then trace each critical section for `std.Io.net` reads/writes under the lock.
+
+Result: exactly **one** mutex exists in all of `src/` — the token-bucket spin-lock in `rate_limiter.zig`. All other scoped files hold zero locks; their concurrency model is a single-threaded accept→handle loop with per-connection arenas, and `Store` has no internal locking, so "no lock held across network I/O" holds vacuously there (a site-by-site row would be fabricating lock sites that don't exist).
+
+| Site | Lock | Critical section | Verdict |
+|------|------|------------------|---------|
+| `src/features/wdbx/rate_limiter.zig:65` `acquire()` | spin-lock (`std.atomic.Mutex`) | `refillLocked()` + token/counter arithmetic only; the 429 response write in `rest.zig:99-111` happens after `acquire()` returns (lock released by `defer`). | SAFE |
+| `src/features/wdbx/rate_limiter.zig:92` `statsJson()` | same spin-lock | one `std.fmt.allocPrint` (allocation, no socket ops); response write happens after return (`rest.zig:121-125`). | SAFE |
+| `rest.zig` / `rest_handlers.zig` / `cluster.zig` / `cluster_rpc.zig` / `runtime.zig` / `durable_store.zig` / `remote_compute.zig` / `mcp/http_transport.zig` | none | no `Mutex`/`lock()` in any of these files (grep-verified 2026-07-23). | SAFE (vacuous) |
+
+Residual risk: if any of these servers ever moves to a threaded accept model, `Store` needs a locking design first — nothing guards concurrent mutation today; that is a known single-threaded-by-design boundary, not a latent race in current code.
+
 ## References
 
 - `docs/spec/wdbx-north-star.mdx` — Current/Partial/Proposed

--- a/tools/bench_regress.sh
+++ b/tools/bench_regress.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # bench_regress.sh — benchmark baseline + regression gate for abi.
 #
-# Standalone and opt-in: NOT wired into build.zig or build.sh. It runs
+# Wired into `zig build full-check` (release-readiness gate); also runs
+# standalone. It runs
 # `zig build benchmarks`, which writes the machine-readable artifact
 # zig-out/bench/results.json (schema "abi-bench/v2", see
 # src/benchmarks.zig BENCH_ARTIFACT_PATH), then compares per-benchmark


### PR DESCRIPTION
Land local work:

- docs(tasks): P0-1 durable lock-across-I/O audit table
- build: wire bench regression gate into full-check
- docs: refresh wave — track multiway README, document octree/hybrid, sync AGENTS

All verified via ./build.sh check.

(Per AGENTS: land via PR even for final merge-all.)