### PR TITLE
refactor(gpu,cli): Metal ObjC + simulate leaf extracts

### DIFF
--- a/src/cli/handlers/wdbx_simulate.zig
+++ b/src/cli/handlers/wdbx_simulate.zig
@@ -14,61 +14,19 @@ const features = @import("abi").features;
 
 const wdbx = features.wdbx;
 
-const MAX_RULE_FILE_BYTES = 1 * 1024 * 1024;
-const MAX_CONFIG_FILE_BYTES = 1 * 1024 * 1024;
-const MAX_RESUME_FILE_BYTES = 256 * 1024 * 1024;
+const format = @import("wdbx_simulate_format.zig");
+const options = @import("wdbx_simulate_options.zig");
 
-pub fn help() u8 {
-    std.debug.print(
-        \\usage: abi wdbx simulate [options]
-        \\
-        \\Run a bounded multiway (Wolfram-style) string-rewriting experiment.
-        \\Simulates a finite, explicitly bounded slice of rule space; it does not
-        \\enumerate "the ruliad" and makes no physics claims.
-        \\
-        \\Rules & initial states
-        \\  --initial <STATE>        Initial state (repeatable; at least one required)
-        \\  --rule '<LHS->RHS>'      Inline rewriting rule (repeatable)
-        \\  --rules-file <PATH>      One rule per line; blank lines and # comments ignored
-        \\  --config <PATH>          JSON experiment config (flags override file values)
-        \\
-        \\Bounds (hard limits; partial results are returned when one is reached)
-        \\  --depth <N>              Maximum depth (default 5)
-        \\  --max-states <N>         Maximum unique states (default 10000)
-        \\  --max-events <N>         Maximum events (default 100000)
-        \\  --max-payload <N>        Maximum state payload bytes (default 4096)
-        \\  --deadline-ms <N>        Wall-clock budget in ms (0 = unlimited)
-        \\  --max-memory <N>         Approximate engine memory budget in bytes (0 = unlimited)
-        \\
-        \\Reproducibility
-        \\  --seed <N>               Recorded random seed (engine is deterministic)
-        \\  --workers <N>            Recorded worker count (expansion is single-threaded)
-        \\
-        \\Output & persistence
-        \\  --format <summary|json|dot>  Output format (default summary)
-        \\  --output <PATH>          Write json/dot export to a file instead of printing
-        \\  --store <PATH>           Persist experiment into a WDBX checkpoint at PATH
-        \\  --resume <PATH>          Resume from a canonical JSON export file
-        \\  --resume-wdbx <PATH>     Resume from the latest experiment in a WDBX checkpoint
-        \\  --dry-run                Validate configuration and print the plan, then exit
-        \\  --quiet                  Suppress the human summary
-        \\  --verbose                Print per-depth tables and extra detail
-        \\
-        \\Ctrl-C cancels a running experiment; the partial result is still
-        \\summarized/exported with termination reason "cancelled".
-        \\
-        \\example:
-        \\  abi wdbx simulate --initial A --rule 'A->AB' --rule 'A->BA' --rule 'BB->A' \
-        \\      --depth 5 --max-states 500 --max-events 5000 --format json --output experiment.json
-        \\
-    , .{});
-    return 0;
-}
-
-fn diag(comptime fmt: []const u8, args: anytype) u8 {
-    std.debug.print("simulate: " ++ fmt ++ "\n", .{} ++ args);
-    return 2;
-}
+pub const help = format.help;
+const diag = format.diag;
+const printSummary = format.printSummary;
+const Options = options.Options;
+const parseRuleLine = options.parseRuleLine;
+const loadRulesFile = options.loadRulesFile;
+const loadConfigFile = options.loadConfigFile;
+const parseUintFlag = options.parseUintFlag;
+const stringFlag = options.stringFlag;
+const MAX_RESUME_FILE_BYTES = options.MAX_RESUME_FILE_BYTES;
 
 var sigint_cancel = std.atomic.Value(bool).init(false);
 
@@ -92,167 +50,6 @@ fn installCancelHandler() void {
             posix.sigaction(posix.SIG.INT, &handler, null);
         },
     }
-}
-
-const Options = struct {
-    initial: std.ArrayListUnmanaged([]const u8) = .empty,
-    rules: std.ArrayListUnmanaged(wdbx.multiway.Rule) = .empty,
-    max_depth: ?u32 = null,
-    max_states: ?u32 = null,
-    max_events: ?u32 = null,
-    max_payload: ?u32 = null,
-    max_duration_ms: ?u64 = null,
-    max_memory_bytes: ?u64 = null,
-    seed: ?u64 = null,
-    workers: ?u32 = null,
-    format: enum { summary, json, dot } = .summary,
-    output: ?[]const u8 = null,
-    store: ?[]const u8 = null,
-    resume_file: ?[]const u8 = null,
-    resume_wdbx: ?[]const u8 = null,
-    dry_run: bool = false,
-    quiet: bool = false,
-    verbose: bool = false,
-};
-
-fn parseRuleLine(allocator: std.mem.Allocator, opts: *Options, text: []const u8, origin: []const u8) !?u8 {
-    const rule = wdbx.multiway.parseRule(allocator, text) catch |err| switch (err) {
-        error.MissingArrow => return diag("invalid rule '{s}' ({s}): expected 'LHS->RHS'", .{ text, origin }),
-        error.EmptyLhs => return diag("invalid rule '{s}' ({s}): left-hand side must be non-empty", .{ text, origin }),
-        error.OutOfMemory => return error.OutOfMemory,
-    };
-    try opts.rules.append(allocator, rule);
-    return null;
-}
-
-fn loadRulesFile(io: std.Io, allocator: std.mem.Allocator, opts: *Options, path: []const u8) !?u8 {
-    const content = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(MAX_RULE_FILE_BYTES)) catch |err| {
-        return diag("cannot read rules file '{s}': {s}", .{ path, @errorName(err) });
-    };
-    var lines = std.mem.splitScalar(u8, content, '\n');
-    while (lines.next()) |raw| {
-        const line = std.mem.trim(u8, raw, " \t\r");
-        if (line.len == 0 or line[0] == '#') continue;
-        if (try parseRuleLine(allocator, opts, line, path)) |code| return code;
-    }
-    return null;
-}
-
-fn jsonUint(value: std.json.Value) ?u64 {
-    return switch (value) {
-        .integer => |n| if (n < 0) null else @intCast(n),
-        else => null,
-    };
-}
-
-fn loadConfigFile(io: std.Io, allocator: std.mem.Allocator, opts: *Options, path: []const u8) !?u8 {
-    const content = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(MAX_CONFIG_FILE_BYTES)) catch |err| {
-        return diag("cannot read config file '{s}': {s}", .{ path, @errorName(err) });
-    };
-    const parsed = std.json.parseFromSliceLeaky(std.json.Value, allocator, content, .{}) catch {
-        return diag("config file '{s}' is not valid JSON", .{path});
-    };
-    const root = switch (parsed) {
-        .object => |obj| obj,
-        else => return diag("config file '{s}': top level must be a JSON object", .{path}),
-    };
-    if (root.get("initial")) |value| {
-        const arr = switch (value) {
-            .array => |a| a,
-            else => return diag("config '{s}': \"initial\" must be an array of strings", .{path}),
-        };
-        for (arr.items) |item| {
-            const text = switch (item) {
-                .string => |s| s,
-                else => return diag("config '{s}': \"initial\" entries must be strings", .{path}),
-            };
-            try opts.initial.append(allocator, try allocator.dupe(u8, text));
-        }
-    }
-    if (root.get("rules")) |value| {
-        const arr = switch (value) {
-            .array => |a| a,
-            else => return diag("config '{s}': \"rules\" must be an array", .{path}),
-        };
-        for (arr.items) |item| {
-            switch (item) {
-                .string => |text| {
-                    if (try parseRuleLine(allocator, opts, text, path)) |code| return code;
-                },
-                .object => |obj| {
-                    const text = switch (obj.get("rule") orelse return diag("config '{s}': rule object missing \"rule\"", .{path})) {
-                        .string => |s| s,
-                        else => return diag("config '{s}': rule object \"rule\" must be a string", .{path}),
-                    };
-                    if (try parseRuleLine(allocator, opts, text, path)) |code| return code;
-                    const rule = &opts.rules.items[opts.rules.items.len - 1];
-                    if (obj.get("weight")) |weight_value| {
-                        rule.weight = switch (weight_value) {
-                            .float => |f| f,
-                            .integer => |n| @floatFromInt(n),
-                            else => return diag("config '{s}': rule \"weight\" must be a number", .{path}),
-                        };
-                    }
-                    if (obj.get("family")) |family_value| {
-                        rule.family = switch (family_value) {
-                            .string => |s| try allocator.dupe(u8, s),
-                            else => return diag("config '{s}': rule \"family\" must be a string", .{path}),
-                        };
-                    }
-                },
-                else => return diag("config '{s}': \"rules\" entries must be strings or objects", .{path}),
-            }
-        }
-    }
-    const uint_fields = .{
-        .{ "max_depth", "max_depth" },
-        .{ "max_states", "max_states" },
-        .{ "max_events", "max_events" },
-        .{ "max_payload", "max_payload" },
-    };
-    inline for (uint_fields) |field| {
-        if (root.get(field[0])) |value| {
-            const n = jsonUint(value) orelse return diag("config '{s}': \"{s}\" must be a non-negative integer", .{ path, field[0] });
-            if (n > std.math.maxInt(u32)) return diag("config '{s}': \"{s}\" too large", .{ path, field[0] });
-            @field(opts, field[1]) = @intCast(n);
-        }
-    }
-    if (root.get("max_duration_ms")) |value| {
-        opts.max_duration_ms = jsonUint(value) orelse return diag("config '{s}': \"max_duration_ms\" must be a non-negative integer", .{path});
-    }
-    if (root.get("max_memory_bytes")) |value| {
-        opts.max_memory_bytes = jsonUint(value) orelse return diag("config '{s}': \"max_memory_bytes\" must be a non-negative integer", .{path});
-    }
-    if (root.get("seed")) |value| {
-        opts.seed = jsonUint(value) orelse return diag("config '{s}': \"seed\" must be a non-negative integer", .{path});
-    }
-    if (root.get("workers")) |value| {
-        const n = jsonUint(value) orelse return diag("config '{s}': \"workers\" must be a non-negative integer", .{path});
-        if (n == 0 or n > std.math.maxInt(u32)) return diag("config '{s}': \"workers\" out of range", .{path});
-        opts.workers = @intCast(n);
-    }
-    return null;
-}
-
-fn parseUintFlag(comptime T: type, args: []const []const u8, index: *usize, flag: []const u8) !?T {
-    if (index.* + 1 >= args.len) {
-        _ = diag("{s} requires a value", .{flag});
-        return error.Reported;
-    }
-    index.* += 1;
-    return std.fmt.parseInt(T, args[index.*], 10) catch {
-        _ = diag("{s}: '{s}' is not a valid non-negative integer", .{ flag, args[index.*] });
-        return error.Reported;
-    };
-}
-
-fn stringFlag(args: []const []const u8, index: *usize, flag: []const u8) ![]const u8 {
-    if (index.* + 1 >= args.len) {
-        _ = diag("{s} requires a value", .{flag});
-        return error.Reported;
-    }
-    index.* += 1;
-    return args[index.*];
 }
 
 /// Entry point; `args` is the full argv (`abi wdbx simulate ...`).
@@ -469,60 +266,6 @@ fn resumeOrDiag(allocator: std.mem.Allocator, export_json: []const u8, config: w
         return null;
     };
 }
-
-fn printSummary(result: *const wdbx.multiway.Result, metrics: *const wdbx.multiway.Metrics, export_hash: *const [64]u8, verbose: bool) void {
-    const elapsed_ms = @as(f64, @floatFromInt(result.elapsed_ns)) / @as(f64, std.time.ns_per_ms);
-    const elapsed_s = @max(elapsed_ms / 1000.0, 1e-9);
-    std.debug.print(
-        \\multiway simulation
-        \\  states (unique):        {d}
-        \\  events:                 {d}
-        \\  transitions (unique):   {d}
-        \\  termination:            {s}
-        \\  exhaustive in domain:   {}
-        \\  mean out-degree:        {d:.3} (unique transitions / unique states)
-        \\  max out-degree:         {d}
-        \\  median out-degree:      {d:.1}
-        \\  convergent states:      {d} (distinct-predecessor in-degree > 1)
-        \\  self-loops:             {d}
-        \\  cycle present:          {}
-        \\  weakly connected comps: {d}
-        \\  payload bytes max/mean: {d}/{d:.2}
-        \\  runtime:                {d:.3} ms ({d:.0} states/s, {d:.0} events/s)
-        \\  export sha256:          {s}
-        \\
-    , .{
-        metrics.unique_states,
-        metrics.event_count,
-        metrics.unique_transitions,
-        metrics.termination.label(),
-        metrics.exhaustive,
-        metrics.mean_out_degree,
-        metrics.max_out_degree,
-        metrics.median_out_degree,
-        metrics.convergent_states,
-        metrics.self_loops,
-        metrics.has_cycle,
-        metrics.weakly_connected_components,
-        metrics.max_payload_bytes,
-        metrics.mean_payload_bytes,
-        elapsed_ms,
-        @as(f64, @floatFromInt(metrics.unique_states)) / elapsed_s,
-        @as(f64, @floatFromInt(metrics.event_count)) / elapsed_s,
-        export_hash,
-    });
-    if (verbose) {
-        std.debug.print("  depth  states  events  growth\n", .{});
-        for (metrics.states_per_depth, 0..) |states, depth| {
-            const growth: f64 = if (depth >= 1 and depth - 1 < metrics.growth_rates.len) metrics.growth_rates[depth - 1] else 0.0;
-            std.debug.print("  {d: >5}  {d: >6}  {d: >6}  {d: >6.2}\n", .{ depth, states, metrics.events_per_depth[depth], growth });
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Tests (run through the public wdbx handler surface)
-// ---------------------------------------------------------------------------
 
 const handleWdbx = @import("wdbx.zig").handleWdbx;
 const test_helpers = @import("abi").foundation.test_helpers;

--- a/src/cli/handlers/wdbx_simulate_format.zig
+++ b/src/cli/handlers/wdbx_simulate_format.zig
@@ -1,0 +1,114 @@
+//! Help text and human summary formatting for `abi wdbx simulate`.
+const std = @import("std");
+const features = @import("abi").features;
+const wdbx = features.wdbx;
+
+pub fn diag(comptime fmt: []const u8, args: anytype) u8 {
+    std.debug.print("simulate: " ++ fmt ++ "\n", .{} ++ args);
+    return 2;
+}
+
+pub fn help() u8 {
+    std.debug.print(
+        \\usage: abi wdbx simulate [options]
+        \\
+        \\Run a bounded multiway (Wolfram-style) string-rewriting experiment.
+        \\Simulates a finite, explicitly bounded slice of rule space; it does not
+        \\enumerate "the ruliad" and makes no physics claims.
+        \\
+        \\Rules & initial states
+        \\  --initial <STATE>        Initial state (repeatable; at least one required)
+        \\  --rule '<LHS->RHS>'      Inline rewriting rule (repeatable)
+        \\  --rules-file <PATH>      One rule per line; blank lines and # comments ignored
+        \\  --config <PATH>          JSON experiment config (flags override file values)
+        \\
+        \\Bounds (hard limits; partial results are returned when one is reached)
+        \\  --depth <N>              Maximum depth (default 5)
+        \\  --max-states <N>         Maximum unique states (default 10000)
+        \\  --max-events <N>         Maximum events (default 100000)
+        \\  --max-payload <N>        Maximum state payload bytes (default 4096)
+        \\  --deadline-ms <N>        Wall-clock budget in ms (0 = unlimited)
+        \\  --max-memory <N>         Approximate engine memory budget in bytes (0 = unlimited)
+        \\
+        \\Reproducibility
+        \\  --seed <N>               Recorded random seed (engine is deterministic)
+        \\  --workers <N>            Recorded worker count (expansion is single-threaded)
+        \\
+        \\Output & persistence
+        \\  --format <summary|json|dot>  Output format (default summary)
+        \\  --output <PATH>          Write json/dot export to a file instead of printing
+        \\  --store <PATH>           Persist experiment into a WDBX checkpoint at PATH
+        \\  --resume <PATH>          Resume from a canonical JSON export file
+        \\  --resume-wdbx <PATH>     Resume from the latest experiment in a WDBX checkpoint
+        \\  --dry-run                Validate configuration and print the plan, then exit
+        \\  --quiet                  Suppress the human summary
+        \\  --verbose                Print per-depth tables and extra detail
+        \\
+        \\Ctrl-C cancels a running experiment; the partial result is still
+        \\summarized/exported with termination reason "cancelled".
+        \\
+        \\example:
+        \\  abi wdbx simulate --initial A --rule 'A->AB' --rule 'A->BA' --rule 'BB->A' \
+        \\      --depth 5 --max-states 500 --max-events 5000 --format json --output experiment.json
+        \\
+    , .{});
+    return 0;
+}
+
+pub fn printSummary(result: *const wdbx.multiway.Result, metrics: *const wdbx.multiway.Metrics, export_hash: *const [64]u8, verbose: bool) void {
+    const elapsed_ms = @as(f64, @floatFromInt(result.elapsed_ns)) / @as(f64, std.time.ns_per_ms);
+    const elapsed_s = @max(elapsed_ms / 1000.0, 1e-9);
+    std.debug.print(
+        \\multiway simulation
+        \\  states (unique):        {d}
+        \\  events:                 {d}
+        \\  transitions (unique):   {d}
+        \\  termination:            {s}
+        \\  exhaustive in domain:   {}
+        \\  mean out-degree:        {d:.3} (unique transitions / unique states)
+        \\  max out-degree:         {d}
+        \\  median out-degree:      {d:.1}
+        \\  convergent states:      {d} (distinct-predecessor in-degree > 1)
+        \\  self-loops:             {d}
+        \\  cycle present:          {}
+        \\  weakly connected comps: {d}
+        \\  payload bytes max/mean: {d}/{d:.2}
+        \\  runtime:                {d:.3} ms ({d:.0} states/s, {d:.0} events/s)
+        \\  export sha256:          {s}
+        \\
+    , .{
+        metrics.unique_states,
+        metrics.event_count,
+        metrics.unique_transitions,
+        metrics.termination.label(),
+        metrics.exhaustive,
+        metrics.mean_out_degree,
+        metrics.max_out_degree,
+        metrics.median_out_degree,
+        metrics.convergent_states,
+        metrics.self_loops,
+        metrics.has_cycle,
+        metrics.weakly_connected_components,
+        metrics.max_payload_bytes,
+        metrics.mean_payload_bytes,
+        elapsed_ms,
+        @as(f64, @floatFromInt(metrics.unique_states)) / elapsed_s,
+        @as(f64, @floatFromInt(metrics.event_count)) / elapsed_s,
+        export_hash,
+    });
+    if (verbose) {
+        std.debug.print("  depth  states  events  growth\n", .{});
+        for (metrics.states_per_depth, 0..) |states, depth| {
+            const growth: f64 = if (depth >= 1 and depth - 1 < metrics.growth_rates.len) metrics.growth_rates[depth - 1] else 0.0;
+            std.debug.print("  {d: >5}  {d: >6}  {d: >6}  {d: >6.2}\n", .{ depth, states, metrics.events_per_depth[depth], growth });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests (run through the public wdbx handler surface)
+// ---------------------------------------------------------------------------
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/cli/handlers/wdbx_simulate_options.zig
+++ b/src/cli/handlers/wdbx_simulate_options.zig
@@ -1,0 +1,175 @@
+//! Argument/config parsing for `abi wdbx simulate`.
+const std = @import("std");
+const features = @import("abi").features;
+const wdbx = features.wdbx;
+const format = @import("wdbx_simulate_format.zig");
+const diag = format.diag;
+
+pub const MAX_RULE_FILE_BYTES = 1 * 1024 * 1024;
+pub const MAX_CONFIG_FILE_BYTES = 1 * 1024 * 1024;
+pub const MAX_RESUME_FILE_BYTES = 256 * 1024 * 1024;
+
+pub const Options = struct {
+    initial: std.ArrayListUnmanaged([]const u8) = .empty,
+    rules: std.ArrayListUnmanaged(wdbx.multiway.Rule) = .empty,
+    max_depth: ?u32 = null,
+    max_states: ?u32 = null,
+    max_events: ?u32 = null,
+    max_payload: ?u32 = null,
+    max_duration_ms: ?u64 = null,
+    max_memory_bytes: ?u64 = null,
+    seed: ?u64 = null,
+    workers: ?u32 = null,
+    format: enum { summary, json, dot } = .summary,
+    output: ?[]const u8 = null,
+    store: ?[]const u8 = null,
+    resume_file: ?[]const u8 = null,
+    resume_wdbx: ?[]const u8 = null,
+    dry_run: bool = false,
+    quiet: bool = false,
+    verbose: bool = false,
+};
+
+pub fn parseRuleLine(allocator: std.mem.Allocator, opts: *Options, text: []const u8, origin: []const u8) !?u8 {
+    const rule = wdbx.multiway.parseRule(allocator, text) catch |err| switch (err) {
+        error.MissingArrow => return diag("invalid rule '{s}' ({s}): expected 'LHS->RHS'", .{ text, origin }),
+        error.EmptyLhs => return diag("invalid rule '{s}' ({s}): left-hand side must be non-empty", .{ text, origin }),
+        error.OutOfMemory => return error.OutOfMemory,
+    };
+    try opts.rules.append(allocator, rule);
+    return null;
+}
+
+pub fn loadRulesFile(io: std.Io, allocator: std.mem.Allocator, opts: *Options, path: []const u8) !?u8 {
+    const content = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(MAX_RULE_FILE_BYTES)) catch |err| {
+        return diag("cannot read rules file '{s}': {s}", .{ path, @errorName(err) });
+    };
+    var lines = std.mem.splitScalar(u8, content, '\n');
+    while (lines.next()) |raw| {
+        const line = std.mem.trim(u8, raw, " \t\r");
+        if (line.len == 0 or line[0] == '#') continue;
+        if (try parseRuleLine(allocator, opts, line, path)) |code| return code;
+    }
+    return null;
+}
+
+fn jsonUint(value: std.json.Value) ?u64 {
+    return switch (value) {
+        .integer => |n| if (n < 0) null else @intCast(n),
+        else => null,
+    };
+}
+
+pub fn loadConfigFile(io: std.Io, allocator: std.mem.Allocator, opts: *Options, path: []const u8) !?u8 {
+    const content = std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(MAX_CONFIG_FILE_BYTES)) catch |err| {
+        return diag("cannot read config file '{s}': {s}", .{ path, @errorName(err) });
+    };
+    const parsed = std.json.parseFromSliceLeaky(std.json.Value, allocator, content, .{}) catch {
+        return diag("config file '{s}' is not valid JSON", .{path});
+    };
+    const root = switch (parsed) {
+        .object => |obj| obj,
+        else => return diag("config file '{s}': top level must be a JSON object", .{path}),
+    };
+    if (root.get("initial")) |value| {
+        const arr = switch (value) {
+            .array => |a| a,
+            else => return diag("config '{s}': \"initial\" must be an array of strings", .{path}),
+        };
+        for (arr.items) |item| {
+            const text = switch (item) {
+                .string => |s| s,
+                else => return diag("config '{s}': \"initial\" entries must be strings", .{path}),
+            };
+            try opts.initial.append(allocator, try allocator.dupe(u8, text));
+        }
+    }
+    if (root.get("rules")) |value| {
+        const arr = switch (value) {
+            .array => |a| a,
+            else => return diag("config '{s}': \"rules\" must be an array", .{path}),
+        };
+        for (arr.items) |item| {
+            switch (item) {
+                .string => |text| {
+                    if (try parseRuleLine(allocator, opts, text, path)) |code| return code;
+                },
+                .object => |obj| {
+                    const text = switch (obj.get("rule") orelse return diag("config '{s}': rule object missing \"rule\"", .{path})) {
+                        .string => |s| s,
+                        else => return diag("config '{s}': rule object \"rule\" must be a string", .{path}),
+                    };
+                    if (try parseRuleLine(allocator, opts, text, path)) |code| return code;
+                    const rule = &opts.rules.items[opts.rules.items.len - 1];
+                    if (obj.get("weight")) |weight_value| {
+                        rule.weight = switch (weight_value) {
+                            .float => |f| f,
+                            .integer => |n| @floatFromInt(n),
+                            else => return diag("config '{s}': rule \"weight\" must be a number", .{path}),
+                        };
+                    }
+                    if (obj.get("family")) |family_value| {
+                        rule.family = switch (family_value) {
+                            .string => |s| try allocator.dupe(u8, s),
+                            else => return diag("config '{s}': rule \"family\" must be a string", .{path}),
+                        };
+                    }
+                },
+                else => return diag("config '{s}': \"rules\" entries must be strings or objects", .{path}),
+            }
+        }
+    }
+    const uint_fields = .{
+        .{ "max_depth", "max_depth" },
+        .{ "max_states", "max_states" },
+        .{ "max_events", "max_events" },
+        .{ "max_payload", "max_payload" },
+    };
+    inline for (uint_fields) |field| {
+        if (root.get(field[0])) |value| {
+            const n = jsonUint(value) orelse return diag("config '{s}': \"{s}\" must be a non-negative integer", .{ path, field[0] });
+            if (n > std.math.maxInt(u32)) return diag("config '{s}': \"{s}\" too large", .{ path, field[0] });
+            @field(opts, field[1]) = @intCast(n);
+        }
+    }
+    if (root.get("max_duration_ms")) |value| {
+        opts.max_duration_ms = jsonUint(value) orelse return diag("config '{s}': \"max_duration_ms\" must be a non-negative integer", .{path});
+    }
+    if (root.get("max_memory_bytes")) |value| {
+        opts.max_memory_bytes = jsonUint(value) orelse return diag("config '{s}': \"max_memory_bytes\" must be a non-negative integer", .{path});
+    }
+    if (root.get("seed")) |value| {
+        opts.seed = jsonUint(value) orelse return diag("config '{s}': \"seed\" must be a non-negative integer", .{path});
+    }
+    if (root.get("workers")) |value| {
+        const n = jsonUint(value) orelse return diag("config '{s}': \"workers\" must be a non-negative integer", .{path});
+        if (n == 0 or n > std.math.maxInt(u32)) return diag("config '{s}': \"workers\" out of range", .{path});
+        opts.workers = @intCast(n);
+    }
+    return null;
+}
+
+pub fn parseUintFlag(comptime T: type, args: []const []const u8, index: *usize, flag: []const u8) !?T {
+    if (index.* + 1 >= args.len) {
+        _ = diag("{s} requires a value", .{flag});
+        return error.Reported;
+    }
+    index.* += 1;
+    return std.fmt.parseInt(T, args[index.*], 10) catch {
+        _ = diag("{s}: '{s}' is not a valid non-negative integer", .{ flag, args[index.*] });
+        return error.Reported;
+    };
+}
+
+pub fn stringFlag(args: []const []const u8, index: *usize, flag: []const u8) ![]const u8 {
+    if (index.* + 1 >= args.len) {
+        _ = diag("{s} requires a value", .{flag});
+        return error.Reported;
+    }
+    index.* += 1;
+    return args[index.*];
+}
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/features/gpu/metal_objc.zig
+++ b/src/features/gpu/metal_objc.zig
@@ -1,0 +1,197 @@
+//! Metal Objective-C runtime FFI helpers (macOS-gated).
+//! Package-private building blocks for metal_shared.zig.
+const builtin = @import("builtin");
+const std = @import("std");
+
+// The objc runtime symbols only exist on macOS. Declare the externs only when
+// targeting macOS so cross-compiles (Linux/Windows) don't emit undefined
+// symbols at link time. Off-macOS this is an empty struct and the objc-using
+// function bodies are comptime-dead (see the `comptime` early returns below).
+pub const objc = if (builtin.target.os.tag == .macos) struct {
+    pub extern fn objc_getClass(name: [*c]const u8) ?*anyopaque;
+    pub extern fn sel_registerName(name: [*c]const u8) ?*anyopaque;
+    pub extern fn objc_msgSend() void;
+} else struct {};
+
+pub const MTLCreateSystemDefaultDeviceFn = fn () callconv(.c) ?*anyopaque;
+pub const MTLCreateSystemDefaultDevice: ?*const MTLCreateSystemDefaultDeviceFn = if (builtin.target.os.tag == .macos)
+    &struct {
+        extern fn MTLCreateSystemDefaultDevice() ?*anyopaque;
+    }.MTLCreateSystemDefaultDevice
+else
+    null;
+
+pub const MTLSize = extern struct {
+    width: usize,
+    height: usize,
+    depth: usize,
+};
+
+pub const MsgSendVoidRetId = *const fn (?*anyopaque, ?*anyopaque) callconv(.c) ?*anyopaque;
+pub const MsgSendVoidRetVoid = *const fn (?*anyopaque, ?*anyopaque) callconv(.c) void;
+pub const MsgSendIdRetId = *const fn (?*anyopaque, ?*anyopaque, ?*anyopaque) callconv(.c) ?*anyopaque;
+pub const MsgSendIdErrRetId = *const fn (?*anyopaque, ?*anyopaque, ?*anyopaque, ?*anyopaque) callconv(.c) ?*anyopaque;
+pub const MsgSendIdIdErrRetId = *const fn (?*anyopaque, ?*anyopaque, ?*anyopaque, ?*anyopaque, ?*anyopaque) callconv(.c) ?*anyopaque;
+pub const MsgSendPtrUsizeUsizeRetId = *const fn (?*anyopaque, ?*anyopaque, ?*const anyopaque, usize, usize) callconv(.c) ?*anyopaque;
+pub const MsgSendUsizeUsizeRetId = *const fn (?*anyopaque, ?*anyopaque, usize, usize) callconv(.c) ?*anyopaque;
+pub const MsgSendVoidRetPtr = *const fn (?*anyopaque, ?*anyopaque) callconv(.c) ?*anyopaque;
+pub const MsgSendIdUsizeUsizeRetVoid = *const fn (?*anyopaque, ?*anyopaque, ?*anyopaque, usize, usize) callconv(.c) void;
+pub const MsgSendPtrUsizeUsizeRetVoid = *const fn (?*anyopaque, ?*anyopaque, ?*const anyopaque, usize, usize) callconv(.c) void;
+pub const MsgSendMtlSizeMtlSizeRetVoid = *const fn (?*anyopaque, ?*anyopaque, MTLSize, MTLSize) callconv(.c) void;
+
+/// Shared ObjC msgSend casts + Metal selectors used by every dispatch path.
+/// Constructed once per call site via `load()` so kernels share one helper path
+/// instead of duplicating cast/selector boilerplate.
+pub const MetalDispatch = struct {
+    msg_void_id: MsgSendVoidRetId,
+    msg_void_void: MsgSendVoidRetVoid,
+    msg_id_id: MsgSendIdRetId,
+    msg_bytes: MsgSendPtrUsizeUsizeRetId,
+    msg_len: MsgSendUsizeUsizeRetId,
+    msg_set_buf: MsgSendIdUsizeUsizeRetVoid,
+    msg_set_bytes: MsgSendPtrUsizeUsizeRetVoid,
+    msg_dispatch: MsgSendMtlSizeMtlSizeRetVoid,
+    msg_contents: MsgSendVoidRetPtr,
+
+    sel_command_buffer: ?*anyopaque,
+    sel_encoder: ?*anyopaque,
+    sel_set_pipeline: ?*anyopaque,
+    sel_new_bytes: ?*anyopaque,
+    sel_new_length: ?*anyopaque,
+    sel_set_buffer: ?*anyopaque,
+    sel_set_bytes: ?*anyopaque,
+    sel_dispatch_threads: ?*anyopaque,
+    sel_dispatch_groups: ?*anyopaque,
+    sel_end: ?*anyopaque,
+    sel_commit: ?*anyopaque,
+    sel_wait: ?*anyopaque,
+    sel_contents: ?*anyopaque,
+    sel_release: ?*anyopaque,
+
+    pub fn load() MetalDispatch {
+        if (comptime builtin.target.os.tag != .macos) {
+            return undefined;
+        }
+        return .{
+            .msg_void_id = @ptrCast(&objc.objc_msgSend),
+            .msg_void_void = @ptrCast(&objc.objc_msgSend),
+            .msg_id_id = @ptrCast(&objc.objc_msgSend),
+            .msg_bytes = @ptrCast(&objc.objc_msgSend),
+            .msg_len = @ptrCast(&objc.objc_msgSend),
+            .msg_set_buf = @ptrCast(&objc.objc_msgSend),
+            .msg_set_bytes = @ptrCast(&objc.objc_msgSend),
+            .msg_dispatch = @ptrCast(&objc.objc_msgSend),
+            .msg_contents = @ptrCast(&objc.objc_msgSend),
+            .sel_command_buffer = objc.sel_registerName("commandBuffer"),
+            .sel_encoder = objc.sel_registerName("computeCommandEncoder"),
+            .sel_set_pipeline = objc.sel_registerName("setComputePipelineState:"),
+            .sel_new_bytes = objc.sel_registerName("newBufferWithBytes:length:options:"),
+            .sel_new_length = objc.sel_registerName("newBufferWithLength:options:"),
+            .sel_set_buffer = objc.sel_registerName("setBuffer:offset:atIndex:"),
+            .sel_set_bytes = objc.sel_registerName("setBytes:length:atIndex:"),
+            .sel_dispatch_threads = objc.sel_registerName("dispatchThreads:threadsPerThreadgroup:"),
+            .sel_dispatch_groups = objc.sel_registerName("dispatchThreadgroups:threadsPerThreadgroup:"),
+            .sel_end = objc.sel_registerName("endEncoding"),
+            .sel_commit = objc.sel_registerName("commit"),
+            .sel_wait = objc.sel_registerName("waitUntilCompleted"),
+            .sel_contents = objc.sel_registerName("contents"),
+            .sel_release = objc.sel_registerName("release"),
+        };
+    }
+
+    pub fn release(self: MetalDispatch, obj: ?*anyopaque) void {
+        self.msg_void_void(obj, self.sel_release);
+    }
+
+    pub fn commitAndWait(self: MetalDispatch, cmd_buf: ?*anyopaque) void {
+        self.msg_void_void(cmd_buf, self.sel_commit);
+        self.msg_void_void(cmd_buf, self.sel_wait);
+    }
+
+    pub fn readF32(self: MetalDispatch, buffer: ?*anyopaque) !f32 {
+        const ptr = self.msg_contents(buffer, self.sel_contents) orelse return error.ReadBufferFailed;
+        return @as([*]f32, @ptrCast(@alignCast(ptr)))[0];
+    }
+
+    pub fn copyBufferToHost(self: MetalDispatch, buffer: ?*anyopaque, dest: []f32) !void {
+        const ptr = self.msg_contents(buffer, self.sel_contents) orelse return error.ReadBufferFailed;
+        @memcpy(dest, @as([*]f32, @ptrCast(@alignCast(ptr)))[0..dest.len]);
+    }
+
+    /// Encode one 256-wide reduce pass into an existing command buffer.
+    /// Returns the newly allocated partials buffer (caller owns) and its length.
+    pub fn encodeReducePass(
+        self: MetalDispatch,
+        device: ?*anyopaque,
+        pipeline: ?*anyopaque,
+        cmd_buf: ?*anyopaque,
+        buffer_in: ?*anyopaque,
+        current_len: usize,
+    ) !struct { buffer: ?*anyopaque, len: usize } {
+        const tg_size: usize = 256;
+        const num_groups = (current_len + tg_size - 1) / tg_size;
+        const partial_bytes = num_groups * @sizeOf(f32);
+        const buffer_out = self.msg_len(device, self.sel_new_length, partial_bytes, 0) orelse
+            return error.BufferAllocationFailed;
+
+        const encoder = self.msg_void_id(cmd_buf, self.sel_encoder) orelse {
+            self.release(buffer_out);
+            return error.EncoderCreationFailed;
+        };
+
+        _ = self.msg_id_id(encoder, self.sel_set_pipeline, pipeline);
+        self.msg_set_buf(encoder, self.sel_set_buffer, buffer_in, 0, 0);
+        self.msg_set_buf(encoder, self.sel_set_buffer, buffer_out, 0, 1);
+        var n_u32: u32 = @intCast(current_len);
+        self.msg_set_bytes(encoder, self.sel_set_bytes, &n_u32, @sizeOf(u32), 2);
+
+        const groups = MTLSize{ .width = num_groups, .height = 1, .depth = 1 };
+        const threads = MTLSize{ .width = tg_size, .height = 1, .depth = 1 };
+        self.msg_dispatch(encoder, self.sel_dispatch_groups, groups, threads);
+        self.msg_void_void(encoder, self.sel_end);
+
+        return .{ .buffer = buffer_out, .len = num_groups };
+    }
+
+    /// Multi-pass reduce encoded into `cmd_buf` (no commit/wait). Returns the
+    /// final single-element buffer; releases intermediate inputs.
+    pub fn encodeReduceToScalar(
+        self: MetalDispatch,
+        device: ?*anyopaque,
+        pipeline: ?*anyopaque,
+        cmd_buf: ?*anyopaque,
+        buffer_in_owned: ?*anyopaque,
+        start_len: usize,
+    ) !?*anyopaque {
+        var buffer_in = buffer_in_owned;
+        var current_len = start_len;
+        errdefer self.release(buffer_in);
+
+        while (current_len > 1) {
+            const pass = try self.encodeReducePass(device, pipeline, cmd_buf, buffer_in, current_len);
+            self.release(buffer_in);
+            buffer_in = pass.buffer;
+            current_len = pass.len;
+        }
+        return buffer_in;
+    }
+};
+
+pub fn createNSString(allocator: std.mem.Allocator, str: []const u8) !?*anyopaque {
+    if (comptime builtin.target.os.tag != .macos) return null;
+    const class_nsstring = objc.objc_getClass("NSString");
+    const sel_string_with_utf8 = objc.sel_registerName("stringWithUTF8String:");
+    const MsgSendCstrRetId = *const fn (?*anyopaque, ?*anyopaque, [*c]const u8) callconv(.c) ?*anyopaque;
+    const msg_send_cstr_ret_id = @as(MsgSendCstrRetId, @ptrCast(&objc.objc_msgSend));
+
+    const c_str = try allocator.alloc(u8, str.len + 1);
+    defer allocator.free(c_str);
+    @memcpy(c_str[0..str.len], str);
+    c_str[str.len] = 0;
+
+    return msg_send_cstr_ret_id(class_nsstring, sel_string_with_utf8, c_str.ptr);
+}
+
+test {
+    @import("std").testing.refAllDecls(@This());
+}

--- a/src/features/gpu/metal_shared.zig
+++ b/src/features/gpu/metal_shared.zig
@@ -1,195 +1,26 @@
+//! Shared Metal context for vector_ops / backends / compute_api.
+//! ObjC FFI helpers live in metal_objc.zig.
 const builtin = @import("builtin");
 const std = @import("std");
 const sync = @import("../../foundation/sync.zig");
+const metal_objc = @import("metal_objc.zig");
 
-// The objc runtime symbols only exist on macOS. Declare the externs only when
-// targeting macOS so cross-compiles (Linux/Windows) don't emit undefined
-// symbols at link time. Off-macOS this is an empty struct and the objc-using
-// function bodies are comptime-dead (see the `comptime` early returns below).
-const objc = if (builtin.target.os.tag == .macos) struct {
-    extern fn objc_getClass(name: [*c]const u8) ?*anyopaque;
-    extern fn sel_registerName(name: [*c]const u8) ?*anyopaque;
-    extern fn objc_msgSend() void;
-} else struct {};
-
-const MTLCreateSystemDefaultDeviceFn = fn () callconv(.c) ?*anyopaque;
-const MTLCreateSystemDefaultDevice: ?*const MTLCreateSystemDefaultDeviceFn = if (builtin.target.os.tag == .macos)
-    &struct {
-        extern fn MTLCreateSystemDefaultDevice() ?*anyopaque;
-    }.MTLCreateSystemDefaultDevice
-else
-    null;
-
-const MTLSize = extern struct {
-    width: usize,
-    height: usize,
-    depth: usize,
-};
-
-const MsgSendVoidRetId = *const fn (?*anyopaque, ?*anyopaque) callconv(.c) ?*anyopaque;
-const MsgSendVoidRetVoid = *const fn (?*anyopaque, ?*anyopaque) callconv(.c) void;
-const MsgSendIdRetId = *const fn (?*anyopaque, ?*anyopaque, ?*anyopaque) callconv(.c) ?*anyopaque;
-const MsgSendIdErrRetId = *const fn (?*anyopaque, ?*anyopaque, ?*anyopaque, ?*anyopaque) callconv(.c) ?*anyopaque;
-const MsgSendIdIdErrRetId = *const fn (?*anyopaque, ?*anyopaque, ?*anyopaque, ?*anyopaque, ?*anyopaque) callconv(.c) ?*anyopaque;
-const MsgSendPtrUsizeUsizeRetId = *const fn (?*anyopaque, ?*anyopaque, ?*const anyopaque, usize, usize) callconv(.c) ?*anyopaque;
-const MsgSendUsizeUsizeRetId = *const fn (?*anyopaque, ?*anyopaque, usize, usize) callconv(.c) ?*anyopaque;
-const MsgSendVoidRetPtr = *const fn (?*anyopaque, ?*anyopaque) callconv(.c) ?*anyopaque;
-const MsgSendIdUsizeUsizeRetVoid = *const fn (?*anyopaque, ?*anyopaque, ?*anyopaque, usize, usize) callconv(.c) void;
-const MsgSendPtrUsizeUsizeRetVoid = *const fn (?*anyopaque, ?*anyopaque, ?*const anyopaque, usize, usize) callconv(.c) void;
-const MsgSendMtlSizeMtlSizeRetVoid = *const fn (?*anyopaque, ?*anyopaque, MTLSize, MTLSize) callconv(.c) void;
-
-/// Shared ObjC msgSend casts + Metal selectors used by every dispatch path.
-/// Constructed once per call site via `load()` so kernels share one helper path
-/// instead of duplicating cast/selector boilerplate.
-const MetalDispatch = struct {
-    msg_void_id: MsgSendVoidRetId,
-    msg_void_void: MsgSendVoidRetVoid,
-    msg_id_id: MsgSendIdRetId,
-    msg_bytes: MsgSendPtrUsizeUsizeRetId,
-    msg_len: MsgSendUsizeUsizeRetId,
-    msg_set_buf: MsgSendIdUsizeUsizeRetVoid,
-    msg_set_bytes: MsgSendPtrUsizeUsizeRetVoid,
-    msg_dispatch: MsgSendMtlSizeMtlSizeRetVoid,
-    msg_contents: MsgSendVoidRetPtr,
-
-    sel_command_buffer: ?*anyopaque,
-    sel_encoder: ?*anyopaque,
-    sel_set_pipeline: ?*anyopaque,
-    sel_new_bytes: ?*anyopaque,
-    sel_new_length: ?*anyopaque,
-    sel_set_buffer: ?*anyopaque,
-    sel_set_bytes: ?*anyopaque,
-    sel_dispatch_threads: ?*anyopaque,
-    sel_dispatch_groups: ?*anyopaque,
-    sel_end: ?*anyopaque,
-    sel_commit: ?*anyopaque,
-    sel_wait: ?*anyopaque,
-    sel_contents: ?*anyopaque,
-    sel_release: ?*anyopaque,
-
-    fn load() MetalDispatch {
-        if (comptime builtin.target.os.tag != .macos) {
-            return undefined;
-        }
-        return .{
-            .msg_void_id = @ptrCast(&objc.objc_msgSend),
-            .msg_void_void = @ptrCast(&objc.objc_msgSend),
-            .msg_id_id = @ptrCast(&objc.objc_msgSend),
-            .msg_bytes = @ptrCast(&objc.objc_msgSend),
-            .msg_len = @ptrCast(&objc.objc_msgSend),
-            .msg_set_buf = @ptrCast(&objc.objc_msgSend),
-            .msg_set_bytes = @ptrCast(&objc.objc_msgSend),
-            .msg_dispatch = @ptrCast(&objc.objc_msgSend),
-            .msg_contents = @ptrCast(&objc.objc_msgSend),
-            .sel_command_buffer = objc.sel_registerName("commandBuffer"),
-            .sel_encoder = objc.sel_registerName("computeCommandEncoder"),
-            .sel_set_pipeline = objc.sel_registerName("setComputePipelineState:"),
-            .sel_new_bytes = objc.sel_registerName("newBufferWithBytes:length:options:"),
-            .sel_new_length = objc.sel_registerName("newBufferWithLength:options:"),
-            .sel_set_buffer = objc.sel_registerName("setBuffer:offset:atIndex:"),
-            .sel_set_bytes = objc.sel_registerName("setBytes:length:atIndex:"),
-            .sel_dispatch_threads = objc.sel_registerName("dispatchThreads:threadsPerThreadgroup:"),
-            .sel_dispatch_groups = objc.sel_registerName("dispatchThreadgroups:threadsPerThreadgroup:"),
-            .sel_end = objc.sel_registerName("endEncoding"),
-            .sel_commit = objc.sel_registerName("commit"),
-            .sel_wait = objc.sel_registerName("waitUntilCompleted"),
-            .sel_contents = objc.sel_registerName("contents"),
-            .sel_release = objc.sel_registerName("release"),
-        };
-    }
-
-    fn release(self: MetalDispatch, obj: ?*anyopaque) void {
-        self.msg_void_void(obj, self.sel_release);
-    }
-
-    fn commitAndWait(self: MetalDispatch, cmd_buf: ?*anyopaque) void {
-        self.msg_void_void(cmd_buf, self.sel_commit);
-        self.msg_void_void(cmd_buf, self.sel_wait);
-    }
-
-    fn readF32(self: MetalDispatch, buffer: ?*anyopaque) !f32 {
-        const ptr = self.msg_contents(buffer, self.sel_contents) orelse return error.ReadBufferFailed;
-        return @as([*]f32, @ptrCast(@alignCast(ptr)))[0];
-    }
-
-    fn copyBufferToHost(self: MetalDispatch, buffer: ?*anyopaque, dest: []f32) !void {
-        const ptr = self.msg_contents(buffer, self.sel_contents) orelse return error.ReadBufferFailed;
-        @memcpy(dest, @as([*]f32, @ptrCast(@alignCast(ptr)))[0..dest.len]);
-    }
-
-    /// Encode one 256-wide reduce pass into an existing command buffer.
-    /// Returns the newly allocated partials buffer (caller owns) and its length.
-    fn encodeReducePass(
-        self: MetalDispatch,
-        device: ?*anyopaque,
-        pipeline: ?*anyopaque,
-        cmd_buf: ?*anyopaque,
-        buffer_in: ?*anyopaque,
-        current_len: usize,
-    ) !struct { buffer: ?*anyopaque, len: usize } {
-        const tg_size: usize = 256;
-        const num_groups = (current_len + tg_size - 1) / tg_size;
-        const partial_bytes = num_groups * @sizeOf(f32);
-        const buffer_out = self.msg_len(device, self.sel_new_length, partial_bytes, 0) orelse
-            return error.BufferAllocationFailed;
-
-        const encoder = self.msg_void_id(cmd_buf, self.sel_encoder) orelse {
-            self.release(buffer_out);
-            return error.EncoderCreationFailed;
-        };
-
-        _ = self.msg_id_id(encoder, self.sel_set_pipeline, pipeline);
-        self.msg_set_buf(encoder, self.sel_set_buffer, buffer_in, 0, 0);
-        self.msg_set_buf(encoder, self.sel_set_buffer, buffer_out, 0, 1);
-        var n_u32: u32 = @intCast(current_len);
-        self.msg_set_bytes(encoder, self.sel_set_bytes, &n_u32, @sizeOf(u32), 2);
-
-        const groups = MTLSize{ .width = num_groups, .height = 1, .depth = 1 };
-        const threads = MTLSize{ .width = tg_size, .height = 1, .depth = 1 };
-        self.msg_dispatch(encoder, self.sel_dispatch_groups, groups, threads);
-        self.msg_void_void(encoder, self.sel_end);
-
-        return .{ .buffer = buffer_out, .len = num_groups };
-    }
-
-    /// Multi-pass reduce encoded into `cmd_buf` (no commit/wait). Returns the
-    /// final single-element buffer; releases intermediate inputs.
-    fn encodeReduceToScalar(
-        self: MetalDispatch,
-        device: ?*anyopaque,
-        pipeline: ?*anyopaque,
-        cmd_buf: ?*anyopaque,
-        buffer_in_owned: ?*anyopaque,
-        start_len: usize,
-    ) !?*anyopaque {
-        var buffer_in = buffer_in_owned;
-        var current_len = start_len;
-        errdefer self.release(buffer_in);
-
-        while (current_len > 1) {
-            const pass = try self.encodeReducePass(device, pipeline, cmd_buf, buffer_in, current_len);
-            self.release(buffer_in);
-            buffer_in = pass.buffer;
-            current_len = pass.len;
-        }
-        return buffer_in;
-    }
-};
-
-fn createNSString(allocator: std.mem.Allocator, str: []const u8) !?*anyopaque {
-    if (comptime builtin.target.os.tag != .macos) return null;
-    const class_nsstring = objc.objc_getClass("NSString");
-    const sel_string_with_utf8 = objc.sel_registerName("stringWithUTF8String:");
-    const MsgSendCstrRetId = *const fn (?*anyopaque, ?*anyopaque, [*c]const u8) callconv(.c) ?*anyopaque;
-    const msg_send_cstr_ret_id = @as(MsgSendCstrRetId, @ptrCast(&objc.objc_msgSend));
-
-    const c_str = try allocator.alloc(u8, str.len + 1);
-    defer allocator.free(c_str);
-    @memcpy(c_str[0..str.len], str);
-    c_str[str.len] = 0;
-
-    return msg_send_cstr_ret_id(class_nsstring, sel_string_with_utf8, c_str.ptr);
-}
+const objc = metal_objc.objc;
+const MTLCreateSystemDefaultDevice = metal_objc.MTLCreateSystemDefaultDevice;
+const MTLSize = metal_objc.MTLSize;
+const MetalDispatch = metal_objc.MetalDispatch;
+const createNSString = metal_objc.createNSString;
+const MsgSendVoidRetId = metal_objc.MsgSendVoidRetId;
+const MsgSendIdIdErrRetId = metal_objc.MsgSendIdIdErrRetId;
+const MsgSendIdErrRetId = metal_objc.MsgSendIdErrRetId;
+const MsgSendIdRetId = metal_objc.MsgSendIdRetId;
+const MsgSendUsizeUsizeRetId = metal_objc.MsgSendUsizeUsizeRetId;
+const MsgSendVoidRetPtr = metal_objc.MsgSendVoidRetPtr;
+const MsgSendIdUsizeUsizeRetVoid = metal_objc.MsgSendIdUsizeUsizeRetVoid;
+const MsgSendPtrUsizeUsizeRetVoid = metal_objc.MsgSendPtrUsizeUsizeRetVoid;
+const MsgSendMtlSizeMtlSizeRetVoid = metal_objc.MsgSendMtlSizeMtlSizeRetVoid;
+const MsgSendPtrUsizeUsizeRetId = metal_objc.MsgSendPtrUsizeUsizeRetId;
+const MsgSendVoidRetVoid = metal_objc.MsgSendVoidRetVoid;
 
 const MetalContext = struct {
     device: ?*anyopaque = null,

--- a/src/features/gpu/mod.zig
+++ b/src/features/gpu/mod.zig
@@ -48,6 +48,8 @@ pub const backendMatrix = compute_api.backendMatrix;
 test {
     std.testing.refAllDecls(@This());
     _ = compute_api;
+    _ = @import("metal_shared.zig");
+    _ = @import("metal_objc.zig");
 }
 
 test "gpu module reexports safe vector operations" {


### PR DESCRIPTION
## Summary
- Extract macOS-gated Metal ObjC FFI into `src/features/gpu/metal_objc.zig`; keep `g_metal_context` on `metal_shared.zig` for vector_ops/backends/compute_api callers.
- Split `abi wdbx simulate` into `wdbx_simulate_options` / `wdbx_simulate_format` with thin hub (`help` + `handleSimulate` unchanged).
- Left `build.zig` alone (550 lines; no wiring change required).

## Test plan
- [x] `./build.sh check-parity`
- [x] `./build.sh check -j1` (41/41)
- [x] `./build.sh lint`
- [x] `abi backends` Metal accelerated
- [x] `abi wdbx simulate --initial A --rule 'A->AB' --depth 2 --format json`
- [x] `./.agents/skills/run-abi/smoke.sh` 18/18


Made with [Cursor](https://cursor.com)