### PR TITLE
fix(auth): replace silent catch in keychain fallback test cleanup

### DIFF
--- a/src/foundation/credentials.zig
+++ b/src/foundation/credentials.zig
@@ -78,7 +78,10 @@ test "keychain env on non-macOS falls back to file load/save without KeychainUns
     defer {
         var threaded: std.Io.Threaded = .init(std.heap.page_allocator, .{});
         defer threaded.deinit();
-        std.Io.Dir.deleteFileAbsolute(threaded.io(), test_path) catch {};
+        std.Io.Dir.deleteFileAbsolute(threaded.io(), test_path) catch |err| switch (err) {
+            error.FileNotFound => {},
+            else => std.log.warn("cleanup failed: {s}", .{@errorName(err)}),
+        };
     }
 
     var environ = std.process.Environ.Map.init(allocator);


### PR DESCRIPTION
## Summary
- Replace `catch {}` in the non-macOS keychain→file fallback test cleanup with the shared `FileNotFound` / warn pattern so `tools/check_silent_catch.sh` passes on `main` after #734.

## Test plan
- [x] `tools/check_silent_catch.sh`
- [ ] CI check on PR / main


Made with [Cursor](https://cursor.com)