### PR TITLE
feat(gpu): public VectorOps.abs + Metal abs_kernel

### DIFF
--- a/src/features/gpu/metal_kernels.zig
+++ b/src/features/gpu/metal_kernels.zig
@@ -28,6 +28,7 @@ pub const MetalContext = struct {
     div_pipeline: ?*anyopaque = null,
     scale_pipeline: ?*anyopaque = null,
     relu_pipeline: ?*anyopaque = null,
+    abs_pipeline: ?*anyopaque = null,
     cosine_parts_pipeline: ?*anyopaque = null,
     batch_cosine_pipeline: ?*anyopaque = null,
     reduce_sum_pipeline: ?*anyopaque = null,
@@ -138,6 +139,15 @@ pub const MetalContext = struct {
             \\    uint id [[thread_position_in_grid]]
             \\) {
             \\    out[id] = max(in[id], 0.0f);
+            \\}
+            \\
+            \\// out[id] = fabs(in[id])
+            \\kernel void abs_kernel(
+            \\    device const float* in [[buffer(0)]],
+            \\    device float* out [[buffer(1)]],
+            \\    uint id [[thread_position_in_grid]]
+            \\) {
+            \\    out[id] = fabs(in[id]);
             \\}
             \\
             \\kernel void cosine_parts_kernel(
@@ -343,6 +353,9 @@ pub const MetalContext = struct {
         const relu_func_name = try createNSString(allocator, "relu_kernel") orelse return error.CreateStringFailed;
         const relu_func = msg_send_id_ret_id(library, sel_newFunctionWithName, relu_func_name) orelse return error.FunctionNotFound;
 
+        const abs_func_name = try createNSString(allocator, "abs_kernel") orelse return error.CreateStringFailed;
+        const abs_func = msg_send_id_ret_id(library, sel_newFunctionWithName, abs_func_name) orelse return error.FunctionNotFound;
+
         const cosine_func_name = try createNSString(allocator, "cosine_parts_kernel") orelse return error.CreateStringFailed;
         const cosine_func = msg_send_id_ret_id(library, sel_newFunctionWithName, cosine_func_name) orelse return error.FunctionNotFound;
 
@@ -398,6 +411,10 @@ pub const MetalContext = struct {
         if (self.relu_pipeline == null) return error.CreatePipelineStateFailed;
 
         err = null;
+        self.abs_pipeline = msg_send_id_err_ret_id(device, sel_newComputePipelineState, abs_func, @ptrCast(&err));
+        if (self.abs_pipeline == null) return error.CreatePipelineStateFailed;
+
+        err = null;
         self.cosine_parts_pipeline = msg_send_id_err_ret_id(device, sel_newComputePipelineState, cosine_func, @ptrCast(&err));
         if (self.cosine_parts_pipeline == null) return error.CreatePipelineStateFailed;
 
@@ -443,6 +460,7 @@ pub const MetalContext = struct {
         msg_send_void_ret_void(div_func, sel_release);
         msg_send_void_ret_void(scale_func, sel_release);
         msg_send_void_ret_void(relu_func, sel_release);
+        msg_send_void_ret_void(abs_func, sel_release);
         msg_send_void_ret_void(cosine_func, sel_release);
         msg_send_void_ret_void(batch_cosine_func, sel_release);
         msg_send_void_ret_void(reduce_func, sel_release);
@@ -460,6 +478,7 @@ pub const MetalContext = struct {
         msg_send_void_ret_void(div_func_name, sel_release);
         msg_send_void_ret_void(scale_func_name, sel_release);
         msg_send_void_ret_void(relu_func_name, sel_release);
+        msg_send_void_ret_void(abs_func_name, sel_release);
         msg_send_void_ret_void(cosine_func_name, sel_release);
         msg_send_void_ret_void(batch_cosine_func_name, sel_release);
         msg_send_void_ret_void(reduce_func_name, sel_release);
@@ -977,6 +996,31 @@ pub const MetalContext = struct {
         const cmd_buf = d.msg_void_id(self.queue, d.sel_command_buffer) orelse
             return error.CommandBufferCreationFailed;
         try encodeUnaryMapKernel(d, self.relu_pipeline, cmd_buf, buffer_in, buffer_out, values.len);
+        d.commitAndWait(cmd_buf);
+        try d.copyBufferToHost(buffer_out, out[0..values.len]);
+    }
+
+    /// `out[i] = fabs(values[i])`. Unary abs map.
+    pub fn runAbs(self: *MetalContext, values: []const f32, out: []f32) !void {
+        if (comptime builtin.target.os.tag != .macos) return error.NotSupported;
+        if (!self.initialized) return error.NotInitialized;
+        if (self.abs_pipeline == null) return error.NotInitialized;
+        if (values.len == 0) return;
+        if (out.len != values.len) return error.DimensionMismatch;
+
+        const d = MetalDispatch.load();
+        const byte_len = values.len * @sizeOf(f32);
+
+        const buffer_in = d.msg_bytes(self.device, d.sel_new_bytes, values.ptr, byte_len, 0) orelse
+            return error.BufferAllocationFailed;
+        defer d.release(buffer_in);
+        const buffer_out = d.msg_bytes(self.device, d.sel_new_bytes, out.ptr, byte_len, 0) orelse
+            return error.BufferAllocationFailed;
+        defer d.release(buffer_out);
+
+        const cmd_buf = d.msg_void_id(self.queue, d.sel_command_buffer) orelse
+            return error.CommandBufferCreationFailed;
+        try encodeUnaryMapKernel(d, self.abs_pipeline, cmd_buf, buffer_in, buffer_out, values.len);
         d.commitAndWait(cmd_buf);
         try d.copyBufferToHost(buffer_out, out[0..values.len]);
     }

--- a/src/features/gpu/mod.zig
+++ b/src/features/gpu/mod.zig
@@ -62,6 +62,10 @@ test "gpu module reexports safe vector operations" {
     try std.testing.expectEqual(@as(f32, 32), try ops.dot(&.{ 1, 2, 3 }, &.{ 4, 5, 6 }));
     try std.testing.expectEqual(@as(f32, 27), try ops.squaredL2(&.{ 1, 2, 3 }, &.{ 4, 5, 6 }));
 
+    var abs_out: [3]f32 = undefined;
+    try ops.abs(&.{ -1.0, 2.0, -3.0 }, &abs_out);
+    try std.testing.expectApproxEqAbs(@as(f32, 1), abs_out[0], 1e-4);
+
     const report = try backendStatusReport(std.testing.allocator);
     defer std.testing.allocator.free(report);
     try std.testing.expect(std.mem.indexOf(u8, report, "simulated:") != null);

--- a/src/features/gpu/stub.zig
+++ b/src/features/gpu/stub.zig
@@ -145,6 +145,13 @@ pub const VectorOps = struct {
         if (out.len != values.len) return error.DimensionMismatch;
         for (values, out) |v, *slot| slot.* = @max(v, 0);
     }
+
+    pub fn abs(self: VectorOps, values: []const f32, out: []f32) !void {
+        _ = self;
+        if (values.len == 0) return;
+        if (out.len != values.len) return error.DimensionMismatch;
+        for (values, out) |v, *slot| slot.* = @abs(v);
+    }
 };
 
 pub fn backendName(backend: Backend) []const u8 {

--- a/src/features/gpu/vector_ops.zig
+++ b/src/features/gpu/vector_ops.zig
@@ -193,6 +193,22 @@ pub const VectorOps = struct {
         cpuRelu(values, out);
     }
 
+    /// `out[i] = fabs(values[i])`. Metal `abs_kernel` when initialized;
+    /// otherwise host loop. No speedup claim.
+    pub fn abs(self: VectorOps, values: []const f32, out: []f32) !void {
+        if (values.len == 0) return;
+        if (out.len != values.len) return error.DimensionMismatch;
+
+        if (self.backend.accelerated and builtin.target.os.tag == .macos and metal.g_metal_context.initialized) {
+            return metal.g_metal_context.runAbs(values, out) catch |err| {
+                std.log.warn("Metal abs failed ({s}); using CPU fallback", .{@errorName(err)});
+                cpuAbs(values, out);
+            };
+        }
+
+        cpuAbs(values, out);
+    }
+
     /// Flattens `candidates` (non-contiguous, pointing into HNSW/caller
     /// storage) into one contiguous host buffer of `candidates.len * query.len`
     /// floats and dispatches the fused batched Metal kernel in a single
@@ -310,6 +326,10 @@ fn cpuScale(values: []const f32, factor: f32, out: []f32) void {
 
 fn cpuRelu(values: []const f32, out: []f32) void {
     for (values, out) |v, *slot| slot.* = @max(v, 0);
+}
+
+fn cpuAbs(values: []const f32, out: []f32) void {
+    for (values, out) |v, *slot| slot.* = @abs(v);
 }
 
 pub fn executeKernel(spec: backends.KernelSpec) !backends.KernelResult {
@@ -637,6 +657,18 @@ test "gpu relu matches independent scalar reference (CPU/GPU parity)" {
     for (values, &expected) |v, *slot| slot.* = @max(v, 0);
     var out: [values.len]f32 = undefined;
     try ops.relu(&values, &out);
+    for (expected, out) |exp, got| {
+        try std.testing.expectApproxEqAbs(exp, got, 1e-4);
+    }
+}
+
+test "gpu abs matches independent scalar reference (CPU/GPU parity)" {
+    const ops = vectorOps();
+    const values = [_]f32{ 1.0, -2.0, 0.0, 4.0, -0.25, 0.5 };
+    var expected: [values.len]f32 = undefined;
+    for (values, &expected) |v, *slot| slot.* = @abs(v);
+    var out: [values.len]f32 = undefined;
+    try ops.abs(&values, &out);
     for (expected, out) |exp, got| {
         try std.testing.expectApproxEqAbs(exp, got, 1e-4);
     }

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -68,7 +68,7 @@ Prioritized after A–G. Do not promote to Done without source + tests + honest 
 | Priority | Item | Status | Notes |
 | -------- | ---- | ------ | ----- |
 | 1 | Neural / ggml in-process sampler (or keep Partial forever) | ◑ Partial | `abi complete --neural` char-LM path + checkpoint round-trip landed (honest demo, not LLM). Residual: real ggml/GGUF transformer sampler. |
-| 2 | Broader Metal GPU path (more kernels / reduce) | ◑ Improved | Fused cosine/dot/L2 + elementwise add/sub/max/min/div + unary scale/relu + multi-pass `reduce_sum_kernel` / `reduce_max_kernel` / `reduce_min_kernel` + demo-grade softmax (on-GPU max). Residual: more kernels / CUDA/ANE disclosed. |
+| 2 | Broader Metal GPU path (more kernels / reduce) | ◑ Improved | Fused cosine/dot/L2 + elementwise add/sub/max/min/div + unary scale/relu/abs + multi-pass reduce + demo softmax. Added public `VectorOps.abs` + Metal abs_kernel (parity tests). Residual: more kernels / CUDA/ANE disclosed. |
 | 3 | Windows **runtime** CI/job | 🔴 Blocked (no Windows runner) | ACL code exists for windows-gnu; execution verify blocked on host. |
 | 4 | OS keychain credential storage | ◑ Partial | macOS login keychain via Security.framework SecItem (opt-in `ABI_CREDENTIALS_BACKEND=keychain`); off-macOS env request is disclosed and load/save fall back to file (Windows/Linux Proposed); default remains file-based; OS-provided at-rest protection only — not hardware-backed, not audited; runtime-verified on macOS host only. |
 | 5 | Phase D cutover plan (HITL) | ◑ Plan landed | `docs/spec/phase-d-cutover-plan.mdx` — checklist only; cutover still needs explicit HITL + gates. Scaffold honesty gate: `tools/check_modernized_refs.sh` in `full-check` (stale `` `src/...` `` refs fail). |


### PR DESCRIPTION
## Summary
- Add public `VectorOps.abs` with Metal `abs_kernel` dispatch and CPU fallback.
- Keep mod/stub parity and note the P2 Metal board update for abs.

## Test plan
- [ ] `./build.sh check-parity` (mod + stub public API)
- [ ] `./build.sh check` or focused GPU/vector_ops tests
- [ ] Confirm `tasks/todo.md` only changes the Priority-2 Metal line


Made with [Cursor](https://cursor.com)