### PR TITLE
test(mcp): deny SSE subscribe with wrong bearer token

### DIFF
--- a/src/mcp/http_transport.zig
+++ b/src/mcp/http_transport.zig
@@ -358,6 +358,37 @@ test "MCP HTTP transport denies unauthenticated SSE subscribe when token configu
     try std.testing.expect(std.mem.indexOf(u8, resp, "event: endpoint") == null);
 }
 
+test "MCP HTTP transport denies SSE subscribe with the wrong bearer token" {
+    const io = std.testing.io;
+    const allocator = std.testing.allocator;
+
+    var bound = try bindLoopback(io);
+    defer bound.server.deinit(io);
+
+    const request = "GET /sse HTTP/1.1\r\nHost: 127.0.0.1\r\nAuthorization: Bearer wrong-token\r\n\r\n";
+
+    var caddr = try std.Io.net.IpAddress.parseIp4("127.0.0.1", bound.port);
+    const client = try caddr.connect(io, .{ .mode = .stream });
+    defer client.close(io);
+
+    {
+        var wb: [256]u8 = undefined;
+        var sw = client.writer(io, &wb);
+        try sw.interface.writeAll(request);
+        try sw.interface.flush();
+    }
+
+    const conn = try bound.server.accept(io);
+    try handleHttpConnectionWithAuth(allocator, io, conn, "local-token");
+
+    var resp_buf: [2048]u8 = undefined;
+    const resp = try readHttpResponse(io, client, &resp_buf);
+    try std.testing.expect(std.mem.indexOf(u8, resp, "401 Unauthorized") != null);
+    try std.testing.expect(std.mem.indexOf(u8, resp, "WWW-Authenticate: Bearer") != null);
+    try std.testing.expect(std.mem.indexOf(u8, resp, "text/event-stream") == null);
+    try std.testing.expect(std.mem.indexOf(u8, resp, "event: endpoint") == null);
+}
+
 test "MCP HTTP transport rejects the wrong bearer token" {
     const io = std.testing.io;
     const allocator = std.testing.allocator;


### PR DESCRIPTION
## Summary
- Adds MCP HTTP SSE wrong-bearer coverage next to the existing missing-token SSE and wrong-token POST tests (Slice A auth symmetry).

## Test plan
- [x] `./build.sh test -Dtest-filter="MCP HTTP transport denies SSE subscribe with the wrong bearer token"`
- [x] `./build.sh check`

Made with [Cursor](https://cursor.com)