### PR TITLE
test: replace e2e skeletons, cover CLI/connector/policy gaps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,14 @@ Canonical instruction file. If this conflicts with `build.zig`, `tools/build.sh`
 - Any public API change → update **both** `mod.zig` and `stub.zig`, then `./build.sh check-parity`. Parity scans column-0 `pub const`/`pub fn` only; struct methods are invisible.
 - 5 contract test files: `tests/contracts/{surface,feature_modules,mcp_tools,plugin_registry,public_docs}.zig`.
 
+## Test topology (not obvious from the file tree)
+- Most coverage is inline `test {}` blocks (~288 of 293 `src/**.zig` files). What *runs* depends on the target:
+- `test` = mod + connector + **cli** + **plugin** + feature-contract artifacts. **`test` does NOT include integration.**
+- **`check` runs `test` but NOT `test-integration`** — only `full-check` runs integration. A test reachable only from `integration_tests.zig` stays unverified in the primary gate.
+- Aggregators exist because inline tests would otherwise never run: CLI ships as an executable (`src/cli_test.zig`) and plugins load by path at runtime (`src/plugins_test.zig`). Adding a test under `src/cli/**` or `src/plugins/**` without the aggregator reaching it silently never executes.
+- `src/tests/*.zig` (e2e/stress) are pulled in only via `refAllDecls` from `src/integration_tests.zig` → `test-integration` → `full-check`.
+- Tests that write under `zig-out/` must create it; a bare `zig build test-integration` on a clean tree has no `zig-out` and fails with `FileNotFound`.
+
 ## Zig 0.17 essentials (easy to miss)
 - `pub fn main(init: std.process.Init) !void`; `ArrayListUnmanaged(T).empty`; `std.mem.trimEnd`/`splitScalar`/`splitAny`/`splitSequence`; `foundation.time.unixMs()`.
 - Tests: inline `test {}`, end modules with `std.testing.refAllDecls(@This())`.

--- a/src/cli/handlers/complete_handlers.zig
+++ b/src/cli/handlers/complete_handlers.zig
@@ -14,11 +14,26 @@ const LearnMetadata = struct {
     adapted: bool,
 };
 
+const DebugWriter = struct {
+    pub fn print(_: *const @This(), comptime format: []const u8, args: anytype) !void {
+        std.debug.print(format, args);
+    }
+};
+
 fn printCompletionMetadata(completion: *const features.ai.CompletionResult, stats: anytype, learn: ?LearnMetadata, skip_output: bool) void {
+    const writer = DebugWriter{};
+    printCompletionMetadataWriter(&writer, completion, stats, learn, skip_output) catch {};
+}
+
+/// Renders the same one-line-per-field completion metadata as
+/// `printCompletionMetadata` through an injectable `writer` (anything with a
+/// `print(comptime fmt, args) !void` method), so the exact formatted content
+/// can be asserted in tests without capturing stderr.
+fn printCompletionMetadataWriter(writer: anytype, completion: *const features.ai.CompletionResult, stats: anytype, learn: ?LearnMetadata, skip_output: bool) !void {
     const persisted = completion.query_vector_id != null and completion.response_vector_id != null and completion.block_id != null;
 
     if (learn) |meta| {
-        std.debug.print("model={s} profile={s} audit_passed={s} audit_escore={d:.3} audit_vetoed={s} persisted={s} learn=true evidence_count={d} adapted={s}\n", .{
+        try writer.print("model={s} profile={s} audit_passed={s} audit_escore={d:.3} audit_vetoed={s} persisted={s} learn=true evidence_count={d} adapted={s}\n", .{
             completion.model,
             completion.selected_profile.label(),
             if (completion.audit.passed) "true" else "false",
@@ -29,7 +44,7 @@ fn printCompletionMetadata(completion: *const features.ai.CompletionResult, stat
             if (meta.adapted) "true" else "false",
         });
     } else {
-        std.debug.print("model={s} profile={s} audit_passed={s} audit_escore={d:.3} audit_vetoed={s} persisted={s}\n", .{
+        try writer.print("model={s} profile={s} audit_passed={s} audit_escore={d:.3} audit_vetoed={s} persisted={s}\n", .{
             completion.model,
             completion.selected_profile.label(),
             if (completion.audit.passed) "true" else "false",
@@ -39,18 +54,18 @@ fn printCompletionMetadata(completion: *const features.ai.CompletionResult, stat
         });
     }
 
-    std.debug.print("wdbx kv_entries={d} vectors={d} blocks={d}\n", .{ stats.kv_entries, stats.vectors, stats.blocks });
+    try writer.print("wdbx kv_entries={d} vectors={d} blocks={d}\n", .{ stats.kv_entries, stats.vectors, stats.blocks });
     if (completion.query_vector_id) |qid| {
-        std.debug.print("query_vector_id={d}\n", .{qid});
-        std.debug.print("metadata_key=completion:{d}\n", .{qid});
+        try writer.print("query_vector_id={d}\n", .{qid});
+        try writer.print("metadata_key=completion:{d}\n", .{qid});
     }
-    if (completion.response_vector_id) |rid| std.debug.print("response_vector_id={d}\n", .{rid});
+    if (completion.response_vector_id) |rid| try writer.print("response_vector_id={d}\n", .{rid});
     if (completion.block_id) |block_id| {
         const block_hex = std.fmt.bytesToHex(block_id, .lower);
-        std.debug.print("block_id={s}\n", .{&block_hex});
+        try writer.print("block_id={s}\n", .{&block_hex});
     }
-    if (!persisted) std.debug.print("wdbx_status={s}\n", .{stats.acceleration.message});
-    if (!skip_output) std.debug.print("{s}\n", .{completion.output});
+    if (!persisted) try writer.print("wdbx_status={s}\n", .{stats.acceleration.message});
+    if (!skip_output) try writer.print("{s}\n", .{completion.output});
 }
 
 /// `abi complete --learn`: run one SEA self-learning pass against the durable
@@ -269,7 +284,7 @@ pub fn handleLocalBridgeComplete(io: std.Io, allocator: std.mem.Allocator, input
         return 0;
     }
 
-    var response = connectors.local_bridge.completeLive(io, allocator, model, input) catch |err| {
+    var response = connectors.local_bridge.completeLive(io, allocator, model, input, null) catch |err| {
         std.debug.print("error: local bridge request failed: {s}\n", .{@errorName(err)});
         return 1;
     };
@@ -346,4 +361,122 @@ pub fn handleNeuralComplete(io: std.Io, allocator: std.mem.Allocator, input: []c
         .{if (stream) "chunked" else "batch"},
     );
     return 0;
+}
+
+const test_helpers = @import("abi").foundation.test_helpers;
+const testing = std.testing;
+
+const test_block_id: [32]u8 = @splat(0xAB);
+
+fn testCompletion(allocator: std.mem.Allocator, output: []const u8, persisted: bool) !features.ai.CompletionResult {
+    var audit = features.ai.constitution.AuditResult.init();
+    audit.escore = 0.875;
+    return .{
+        .model = "claude-fable-5",
+        .selected_profile = .abbey,
+        .output = try allocator.dupe(u8, output),
+        .audit = audit,
+        .query_vector_id = if (persisted) 7 else null,
+        .response_vector_id = if (persisted) 8 else null,
+        .block_id = if (persisted) test_block_id else null,
+    };
+}
+
+const testStats = .{
+    .kv_entries = 3,
+    .vectors = 5,
+    .blocks = 1,
+    .acceleration = .{ .message = "cpu_fallback (deterministic SIMD)" },
+};
+
+test "printCompletionMetadataWriter: persisted completion without learn omits learn/evidence fields" {
+    const a = testing.allocator;
+    var completion = try testCompletion(a, "hello there", true);
+    defer completion.deinit(a);
+
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
+    defer buf.deinit(a);
+    const writer = test_helpers.TestWriter{ .allocator = a, .buffer = &buf };
+
+    try printCompletionMetadataWriter(&writer, &completion, testStats, null, false);
+
+    try testing.expect(std.mem.indexOf(u8, buf.items, "model=claude-fable-5") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "profile=abbey") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "audit_passed=true") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "audit_escore=0.875") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "persisted=true") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "learn=true") == null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "evidence_count") == null);
+
+    try testing.expect(std.mem.indexOf(u8, buf.items, "wdbx kv_entries=3 vectors=5 blocks=1") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "query_vector_id=7") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "metadata_key=completion:7") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "response_vector_id=8") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "block_id=") != null);
+    // A persisted completion never reports the fallback wdbx_status line.
+    try testing.expect(std.mem.indexOf(u8, buf.items, "wdbx_status=") == null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "hello there") != null);
+}
+
+test "printCompletionMetadataWriter: learn metadata adds evidence_count and adapted fields" {
+    const a = testing.allocator;
+    var completion = try testCompletion(a, "learned output", true);
+    defer completion.deinit(a);
+
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
+    defer buf.deinit(a);
+    const writer = test_helpers.TestWriter{ .allocator = a, .buffer = &buf };
+
+    try printCompletionMetadataWriter(&writer, &completion, testStats, .{ .evidence_count = 4, .adapted = true }, false);
+
+    try testing.expect(std.mem.indexOf(u8, buf.items, "learn=true") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "evidence_count=4") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "adapted=true") != null);
+}
+
+test "printCompletionMetadataWriter: unpersisted completion reports wdbx_status and omits vector/block ids" {
+    const a = testing.allocator;
+    var completion = try testCompletion(a, "no store output", false);
+    defer completion.deinit(a);
+
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
+    defer buf.deinit(a);
+    const writer = test_helpers.TestWriter{ .allocator = a, .buffer = &buf };
+
+    try printCompletionMetadataWriter(&writer, &completion, testStats, null, false);
+
+    try testing.expect(std.mem.indexOf(u8, buf.items, "persisted=false") != null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "query_vector_id=") == null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "response_vector_id=") == null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "block_id=") == null);
+    try testing.expect(std.mem.indexOf(u8, buf.items, "wdbx_status=cpu_fallback (deterministic SIMD)") != null);
+}
+
+test "printCompletionMetadataWriter: skip_output suppresses the completion body" {
+    const a = testing.allocator;
+    var completion = try testCompletion(a, "should not appear", true);
+    defer completion.deinit(a);
+
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
+    defer buf.deinit(a);
+    const writer = test_helpers.TestWriter{ .allocator = a, .buffer = &buf };
+
+    try printCompletionMetadataWriter(&writer, &completion, testStats, null, true);
+
+    try testing.expect(std.mem.indexOf(u8, buf.items, "should not appear") == null);
+}
+
+test "handleFmComplete refuses on-device completion without --confirm" {
+    const a = testing.allocator;
+    const code = try handleFmComplete(a, "hi", "apple-fm", false);
+    try testing.expectEqual(@as(u8, 2), code);
+}
+
+test "handleLiveComplete rejects non-anthropic models before touching credentials or network" {
+    const code = try handleLiveComplete(testing.io, testing.allocator, "hi", "gpt-4", false);
+    try testing.expectEqual(@as(u8, 2), code);
+}
+
+test {
+    std.testing.refAllDecls(@This());
 }

--- a/src/cli/handlers/complete_handlers.zig
+++ b/src/cli/handlers/complete_handlers.zig
@@ -20,9 +20,9 @@ const DebugWriter = struct {
     }
 };
 
-fn printCompletionMetadata(completion: *const features.ai.CompletionResult, stats: anytype, learn: ?LearnMetadata, skip_output: bool) void {
+fn printCompletionMetadata(completion: *const features.ai.CompletionResult, stats: anytype, learn: ?LearnMetadata, skip_output: bool) !void {
     const writer = DebugWriter{};
-    printCompletionMetadataWriter(&writer, completion, stats, learn, skip_output) catch {};
+    try printCompletionMetadataWriter(&writer, completion, stats, learn, skip_output);
 }
 
 /// Renders the same one-line-per-field completion metadata as
@@ -82,7 +82,7 @@ pub fn handleLearnComplete(
 
     const completion = result.completion;
     const stats = store.stats();
-    printCompletionMetadata(&completion, stats, .{ .evidence_count = result.evidence_count, .adapted = result.adapted }, false);
+    try printCompletionMetadata(&completion, stats, .{ .evidence_count = result.evidence_count, .adapted = result.adapted }, false);
     return 0;
 }
 
@@ -246,7 +246,7 @@ pub fn handleLocalBridgeComplete(io: std.Io, allocator: std.mem.Allocator, input
             defer result.deinit(allocator);
             std.debug.print("\n", .{});
             const stats = store.stats();
-            printCompletionMetadata(&result, stats, null, false);
+            try printCompletionMetadata(&result, stats, null, false);
             return 0;
         }
         var result = try features.ai.completeWithScheduler(allocator, store, &scheduler, "complete:local-bridge-fallback", .{
@@ -256,7 +256,7 @@ pub fn handleLocalBridgeComplete(io: std.Io, allocator: std.mem.Allocator, input
         });
         defer result.deinit(allocator);
         const stats = store.stats();
-        printCompletionMetadata(&result, stats, null, false);
+        try printCompletionMetadata(&result, stats, null, false);
         return 0;
     }
 

--- a/src/connectors/anthropic.zig
+++ b/src/connectors/anthropic.zig
@@ -124,6 +124,64 @@ pub const Client = struct {
     }
 };
 
+test "Client.message on the local transport synthesizes a parseable response without any network call" {
+    const a = std.testing.allocator;
+    var client = Client.init(a, .{
+        .api_key = "test-key",
+        .base_url = "http://local.invalid",
+        .transport = .local,
+    });
+    defer client.deinit();
+
+    var response = try client.message(a, "fable-5", "hello there", 256);
+    defer response.deinit(a);
+
+    try std.testing.expectEqual(@as(u16, 200), response.status);
+    try json.validateJsonValue(a, response.body, .object);
+    try std.testing.expect(std.mem.indexOf(u8, response.body, "model=fable-5") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response.body, "max_tokens=256") != null);
+}
+
+test "Client.streamMessage on the local transport synthesizes SSE-shaped output" {
+    const a = std.testing.allocator;
+    var client = Client.init(a, .{
+        .api_key = "test-key",
+        .base_url = "http://local.invalid",
+        .transport = .local,
+    });
+    defer client.deinit();
+
+    var response = try client.streamMessage(a, "fable-5", "hi", 128);
+    defer response.deinit(a);
+
+    try std.testing.expectEqual(@as(u16, 200), response.status);
+    try std.testing.expect(std.mem.startsWith(u8, response.body, "event: content_block_delta\ndata: "));
+}
+
+test "Client.message rejects an empty api key before building any request" {
+    const a = std.testing.allocator;
+    var client = Client.init(a, .{
+        .api_key = "",
+        .base_url = "http://local.invalid",
+        .transport = .local,
+    });
+    defer client.deinit();
+
+    try std.testing.expectError(ConnectorError.AuthenticationError, client.message(a, "fable-5", "hi", 128));
+}
+
+test "Client.message on the live transport refuses local synthesis (LiveTransportUnavailable)" {
+    const a = std.testing.allocator;
+    var client = Client.init(a, .{
+        .api_key = "test-key",
+        .base_url = "https://api.anthropic.com",
+        .transport = .live,
+    });
+    defer client.deinit();
+
+    try std.testing.expectError(ConnectorError.LiveTransportUnavailable, client.message(a, "fable-5", "hi", 128));
+}
+
 test {
     std.testing.refAllDecls(@This());
 }

--- a/src/connectors/json.zig
+++ b/src/connectors/json.zig
@@ -162,6 +162,138 @@ pub fn discordLocalAck(allocator: std.mem.Allocator, channel_id: []const u8, con
     return try out.toOwnedSlice(allocator);
 }
 
+test "appendJsonString escapes quotes, backslashes, and common control characters" {
+    const a = std.testing.allocator;
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(a);
+
+    try appendJsonString(&out, a, "line1\nline2\ttab\r\"quoted\"\\backslash");
+    try std.testing.expectEqualStrings(
+        "\"line1\\nline2\\ttab\\r\\\"quoted\\\"\\\\backslash\"",
+        out.items,
+    );
+}
+
+test "appendJsonString escapes backspace, form feed, and low control bytes as \\u escapes" {
+    const a = std.testing.allocator;
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(a);
+
+    try appendJsonString(&out, a, &.{ 0x08, 0x0c, 0x01, 0x1f });
+    try std.testing.expectEqualStrings("\"\\b\\f\\u0001\\u001F\"", out.items);
+}
+
+test "appendJsonString passes through plain ASCII unchanged" {
+    const a = std.testing.allocator;
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(a);
+
+    try appendJsonString(&out, a, "hello world 123");
+    try std.testing.expectEqualStrings("\"hello world 123\"", out.items);
+}
+
+test "validateJsonValue enforces the expected top-level kind" {
+    const a = std.testing.allocator;
+    try validateJsonValue(a, "[1,2,3]", .array);
+    try validateJsonValue(a, "{\"k\":1}", .object);
+    try validateJsonValue(a, "\"anything\"", .any);
+
+    try std.testing.expectError(ConnectorError.InvalidResponse, validateJsonValue(a, "{\"k\":1}", .array));
+    try std.testing.expectError(ConnectorError.InvalidResponse, validateJsonValue(a, "[1]", .object));
+    try std.testing.expectError(ConnectorError.InvalidResponse, validateJsonValue(a, "not json", .any));
+}
+
+test "buildOpenAiBody requires a JSON array for messages and embeds model/stream" {
+    const a = std.testing.allocator;
+
+    try std.testing.expectError(ConnectorError.InvalidResponse, buildOpenAiBody(a, "gpt-4", "{\"not\":\"array\"}", false));
+
+    const body = try buildOpenAiBody(a, "gpt-4", "[{\"role\":\"user\",\"content\":\"hi\"}]", false);
+    defer a.free(body);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"model\":\"gpt-4\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"stream\"") == null);
+    try validateJsonValue(a, body, .object);
+
+    const streamed = try buildOpenAiBody(a, "gpt-4", "[]", true);
+    defer a.free(streamed);
+    try std.testing.expect(std.mem.indexOf(u8, streamed, "\"stream\":true") != null);
+}
+
+test "buildAnthropicBody embeds model, max_tokens, and the user message" {
+    const a = std.testing.allocator;
+
+    const body = try buildAnthropicBody(a, "fable-5", "hello \"claude\"", 512, false);
+    defer a.free(body);
+    try validateJsonValue(a, body, .object);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"model\":\"fable-5\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"max_tokens\":512") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\\\"claude\\\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "\"stream\"") == null);
+
+    const streamed = try buildAnthropicBody(a, "fable-5", "hi", 128, true);
+    defer a.free(streamed);
+    try std.testing.expect(std.mem.indexOf(u8, streamed, "\"stream\":true") != null);
+}
+
+test "buildDiscordMessageBody and buildDiscordIdentifyBody produce parseable JSON with expected fields" {
+    const a = std.testing.allocator;
+
+    const msg_body = try buildDiscordMessageBody(a, "hello discord");
+    defer a.free(msg_body);
+    try validateJsonValue(a, msg_body, .object);
+    try std.testing.expect(std.mem.indexOf(u8, msg_body, "\"content\":\"hello discord\"") != null);
+
+    const identify_body = try buildDiscordIdentifyBody(a, "tok123", 513);
+    defer a.free(identify_body);
+    try validateJsonValue(a, identify_body, .object);
+    try std.testing.expect(std.mem.indexOf(u8, identify_body, "\"op\":2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, identify_body, "\"token\":\"tok123\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, identify_body, "\"intents\":513") != null);
+}
+
+test "openAiLocalResponse and openAiLocalStream embed model/byte-count metadata as parseable JSON" {
+    const a = std.testing.allocator;
+
+    const resp = try openAiLocalResponse(a, "gpt-4", "[1,2,3]", 42);
+    defer a.free(resp);
+    try validateJsonValue(a, resp, .object);
+    try std.testing.expect(std.mem.indexOf(u8, resp, "model=gpt-4") != null);
+    try std.testing.expect(std.mem.indexOf(u8, resp, "messages_bytes=7") != null);
+    try std.testing.expect(std.mem.indexOf(u8, resp, "request_bytes=42") != null);
+
+    const stream = try openAiLocalStream(a, "gpt-4", "[1,2,3]", 42);
+    defer a.free(stream);
+    try std.testing.expect(std.mem.startsWith(u8, stream, "data: "));
+    try std.testing.expect(std.mem.endsWith(u8, stream, "data: [DONE]\n\n"));
+}
+
+test "anthropicLocalResponse and anthropicLocalStream embed model/prompt/max_tokens metadata" {
+    const a = std.testing.allocator;
+
+    const resp = try anthropicLocalResponse(a, "fable-5", "hi there", 256, 99);
+    defer a.free(resp);
+    try validateJsonValue(a, resp, .object);
+    try std.testing.expect(std.mem.indexOf(u8, resp, "model=fable-5") != null);
+    try std.testing.expect(std.mem.indexOf(u8, resp, "prompt_bytes=8") != null);
+    try std.testing.expect(std.mem.indexOf(u8, resp, "max_tokens=256") != null);
+    try std.testing.expect(std.mem.indexOf(u8, resp, "request_bytes=99") != null);
+
+    const stream = try anthropicLocalStream(a, "fable-5", "hi there", 256, 99);
+    defer a.free(stream);
+    try std.testing.expect(std.mem.startsWith(u8, stream, "event: content_block_delta\ndata: "));
+    try std.testing.expect(std.mem.endsWith(u8, stream, "event: message_stop\n\n"));
+}
+
+test "discordLocalAck reports channel id and content byte length as parseable JSON" {
+    const a = std.testing.allocator;
+    const ack = try discordLocalAck(a, "chan-42", "hello");
+    defer a.free(ack);
+    try validateJsonValue(a, ack, .object);
+    try std.testing.expect(std.mem.indexOf(u8, ack, "\"status\":\"queued-local\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, ack, "\"channel_id\":\"chan-42\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, ack, "\"content_bytes\":5") != null);
+}
+
 test {
     std.testing.refAllDecls(@This());
 }

--- a/src/connectors/local_bridge.zig
+++ b/src/connectors/local_bridge.zig
@@ -72,15 +72,17 @@ pub fn healthCheck(io: std.Io, allocator: std.mem.Allocator, endpoint: []const u
 /// (owned by the caller). The caller is responsible for parsing the
 /// `choices[0].message.content` field.
 ///
-/// `endpoint_override` (default `null`) forces a base URL — same semantics as
-/// `endpointFor`'s override — so tests can target an unreachable host without
-/// racing whatever may be listening on the default `:8080`.
+/// `endpoint_override` forces a base URL — same semantics as `endpointFor`'s
+/// override — so tests can target an unreachable host without racing whatever
+/// may be listening on the default `:8080`. Pass `null` for the default
+/// endpoint resolution (Zig has no default parameter values, so callers that
+/// want the default must pass `null` explicitly).
 pub fn completeLive(
     io: std.Io,
     allocator: std.mem.Allocator,
     model: []const u8,
     input: []const u8,
-    endpoint_override: ?[]const u8 = null,
+    endpoint_override: ?[]const u8,
 ) !Response {
     const endpoint = endpointFor(model, endpoint_override);
     const config = ConnectorConfig{
@@ -219,7 +221,10 @@ test "local_bridge completeLive errors for unreachable endpoint (no leak on succ
     // httpPostJson → ConnectionFailed (typically), or Timeout /
     // LiveTransportUnavailable.
     if (completeLive(io, allocator, "llama/phi3", "ping", "http://127.0.0.1:1")) |response| {
-        defer response.deinit(allocator);
+        // `deinit` takes a mutable pointer, and an `if` payload capture is
+        // const, so rebind before freeing.
+        var owned = response;
+        defer owned.deinit(allocator);
         try std.testing.expect(false); // success must not pass
     } else |err| {
         try std.testing.expect(err == error.ConnectionFailed or err == error.Timeout or err == error.LiveTransportUnavailable);

--- a/src/connectors/openai.zig
+++ b/src/connectors/openai.zig
@@ -98,6 +98,64 @@ pub const Client = struct {
     }
 };
 
+test "Client.chatCompletion on the local transport synthesizes a parseable response without any network call" {
+    const a = std.testing.allocator;
+    var client = Client.init(a, .{
+        .api_key = "test-key",
+        .base_url = "http://local.invalid",
+        .transport = .local,
+    });
+    defer client.deinit();
+
+    var response = try client.chatCompletion(a, "gpt-4", "[{\"role\":\"user\",\"content\":\"hi\"}]");
+    defer response.deinit(a);
+
+    try std.testing.expectEqual(@as(u16, 200), response.status);
+    try json.validateJsonValue(a, response.body, .object);
+    try std.testing.expect(std.mem.indexOf(u8, response.body, "model=gpt-4") != null);
+}
+
+test "Client.chatCompletion rejects malformed (non-array) messages before synthesizing a response" {
+    const a = std.testing.allocator;
+    var client = Client.init(a, .{
+        .api_key = "test-key",
+        .base_url = "http://local.invalid",
+        .transport = .local,
+    });
+    defer client.deinit();
+
+    try std.testing.expectError(ConnectorError.InvalidResponse, client.chatCompletion(a, "gpt-4", "{\"not\":\"array\"}"));
+}
+
+test "Client.streamChatCompletion on the local transport synthesizes SSE-shaped output" {
+    const a = std.testing.allocator;
+    var client = Client.init(a, .{
+        .api_key = "test-key",
+        .base_url = "http://local.invalid",
+        .transport = .local,
+    });
+    defer client.deinit();
+
+    var response = try client.streamChatCompletion(a, "gpt-4", "[]");
+    defer response.deinit(a);
+
+    try std.testing.expectEqual(@as(u16, 200), response.status);
+    try std.testing.expect(std.mem.startsWith(u8, response.body, "data: "));
+    try std.testing.expect(std.mem.endsWith(u8, response.body, "data: [DONE]\n\n"));
+}
+
+test "Client.chatCompletion on the live transport refuses local synthesis (LiveTransportUnavailable)" {
+    const a = std.testing.allocator;
+    var client = Client.init(a, .{
+        .api_key = "test-key",
+        .base_url = "https://api.openai.com",
+        .transport = .live,
+    });
+    defer client.deinit();
+
+    try std.testing.expectError(ConnectorError.LiveTransportUnavailable, client.chatCompletion(a, "gpt-4", "[]"));
+}
+
 test {
     std.testing.refAllDecls(@This());
 }

--- a/src/connectors/twilio_relay.zig
+++ b/src/connectors/twilio_relay.zig
@@ -341,6 +341,214 @@ fn containsIgnoreCase(haystack: []const u8, needle: []const u8) bool {
     return false;
 }
 
+const testing = std.testing;
+
+fn eventFor(kind: ConversationRelayEventKind, transcript: []const u8) ConversationRelayEvent {
+    return .{
+        .kind = kind,
+        .conversation_id = "conv-1",
+        .customer_id = "cust-1",
+        .transcript = transcript,
+        .owned = false,
+    };
+}
+
+test "classifyEscalation: normal transcript is not escalated" {
+    try testing.expect(classifyEscalation(eventFor(.user_transcript, "I'd like to check my order status please")) == null);
+}
+
+test "classifyEscalation: empty or whitespace-only transcript escalates" {
+    try testing.expectEqual(EscalationReason.empty_transcript, classifyEscalation(eventFor(.user_transcript, "")).?);
+    try testing.expectEqual(EscalationReason.empty_transcript, classifyEscalation(eventFor(.user_transcript, "   \t  ")).?);
+}
+
+test "classifyEscalation: explicit human request keywords escalate case-insensitively" {
+    try testing.expectEqual(EscalationReason.human_requested, classifyEscalation(eventFor(.user_transcript, "let me talk to a HUMAN please")).?);
+    try testing.expectEqual(EscalationReason.human_requested, classifyEscalation(eventFor(.user_transcript, "I want a representative")).?);
+    try testing.expectEqual(EscalationReason.human_requested, classifyEscalation(eventFor(.user_transcript, "connect me with a real person")).?);
+    try testing.expectEqual(EscalationReason.human_requested, classifyEscalation(eventFor(.user_transcript, "get me a Support Agent")).?);
+}
+
+test "classifyEscalation: sensitive topic keywords escalate case-insensitively" {
+    try testing.expectEqual(EscalationReason.sensitive_topic, classifyEscalation(eventFor(.user_transcript, "my credit card was declined")).?);
+    try testing.expectEqual(EscalationReason.sensitive_topic, classifyEscalation(eventFor(.user_transcript, "here is my SSN")).?);
+    try testing.expectEqual(EscalationReason.sensitive_topic, classifyEscalation(eventFor(.user_transcript, "I need a medical diagnosis")).?);
+    try testing.expectEqual(EscalationReason.sensitive_topic, classifyEscalation(eventFor(.user_transcript, "this is about debt collection")).?);
+}
+
+test "classifyEscalation: very short or low-confidence phrasing escalates" {
+    try testing.expectEqual(EscalationReason.low_confidence, classifyEscalation(eventFor(.user_transcript, "hi")).?);
+    try testing.expectEqual(EscalationReason.low_confidence, classifyEscalation(eventFor(.user_transcript, "I'm not sure what happened")).?);
+    try testing.expectEqual(EscalationReason.low_confidence, classifyEscalation(eventFor(.user_transcript, "totally confused right now")).?);
+    try testing.expectEqual(EscalationReason.low_confidence, classifyEscalation(eventFor(.user_transcript, "got an unknown error code")).?);
+}
+
+test "classifyEscalation: intelligence signal overrides transcript content, even a clean one" {
+    var event = eventFor(.user_transcript, "everything is going great, thanks!");
+    event.intelligence = .{ .escalation_recommended = true };
+    try testing.expectEqual(EscalationReason.intelligence_signal, classifyEscalation(event).?);
+}
+
+test "classifyEscalation: intelligence signal present but not recommending escalation defers to transcript" {
+    var event = eventFor(.user_transcript, "everything is going great, thanks!");
+    event.intelligence = .{ .escalation_recommended = false };
+    try testing.expect(classifyEscalation(event) == null);
+}
+
+test "buildLocalConversationResponse: fixed replies for setup/disconnect/interrupt/dtmf need no classification" {
+    const a = testing.allocator;
+
+    var setup = try buildLocalConversationResponse(a, eventFor(.setup, ""), "unused");
+    defer setup.deinit(a);
+    try testing.expect(std.mem.indexOf(u8, setup.text, "ABI support") != null);
+    try testing.expect(setup.escalation == null);
+
+    var disconnect = try buildLocalConversationResponse(a, eventFor(.disconnect, ""), "unused");
+    defer disconnect.deinit(a);
+    try testing.expect(std.mem.indexOf(u8, disconnect.text, "Thanks for contacting") != null);
+
+    var interrupt = try buildLocalConversationResponse(a, eventFor(.interrupt, ""), "unused");
+    defer interrupt.deinit(a);
+    try testing.expect(std.mem.indexOf(u8, interrupt.text, "interruption") != null);
+
+    var dtmf_event = eventFor(.dtmf, "");
+    dtmf_event.digit = "5";
+    var dtmf = try buildLocalConversationResponse(a, dtmf_event, "unused");
+    defer dtmf.deinit(a);
+    try testing.expect(std.mem.indexOf(u8, dtmf.text, "keypad input 5") != null);
+
+    var dtmf_no_digit = try buildLocalConversationResponse(a, eventFor(.dtmf, ""), "unused");
+    defer dtmf_no_digit.deinit(a);
+    try testing.expect(std.mem.indexOf(u8, dtmf_no_digit.text, "keypad input unknown") != null);
+}
+
+test "buildLocalConversationResponse: user_transcript with no escalation carries the agent reply and memory recall" {
+    const a = testing.allocator;
+
+    var plain = try buildLocalConversationResponse(a, eventFor(.user_transcript, "what are your hours?"), "We're open 9-5.");
+    defer plain.deinit(a);
+    try testing.expectEqualStrings("We're open 9-5.", plain.text);
+    try testing.expect(plain.escalation == null);
+
+    var with_memory = eventFor(.user_transcript, "what are your hours?");
+    with_memory.memory = .{ .recall_summary = "previously asked about returns" };
+    var with_memory_response = try buildLocalConversationResponse(a, with_memory, "We're open 9-5.");
+    defer with_memory_response.deinit(a);
+    try testing.expect(std.mem.indexOf(u8, with_memory_response.text, "We're open 9-5.") != null);
+    try testing.expect(std.mem.indexOf(u8, with_memory_response.text, "previously asked about returns") != null);
+}
+
+test "buildLocalConversationResponse: escalating user_transcript attaches an escalation payload" {
+    const a = testing.allocator;
+
+    var response = try buildLocalConversationResponse(a, eventFor(.user_transcript, "let me talk to a human"), "unused");
+    defer response.deinit(a);
+
+    try testing.expect(std.mem.indexOf(u8, response.text, "support specialist") != null);
+    const payload = response.escalation.?;
+    try testing.expectEqualStrings("human_requested", payload.reason_code);
+    try testing.expectEqualStrings("conv-1", payload.conversation_id);
+    try testing.expectEqualStrings("cust-1", payload.customer_id);
+    try testing.expect(std.mem.indexOf(u8, payload.routing_hints, "priority=normal") != null);
+}
+
+test "buildEscalationPayload: sensitive_topic and intelligence_signal get high routing priority, others normal" {
+    const a = testing.allocator;
+
+    var sensitive = try buildEscalationPayload(a, eventFor(.user_transcript, "my ssn is 123"), .sensitive_topic);
+    defer sensitive.deinit(a);
+    try testing.expect(std.mem.indexOf(u8, sensitive.routing_hints, "priority=high") != null);
+
+    var human = try buildEscalationPayload(a, eventFor(.user_transcript, "get me a human"), .human_requested);
+    defer human.deinit(a);
+    try testing.expect(std.mem.indexOf(u8, human.routing_hints, "priority=normal") != null);
+
+    var empty = try buildEscalationPayload(a, eventFor(.user_transcript, ""), .empty_transcript);
+    defer empty.deinit(a);
+    try testing.expect(std.mem.indexOf(u8, empty.summary, "no usable transcript captured") != null);
+}
+
+test "parseConversationRelayEvent: recognizes all event kind aliases" {
+    const a = testing.allocator;
+
+    const cases = .{
+        .{ "{\"type\":\"setup\"}", ConversationRelayEventKind.setup },
+        .{ "{\"type\":\"user_transcript\"}", ConversationRelayEventKind.user_transcript },
+        .{ "{\"type\":\"transcript\"}", ConversationRelayEventKind.user_transcript },
+        .{ "{\"event\":\"prompt\"}", ConversationRelayEventKind.user_transcript },
+        .{ "{\"type\":\"DTMF\"}", ConversationRelayEventKind.dtmf },
+        .{ "{\"type\":\"interrupt\"}", ConversationRelayEventKind.interrupt },
+        .{ "{\"type\":\"disconnect\"}", ConversationRelayEventKind.disconnect },
+    };
+    inline for (cases) |case| {
+        var event = try parseConversationRelayEvent(a, case[0]);
+        defer event.deinit(a);
+        try testing.expectEqual(case[1], event.kind);
+    }
+}
+
+test "parseConversationRelayEvent: unknown event type is InvalidResponse" {
+    const a = testing.allocator;
+    try testing.expectError(ConnectorError.InvalidResponse, parseConversationRelayEvent(a, "{\"type\":\"bogus\"}"));
+    try testing.expectError(ConnectorError.InvalidResponse, parseConversationRelayEvent(a, "not json"));
+    try testing.expectError(ConnectorError.InvalidResponse, parseConversationRelayEvent(a, "[1,2,3]"));
+}
+
+test "parseConversationRelayEvent: applies field aliases and defaults for missing ids" {
+    const a = testing.allocator;
+    var event = try parseConversationRelayEvent(a, "{\"type\":\"user_transcript\",\"callSid\":\"CA123\",\"from\":\"+15551234567\",\"text\":\"hello\"}");
+    defer event.deinit(a);
+    try testing.expectEqualStrings("CA123", event.conversation_id);
+    try testing.expectEqualStrings("+15551234567", event.customer_id);
+    try testing.expectEqualStrings("hello", event.transcript);
+
+    var defaults = try parseConversationRelayEvent(a, "{\"type\":\"setup\"}");
+    defer defaults.deinit(a);
+    try testing.expectEqualStrings("local-conversation", defaults.conversation_id);
+    try testing.expectEqualStrings("anonymous", defaults.customer_id);
+}
+
+test "parseConversationRelayEvent: parses nested memory and intelligence objects" {
+    const a = testing.allocator;
+    var event = try parseConversationRelayEvent(a,
+        \\{"type":"user_transcript","transcript":"hi","memory":{"profile_id":"p1","recall_summary":"likes tea"},"intelligence":{"sentiment":"positive","escalation_recommended":true}}
+    );
+    defer event.deinit(a);
+
+    try testing.expect(event.memory != null);
+    try testing.expectEqualStrings("p1", event.memory.?.profile_id);
+    try testing.expectEqualStrings("likes tea", event.memory.?.recall_summary);
+
+    try testing.expect(event.intelligence != null);
+    try testing.expectEqualStrings("positive", event.intelligence.?.sentiment);
+    try testing.expect(event.intelligence.?.escalation_recommended);
+}
+
+test "parseConversationRelayEvent: non-object memory/intelligence values are InvalidResponse" {
+    const a = testing.allocator;
+    try testing.expectError(ConnectorError.InvalidResponse, parseConversationRelayEvent(a, "{\"type\":\"setup\",\"memory\":\"nope\"}"));
+    try testing.expectError(ConnectorError.InvalidResponse, parseConversationRelayEvent(a, "{\"type\":\"setup\",\"intelligence\":42}"));
+}
+
+test "buildConversationRelayJson: round-trips text with and without an escalation payload" {
+    const a = testing.allocator;
+
+    var no_escalation_response = ConversationRelayResponse{ .text = try a.dupe(u8, "hello \"world\"") };
+    defer no_escalation_response.deinit(a);
+    const no_escalation = try buildConversationRelayJson(a, no_escalation_response);
+    defer a.free(no_escalation);
+    try json_lib.validateJsonValue(a, no_escalation, .object);
+    try testing.expect(std.mem.indexOf(u8, no_escalation, "\"escalation\":null") != null);
+
+    const payload = try buildEscalationPayload(a, eventFor(.user_transcript, "get me a human"), .human_requested);
+    var with_escalation_response = ConversationRelayResponse{ .text = try a.dupe(u8, "please hold"), .escalation = payload };
+    defer with_escalation_response.deinit(a);
+    const with_escalation = try buildConversationRelayJson(a, with_escalation_response);
+    defer a.free(with_escalation);
+    try json_lib.validateJsonValue(a, with_escalation, .object);
+    try testing.expect(std.mem.indexOf(u8, with_escalation, "\"reason_code\":\"human_requested\"") != null);
+}
+
 test {
     std.testing.refAllDecls(@This());
 }

--- a/src/features/os_control/policy.zig
+++ b/src/features/os_control/policy.zig
@@ -179,3 +179,34 @@ fn isAllowedLsOption(arg: []const u8) bool {
     }
     return true;
 }
+
+test "pathContained: exact workspace root path is contained" {
+    try std.testing.expect(pathContained("/home/user/abi", "/home/user/abi"));
+}
+
+test "pathContained: a proper subdirectory or file is contained" {
+    try std.testing.expect(pathContained("/home/user/abi/src/main.zig", "/home/user/abi"));
+    try std.testing.expect(pathContained("/home/user/abi/", "/home/user/abi"));
+}
+
+test "pathContained: a sibling directory sharing the workspace root as a string prefix is NOT contained" {
+    // "/home/user/abi-other" starts with the literal bytes "/home/user/abi" but
+    // is a sibling directory, not a subpath — the separator check must catch this.
+    try std.testing.expect(!pathContained("/home/user/abi-other", "/home/user/abi"));
+    try std.testing.expect(!pathContained("/home/user/abisecret/file", "/home/user/abi"));
+}
+
+test "pathContained: a parent or unrelated directory is NOT contained" {
+    try std.testing.expect(!pathContained("/home/user", "/home/user/abi"));
+    try std.testing.expect(!pathContained("/etc/passwd", "/home/user/abi"));
+    try std.testing.expect(!pathContained("/", "/home/user/abi"));
+}
+
+test "pathContained: relative paths are never contained regardless of textual overlap" {
+    try std.testing.expect(!pathContained("home/user/abi/file", "/home/user/abi"));
+    try std.testing.expect(!pathContained("../abi/file", "/home/user/abi"));
+}
+
+test "pathContained: empty path is never contained in a non-empty workspace root" {
+    try std.testing.expect(!pathContained("", "/home/user/abi"));
+}

--- a/src/tests/e2e_database_test.zig
+++ b/src/tests/e2e_database_test.zig
@@ -1,5 +1,114 @@
-test "e2e: vector DB insert -> search -> update -> delete (skeleton)" {
-    // TODO: Use in-memory test helpers if available.
-    // This test is intentionally a compile-time skeleton to be fleshed out by maintainers.
-    _ = 0;
+//! End-to-end WDBX database journey: insert vectors + key/value entries through
+//! a durable `Session` (the same path the CLI and MCP server use), search,
+//! checkpoint, close, and reopen through crash recovery to verify the whole
+//! chain — not just an individual module — round-trips correctly.
+//!
+//! Note: the `Store` vector index has no delete/update-in-place API (only
+//! `putVector`/`search`/`getVector`); the generic key/value side supports
+//! upsert via `store()`. This test exercises what the store actually
+//! supports rather than asserting a vector-delete path that does not exist.
+
+const std = @import("std");
+const durable_store = @import("../features/wdbx/durable_store.zig");
+
+const testing = std.testing;
+
+fn deleteIfExists(path: []const u8) void {
+    std.Io.Dir.cwd().deleteFile(testing.io, path) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => std.debug.print("e2e db cleanup: failed to delete '{s}': {s}\n", .{ path, @errorName(err) }),
+    };
+}
+
+/// `zig-out` only exists after an install step has run, so a bare
+/// `zig build test-integration` on a clean tree would otherwise fail with
+/// FileNotFound before reaching a single assertion.
+fn ensureOutDir() !void {
+    std.Io.Dir.createDirPath(.cwd(), testing.io, "zig-out") catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => return err,
+    };
+}
+
+test "e2e: vector DB insert -> search -> update -> recover across a restart" {
+    try ensureOutDir();
+    const base = "zig-out/e2e-database.jsonl";
+    const wp = "zig-out/e2e-database.jsonl.wal";
+    const manifest = "zig-out/e2e-database.jsonl.manifest";
+    const seg0 = "zig-out/e2e-database.jsonl.seg.0.jsonl";
+    defer {
+        deleteIfExists(base);
+        deleteIfExists(wp);
+        deleteIfExists(manifest);
+        deleteIfExists(seg0);
+    }
+    deleteIfExists(base);
+    deleteIfExists(wp);
+    deleteIfExists(manifest);
+    deleteIfExists(seg0);
+
+    var v1: u32 = undefined;
+    var v2: u32 = undefined;
+
+    // --- Phase 1: insert vectors + kv, search, checkpoint on close. ---
+    {
+        var session = try durable_store.Session.openAt(testing.io, testing.allocator, base);
+        defer session.deinit(); // folds the WAL into a checkpoint on close
+
+        const store = session.storePtr();
+        v1 = try store.putVector(&.{ 1.0, 0.0, 0.0, 0.0 });
+        v2 = try store.putVector(&.{ 0.0, 1.0, 0.0, 0.0 });
+        _ = try store.putVector(&.{ 0.9, 0.1, 0.0, 0.0 });
+        try testing.expectEqual(@as(usize, 3), store.vectorCount());
+
+        try store.store("session:profile", "abbey");
+
+        const results = try store.search(&.{ 1.0, 0.0, 0.0, 0.0 }, 2);
+        defer testing.allocator.free(results);
+        try testing.expect(results.len == 2);
+        try testing.expect(results[0].score >= results[1].score);
+        try testing.expectEqual(v1, results[0].id);
+    }
+
+    // --- Phase 2: reopen through recovery, verify persisted state, "update" ---
+    // the kv entry (upsert, since vectors have no update-in-place API).
+    {
+        var reopened = try durable_store.Session.openAt(testing.io, testing.allocator, base);
+        defer reopened.deinit();
+
+        const store = reopened.storePtr();
+        try testing.expectEqual(@as(usize, 3), store.vectorCount());
+        try testing.expectEqualStrings("abbey", store.get("session:profile").?);
+
+        // getVector confirms the recovered vector index still answers by id,
+        // not just by count.
+        const recovered_v1 = store.getVector(v1).?;
+        try testing.expectEqualSlices(f32, &.{ 1.0, 0.0, 0.0, 0.0 }, recovered_v1);
+
+        const recovered_v2 = store.getVector(v2).?;
+        try testing.expectEqualSlices(f32, &.{ 0.0, 1.0, 0.0, 0.0 }, recovered_v2);
+
+        // "update" == upsert on the same key.
+        try store.store("session:profile", "aviva");
+        try testing.expectEqualStrings("aviva", store.get("session:profile").?);
+
+        // Search still works post-recovery against the recovered index.
+        const results = try store.search(&.{ 0.0, 1.0, 0.0, 0.0 }, 1);
+        defer testing.allocator.free(results);
+        try testing.expectEqual(@as(usize, 1), results.len);
+        try testing.expectEqual(v2, results[0].id);
+    }
+
+    // --- Phase 3: reopen once more, confirm the update from phase 2 survived
+    // its own checkpoint. ---
+    {
+        var final = try durable_store.Session.openAt(testing.io, testing.allocator, base);
+        defer final.deinit();
+        try testing.expectEqualStrings("aviva", final.storePtr().get("session:profile").?);
+        try testing.expectEqual(@as(usize, 3), final.storePtr().vectorCount());
+    }
+}
+
+test {
+    std.testing.refAllDecls(@This());
 }

--- a/src/tests/e2e_llm_test.zig
+++ b/src/tests/e2e_llm_test.zig
@@ -1,5 +1,114 @@
-test "e2e: llm pipeline (skeleton)" {
-    // TODO: implement full LLM pipeline test (load -> tokenize -> generate -> decode)
-    // This skeleton ensures the test file compiles in CI.
-    _ = 0;
+//! End-to-end pipeline for the `nn` character-level trainer: write a JSONL
+//! corpus to disk, load + extract + train from it (`trainOnJsonl`), separately
+//! train a `Model`, persist it to a checkpoint *file* (`saveModelPath`, not
+//! just in-memory bytes), reload it (`loadModelPath`), and greedily generate
+//! (sample/decode) from both the original and reloaded model to confirm the
+//! whole file-backed chain is deterministic end to end.
+//!
+//! This is a small, from-scratch, pure-Zig demo trainer (see
+//! `src/features/nn/types.zig`) — not a production or distributed LLM.
+
+const std = @import("std");
+const nn = @import("../features/nn/mod.zig");
+const train_mod = @import("../features/nn/train.zig");
+const persist = @import("../features/nn/persist.zig");
+
+const testing = std.testing;
+
+fn deleteIfExists(path: []const u8) void {
+    std.Io.Dir.cwd().deleteFile(testing.io, path) catch |err| switch (err) {
+        error.FileNotFound => {},
+        else => std.debug.print("e2e llm cleanup: failed to delete '{s}': {s}\n", .{ path, @errorName(err) }),
+    };
+}
+
+/// `zig-out` only exists after an install step has run, so a bare
+/// `zig build test-integration` on a clean tree would otherwise fail with
+/// FileNotFound before reaching a single assertion.
+fn ensureOutDir() !void {
+    std.Io.Dir.createDirPath(.cwd(), testing.io, "zig-out") catch |err| switch (err) {
+        error.PathAlreadyExists => {},
+        else => return err,
+    };
+}
+
+test "e2e: llm pipeline (jsonl load -> train -> save -> load -> generate -> decode)" {
+    const a = testing.allocator;
+    try ensureOutDir();
+
+    const corpus_path = "zig-out/e2e-llm-corpus.jsonl";
+    const checkpoint_path = "zig-out/e2e-llm-checkpoint.bin";
+    defer {
+        deleteIfExists(corpus_path);
+        deleteIfExists(checkpoint_path);
+    }
+    deleteIfExists(corpus_path);
+    deleteIfExists(checkpoint_path);
+
+    // --- Phase 1: "load" — write a JSONL corpus to disk and extract+train
+    // from the file, the same shape as `abi nn train --jsonl`. ---
+    const jsonl =
+        \\{"text": "hello world hello world "}
+        \\{"text": ""}
+        \\{"other": "ignored"}
+        \\{"text": "hello world hello world "}
+        \\
+    ;
+    {
+        var dir = std.Io.Dir.cwd();
+        try dir.writeFile(testing.io, .{ .sub_path = corpus_path, .data = jsonl });
+    }
+
+    const config = nn.TrainConfig{
+        .seq_len = 2,
+        .hidden = 8,
+        .embed_dim = 4,
+        .epochs = 60,
+        .lr = 0.5,
+        .seed = 7,
+    };
+
+    const report = try train_mod.trainOnJsonl(a, corpus_path, "text", config);
+    try testing.expect(report.improved);
+    try testing.expect(report.final_loss < report.initial_loss);
+
+    // --- Phase 2: train a model directly (same corpus content) so we hold
+    // the live `Model` needed to save/sample. ---
+    const corpus_bytes =
+        \\hello world hello world
+        \\hello world hello world
+    ;
+    var model = try train_mod.trainModel(a, corpus_bytes, config);
+    defer model.deinit();
+    try testing.expect(model.report.improved);
+
+    // --- Phase 3: "save" the trained model to a checkpoint *file*. ---
+    try persist.saveModelPath(testing.io, a, &model, checkpoint_path);
+
+    // --- Phase 4: "load" the checkpoint back from disk into a fresh Model. ---
+    var loaded = try persist.loadModelPath(testing.io, a, checkpoint_path);
+    defer loaded.deinit();
+
+    try testing.expectEqual(model.vocab_size, loaded.vocab_size);
+    try testing.expectEqual(model.seq_len, loaded.seq_len);
+    try testing.expectEqualSlices(f32, model.w1.data, loaded.w1.data);
+
+    // --- Phase 5: "generate -> decode" — greedy-sample bytes from both the
+    // original and the reloaded model; the checkpoint round trip must not
+    // change generation output. ---
+    const original_output = try nn.sample(a, &model, 'h', 24);
+    defer a.free(original_output);
+    const reloaded_output = try nn.sample(a, &loaded, 'h', 24);
+    defer a.free(reloaded_output);
+
+    try testing.expectEqualStrings(original_output, reloaded_output);
+    // Decoded bytes must be printable corpus characters, not garbage — the
+    // "decode" step of the pipeline.
+    for (original_output) |byte| {
+        try testing.expect(std.ascii.isPrint(byte));
+    }
+}
+
+test {
+    std.testing.refAllDecls(@This());
 }

--- a/src/tests/stress_test.zig
+++ b/src/tests/stress_test.zig
@@ -1,4 +1,95 @@
-test "stress: placeholder (ignore by default)" {
-    // Long-running stress test placeholder. Mark as ignored by default in CI.
-    _ = 0;
+//! Bounded correctness-under-load checks. These insert enough records to
+//! exercise growth/rehashing paths that small unit tests never touch, but
+//! stay small enough (low thousands of ops, sub-second) to run alongside the
+//! rest of the integration suite rather than needing a separate opt-in gate.
+//!
+//! These assert correctness only, never wall-clock timing — a latency
+//! threshold would be flaky across CI hardware. (`test_helpers.bench` is
+//! deliberately not used: it is currently uncompilable dead code, since
+//! `std.time.Instant` no longer exists on the pinned toolchain.)
+
+const std = @import("std");
+const wdbx = @import("../features/wdbx/mod.zig");
+
+const testing = std.testing;
+
+const VECTOR_STRESS_COUNT: u32 = 2000;
+const KV_STRESS_COUNT: usize = 2000;
+
+test "stress: many vector inserts and searches stay correct under load" {
+    const a = testing.allocator;
+    var store = wdbx.Store.init(a);
+    defer store.deinit();
+
+    var prng = std.Random.DefaultPrng.init(0xC0FFEE);
+    const rand = prng.random();
+
+    var ids: [VECTOR_STRESS_COUNT]u32 = undefined;
+
+    var inserted: u32 = 0;
+    while (inserted < VECTOR_STRESS_COUNT) : (inserted += 1) {
+        var vec: [8]f32 = undefined;
+        for (&vec) |*component| component.* = rand.float(f32);
+        ids[inserted] = try store.putVector(&vec);
+    }
+
+    try testing.expectEqual(@as(usize, VECTOR_STRESS_COUNT), store.vectorCount());
+
+    // Every inserted id must resolve back to a vector (no silent drops from
+    // whatever growth/rehash strategy the index uses internally).
+    for (ids) |id| {
+        try testing.expect(store.getVector(id) != null);
+    }
+
+    // Repeated searches against a large index must stay well-formed: correct
+    // result count, and scores in non-increasing order.
+    const query = [_]f32{ 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5 };
+    var search_round: usize = 0;
+    while (search_round < 50) : (search_round += 1) {
+        const results = try store.search(&query, 10);
+        defer a.free(results);
+        try testing.expectEqual(@as(usize, 10), results.len);
+        var i: usize = 1;
+        while (i < results.len) : (i += 1) {
+            try testing.expect(results[i - 1].score >= results[i].score);
+        }
+    }
+}
+
+test "stress: many key/value upserts stay consistent under load" {
+    const a = testing.allocator;
+    var store = wdbx.Store.init(a);
+    defer store.deinit();
+
+    var buf: [32]u8 = undefined;
+
+    var inserted: usize = 0;
+    while (inserted < KV_STRESS_COUNT) : (inserted += 1) {
+        const key = try std.fmt.bufPrint(&buf, "stress:key:{d}", .{inserted});
+        try store.store(key, "v1");
+    }
+
+    try testing.expectEqual(@as(usize, KV_STRESS_COUNT), store.count());
+
+    // Re-upsert every other key with a new value; verify both the updated
+    // and untouched keys read back correctly (no cross-contamination).
+    var i: usize = 0;
+    while (i < KV_STRESS_COUNT) : (i += 2) {
+        const key = try std.fmt.allocPrint(a, "stress:key:{d}", .{i});
+        defer a.free(key);
+        try store.store(key, "v2");
+    }
+    try testing.expectEqual(@as(usize, KV_STRESS_COUNT), store.count());
+
+    i = 0;
+    while (i < KV_STRESS_COUNT) : (i += 1) {
+        const key = try std.fmt.allocPrint(a, "stress:key:{d}", .{i});
+        defer a.free(key);
+        const expected = if (i % 2 == 0) "v2" else "v1";
+        try testing.expectEqualStrings(expected, store.get(key).?);
+    }
+}
+
+test {
+    std.testing.refAllDecls(@This());
 }


### PR DESCRIPTION
## Context

Started as a test-coverage analysis. The codebase has broad coverage (~1282 inline `test {}` blocks across 288 of 293 `src/**.zig` files), but it's uneven — a few high-value surfaces were effectively unverified, and three "tests" asserted nothing at all.

## The headline problem: green tests that tested nothing

`src/tests/{e2e_database_test,e2e_llm_test,stress_test}.zig` were each a single `_ = 0;` with a TODO. They're wired into `integration_tests.zig` via `refAllDecls`, so they compiled and counted as passing. The documented end-to-end paths had **zero** real verification.

Replaced with real tests:

| File | What it now does |
|---|---|
| `e2e_database_test.zig` | 3-phase durable `Session` journey: insert vectors + kv → search → checkpoint on close → reopen through recovery → verify by id (not just count) → upsert → reopen again |
| `e2e_llm_test.zig` | File-backed `nn` pipeline: write JSONL → `trainOnJsonl` → `trainModel` → `saveModelPath` → `loadModelPath` → `sample`, asserting the checkpoint round trip doesn't change generated output |
| `stress_test.zig` | 2000 vector inserts (every id resolvable, scores non-increasing) and 2000 kv upserts (no cross-contamination). Correctness only — no wall-clock assertions, which would be flaky across CI hardware |

## New coverage for untested logic

- **`cli/handlers/complete_handlers.zig`** — had **0 tests** despite rendering all `abi complete` output. Split the metadata renderer into an injectable-writer variant (mirroring the existing `dashboard.zig` `TestWriter` pattern) so exact output is assertable without capturing stderr. Covers learn/non-learn, persisted/unpersisted, and `skip_output` branches, plus two early-return guards.
- **`connectors/json.zig`** — escaping (quotes, backslashes, control bytes, `\u` escapes), top-level kind validation, and every request/response builder.
- **`connectors/{anthropic,openai}.zig`** — local-transport synthesis, malformed input rejection, and the `.live` transport refusal boundary. No network involved.
- **`connectors/twilio_relay.zig`** — all five `EscalationReason` paths, intelligence-signal override precedence, event-kind aliases, field aliases/defaults, nested memory/intelligence parsing.
- **`os_control/policy.zig`** — `pathContained` was only reachable indirectly through `validateCommand`. Now covered directly, including the sibling-directory case (`/home/user/abi-other` vs `/home/user/abi`) that a naive `startsWith` would wrongly accept — a sandbox-escape-shaped failure.

## Drive-by fixes — `main` currently does not compile

Both pre-existing, both introduced by 60af410 (current `main` HEAD), and neither related to my test work — but they blocked all verification, so they're fixed here:

1. `local_bridge.completeLive` declared `endpoint_override: ?[]const u8 = null` — a **default parameter value**, which Zig has never supported. The module failed to *parse*, taking 6 build targets down with it. Made the parameter explicit; updated the one caller to pass `null`.
2. With that fixed, its own test then failed to compile: `deinit` takes `*Response` but an `if`-payload capture is const. Rebound before freeing.

Worth flagging: **that commit's `local_bridge` changes were evidently never compiled.** Unblocking this took the main suite from 133 to 1376 collected tests.

## Docs

Added a "Test topology" section to `AGENTS.md` (the canonical instruction file — `CLAUDE.md`/`GEMINI.md` are intentionally thin redirects, so I did not duplicate content into them). It records the non-obvious bit that explains how the skeletons survived: **`check` runs `test` but not `test-integration`** — only `full-check` runs integration. It also documents why the `cli_test.zig`/`plugins_test.zig` aggregators exist.

## Verification

Ran on Linux x86_64 with Zig `0.17.0-dev.1454+5faa79730`. **Note: this is 12 commits newer than the pinned `0.17.0-dev.1442+972627084`**, which is no longer downloadable from ziglang.org — so results carry that caveat.

- `zig fmt --check` clean on all changed files
- **0 compile errors** (was 2, blocking 6 targets)
- `zig build test`: 1135/1161 pass
- Targeted filter runs for `pathContained`, `classifyEscalation`, `printCompletionMetadataWriter`, `appendJsonString`, `buildAnthropicBody` — all pass, no failures
- `e2e_llm_test` and both `stress_test` tests pass

**Not passing on this host**, and I want to be explicit rather than bury it:

- **23 crashes + `e2e_database_test`** — all `panic: programmer bug caused syscall error: BADF`, originating in std's `Io/Threaded.zig` `errnoBug` via `wal.zig`'s `syncParentDirBestEffort`. Newer std panics on `BADF` instead of returning an error, defeating the "best effort" `catch`. This hits **18 pre-existing WAL/recovery/durable_store tests** in files I never touched — including `durable_store: persistent round-trip`, which exercises the same path my e2e database test does. I read this as toolchain drift (and possibly this container's filesystem), not a regression from this PR, but **`e2e_database_test` is consequently unverified here** and should be confirmed on the pinned toolchain.
- **1 failure** in `features/accelerator/mod.zig` (`shader ... "not linked"`) — environment/GPU-dependent, untouched by this PR.

`./build.sh check` was not run: it's the macOS Metal-linking entrypoint and this is a Linux container without the pinned toolchain.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdkLxvHpPRLQDNeHnUjx2D)_