### PR TITLE
chore: Compound Engineering local config scaffold

### DIFF
--- a/.compound-engineering/config.local.example.yaml
+++ b/.compound-engineering/config.local.example.yaml
@@ -1,0 +1,127 @@
+# Compound Engineering -- local config
+# Copy to .compound-engineering/config.local.yaml in your project root.
+# All settings are optional. Invalid values fall through to defaults.
+
+# --- Product pulse ---
+# Settings written by /ce-product-pulse first-run interview. Re-run the skill with
+# argument `setup` or `reconfigure` to edit interactively.
+
+# pulse_product_name: "Spiral"                          # used in report titles (no default)
+# pulse_lookback_default: 24h                           # 1h | 24h | 7d | 30d (default: 24h)
+# pulse_primary_event: "session_started"                # the event that means "user showed up"
+# pulse_value_event: "task_completed"                   # the event that means "user got value"
+# pulse_completion_events: "onboarded,first_purchase"   # comma-separated, 0-3 events
+# pulse_quality_scoring: false                          # true | false (default: false; AI products only)
+# pulse_quality_dimension: "answer accuracy"            # dimension scored 1-5 when pulse_quality_scoring is true
+# pulse_analytics_source: posthog                       # posthog | mixpanel | custom (no default)
+# pulse_tracing_source: sentry                          # sentry | datadog | custom (no default)
+# pulse_payments_source: stripe                         # stripe | custom (no default)
+# pulse_db_enabled: false                               # true | false (default: false; read-only DB if true)
+# pulse_metric_sources: "retention_d7=posthog,nps=delighted"  # strategy-metric -> source overrides; comma-separated 'metric=source' pairs; unlisted metrics fall back to pulse_analytics_source
+# pulse_pending_metrics: "retention_d7,nps"             # comma-separated strategy metrics awaiting instrumentation; render as 'no data'
+# pulse_excluded_metrics: "north_star"                  # comma-separated strategy metrics intentionally not in pulse
+
+# --- Output format ---
+# Per-skill output format default. Selects the exclusive format the artifact
+# is written in: `md` produces a markdown file, `html` produces a single
+# self-contained HTML file. The two are mutually exclusive -- there is no
+# sibling artifact. See DESIGN.md or your agent instructions to influence
+# HTML styling. Precedence: a format request in your prompt for that run wins
+# (e.g. "output:html" or "make it HTML"); a preference you established earlier
+# (in-session, saved to memory, or in your agent instructions) overrides these
+# keys (this config is the persisted fallback); pipeline contexts (e.g., LFG,
+# disable-model-invocation) always force `md`.
+
+# plan_output: html              # md | html (default: md)
+# brainstorm_output: html        # md | html (default: md)
+# ideate_output: md              # md | html (default: html -- ideation docs are human-facing, so HTML is the default; set md to opt out)
+
+# --- Fable elevation (Claude Code only) ---
+# Claude Code ONLY; silently ignored on every other harness (Codex, Cursor, ...).
+# When on, /ce-plan and /ce-brainstorm dispatch their reasoning-heavy step (plan
+# authoring; approach generation) to the Fable model via a subagent, so you get
+# higher-reasoning output even when your session model is cheaper -- no session
+# switch. Per-skill so you can enable one without the other. You can also just
+# say "use fable" in a prompt for a one-off. Invalid/commented/missing -> off.
+
+# plan_use_fable: true           # true | false (default: false)
+# brainstorm_use_fable: true     # true | false (default: false)
+# fable_nudge: false             # true | false (default: true -- one-time tip when elevation is available but off)
+
+# --- PR concept teaching (ce-commit-push-pr) ---
+# When a PR introduces a concept new to the codebase, the generated PR
+# description gains a "New concepts" section teaching it. The section toggle is
+# the single gate: off disables judgment, the section, the /ce-explain offer,
+# and archival. Archival additionally writes the explainer to docs/explainers/
+# and links it from the PR (full-workflow runs only; override per run with
+# archive:on|off). Note: this file is gitignored and per-checkout -- fresh
+# worktrees don't inherit it.
+
+# pr_teaching_section: false     # true | false (default: true)
+# pr_teaching_archive: true      # true | false (default: false; full-workflow runs only)
+
+# --- ce-commit-push-pr babysit handoff ---
+# After a full-workflow PR is opened, ce-commit-push-pr auto-invokes ce-babysit-pr
+# to watch CI + incoming review and drive the PR toward merge-ready. Set false to
+# opt out standing (per-run override: the babysit:off token).
+# auto_babysit: false            # true | false (default: true)
+
+# --- ce-plan scoping confirmation ---
+# By default /ce-plan pauses before research/plan-write to show a scoping
+# summary and wait for you to confirm scope. Set this to skip that wait: ce-plan
+# composes the summary for itself, records any inferred scope under an
+# Assumptions section, announces that it's proceeding, and keeps going. It skips
+# only that confirmation -- genuine blocking questions and the post-plan menu
+# still appear. Override per run with `confirm:auto` (skip) or `confirm:ask`
+# (force the gate on for one run).
+
+# plan_skip_scoping_confirm: true   # true | false (default: false)
+
+# --- Cross-model review preference ---
+# Preferred peer for ce-doc-review and ce-code-review when their conditional
+# cross-model pass activates. Conversation instructions still win, and the
+# skills skip routes that cannot establish the required host/peer distinction.
+
+# cross_model_peer: codex          # codex | claude | grok | cursor | composer
+
+# --- ce-work implementation engine ---
+# Standing, per-checkout preferences for who authors implementation units. Live
+# task/session/project instructions and LFG's provenance-bearing binding may
+# override or narrow these defaults. `off` disables only this standing preference.
+# `prefer` tries candidates in order, then falls back natively with disclosure.
+# `require` asks before native fallback in an interactive ce-work run and blocks
+# without prompting under LFG/headless execution. Harnesses: codex | claude | grok
+# | cursor. Omit model to use that harness's configured default. Composer is a model
+# family through Cursor: { harness: cursor, model: composer }. Do not put CLI flags
+# or commands here. A candidate equivalent to the current host/default is skipped;
+# a different explicit model in the same harness remains eligible.
+
+# work_engine_mode: prefer        # off | prefer | require (default: off)
+# work_engine_preferences:
+#   - harness: cursor
+#     model: composer
+#   - harness: codex
+#     model: "gpt-5.6"
+#   - harness: claude             # configured default model
+
+# --- ce-promote ---
+# Written automatically when you decline the Spiral setup offer in /ce-promote.
+# Suppresses that one-time setup nudge in this project. Remove the key to re-enable.
+
+# ce_promote_spiral_optout: true   # true | (absent) (default: absent -- offer once)
+
+# --- Sweep (ce-sweep) ---
+
+# Feedback sources swept by /ce-sweep. Generic key: other skills may read this list.
+# Each entry: type (slack | github-issues | email), id (short name), target (channel ID /
+# owner/repo / mailbox), ack_action, closeout_action, sensitive (true withholds content
+# from committed state/plan text), approved (standing approval for source-side writes).
+# feedback_sources:
+#   - { type: slack, id: slack-alpha, target: C0XXXXXXX, ack_action: eyes, closeout_action: white_check_mark, sensitive: false, approved: true }
+#   - { type: github-issues, id: gh-issues, target: owner/repo, ack_action: "feedback:ack", closeout_action: "feedback:resolved", sensitive: false, approved: true }
+
+# Sweep-owned settings.
+# sweep_state_path: docs/feedback-sweep/state.yml   # committed (multi-agent) or /tmp path (solo)
+# sweep_ack_cap: 25                                 # max acks per source per run before the circuit breaker
+# sweep_lease_ttl_minutes: 60                       # single-writer lease staleness threshold
+# sweep_shared_branch: false                        # true: push-gated lease for shared-docs-branch topology

--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ legacy/
 
 # ── Unrelated local projects ───────────────────────────────
 /alien-invasion/
+
+# ── Compound Engineering (machine-local) ────────────────
+.compound-engineering/*.local.yaml


### PR DESCRIPTION
## Summary
- Add `.compound-engineering/config.local.example.yaml` from CE plugin template (commented defaults).
- Gitignore `.compound-engineering/*.local.yaml` so machine-local preferences stay untracked.

## Test plan
- [x] `git check-ignore` confirms `config.local.yaml` ignored and example trackable
- [x] CE health check reported project config healthy / optional tools 5/5 locally
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)