### PR TITLE
chore(skills): port remaining agent smokes to Rust nightly

### DIFF
--- a/.agents/skills/abi-superpower-tui/SKILL.md
+++ b/.agents/skills/abi-superpower-tui/SKILL.md
@@ -27,15 +27,15 @@ paths below (or the `run-tui` / `dashboard-smoke` drivers).
 ### repl
 Launch the agent REPL (slash commands live here):
 ```bash
-./zig-out/bin/abi agent tui
+./target/debug/abi agent tui
 ```
 
 ### dashboard
 Show the diagnostics dashboard (`abi tui` is an alias of `abi dashboard`):
 ```bash
-./zig-out/bin/abi dashboard --pane system
-./zig-out/bin/abi dashboard --pane plugins --once --json
-./zig-out/bin/abi tui --compact --pane scheduler
+./target/debug/abi dashboard --pane system
+./target/debug/abi dashboard --pane plugins --once --json
+./target/debug/abi tui --compact --pane scheduler
 ```
 
 Interactive pty smoke (tmux driver):
@@ -55,8 +55,8 @@ scheduler, memory, or 1–5). In the interactive refresh loop, switch panes with
 hotkeys / Tab — there is no separate `pane --focus` CLI.
 
 ```bash
-./zig-out/bin/abi dashboard --list-panes
-./zig-out/bin/abi dashboard --pane memory
+./target/debug/abi dashboard --list-panes
+./target/debug/abi dashboard --pane memory
 ```
 
 ## Slash Commands (in `abi agent tui` REPL)

--- a/.agents/skills/agent-plan-train/SKILL.md
+++ b/.agents/skills/agent-plan-train/SKILL.md
@@ -21,7 +21,7 @@ description: Plan and execute ABI repo work from current TODOs, roadmap/spec doc
 - Treat `tasks/todo.md` as the active board and `docs/spec/wdbx-north-star.mdx` as the Current/Partial/Proposed map.
 - Do not convert disclosed stubs into fake completions. Native dispatch, production clustering, production FHE, and learned-compression claims need real source/tests.
 - Do not add legacy CLI names. Preserve the frozen top-level command set and the MCP 12-tool contract.
-- When changing public feature APIs, update both the real and stub modules and run `zig build check-parity`.
+- When changing public feature APIs, update both the real and stub modules and run `./tools/check.sh`.
 - When changing docs, run `.agents/skills/docs-validate/validate.sh` in addition to code gates.
 
 ## Useful Commands
@@ -30,8 +30,8 @@ description: Plan and execute ABI repo work from current TODOs, roadmap/spec doc
 # optional; codex abi-mega plugin only:
 #   abi_inventory --repo /Users/donaldfilimon/abi
 zig version
-zig build check-parity --summary all
-./build.sh check
+./tools/check.sh
+./tools/check.sh
 ```
 
 Use the optional sibling goals markdown named `current-goals` under this skill's `references/` dir (when present — see Workflow step 5) for the current source inventory and validation ladder.

--- a/.agents/skills/agent-plan-train/agent.sh
+++ b/.agents/skills/agent-plan-train/agent.sh
@@ -8,7 +8,7 @@ set -uo pipefail
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd -- "$SCRIPT_DIR/../../.." && pwd)
 cd "$REPO_ROOT"
-ABI="$REPO_ROOT/zig-out/bin/abi"
+ABI="$REPO_ROOT/target/debug/abi"
 PLAN="${1:-summarize the scheduler status}"
 PROFILE="${2:-abbey}"
 fail=0
@@ -18,7 +18,7 @@ markers() { local out="$1"; shift; for m in "$@"; do
         || { echo "[FAIL] missing marker: $m"; fail=$((fail+1)); }; done; }
 
 say "build cli"
-./build.sh cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
+./tools/cargo.sh build -p abi-cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
 [ -x "$ABI" ] || { echo "[FAIL] $ABI not produced"; exit 1; }
 
 say "abi agent plan (dry-run)"

--- a/.agents/skills/auth-localcheck/SKILL.md
+++ b/.agents/skills/auth-localcheck/SKILL.md
@@ -37,5 +37,5 @@ five providers as `not configured`; bare `signin` prints its usage banner.
 ## Troubleshooting
 | Symptom | Fix |
 |---|---|
-| `build` FAIL | Check `zig version` (see `/zig-pin`), then `./build.sh check`. |
+| `build` FAIL | Check `zig version` (see `/zig-pin`), then `./tools/check.sh`. |
 | `Authentication Status:` missing | Handler grammar drift — check the `auth` path in `src/cli/handlers/` and `src/foundation` credentials. |

--- a/.agents/skills/auth-localcheck/auth.sh
+++ b/.agents/skills/auth-localcheck/auth.sh
@@ -11,7 +11,7 @@ set -uo pipefail
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd -- "$SCRIPT_DIR/../../.." && pwd)
 cd "$REPO_ROOT"
-ABI="$REPO_ROOT/zig-out/bin/abi"
+ABI="$REPO_ROOT/target/debug/abi"
 fail=0
 say() { printf '\n=== %s ===\n' "$*"; }
 markers() { local out="$1"; shift; for m in "$@"; do
@@ -19,7 +19,7 @@ markers() { local out="$1"; shift; for m in "$@"; do
         || { echo "[FAIL] missing marker: $m"; fail=$((fail+1)); }; done; }
 
 say "build cli"
-./build.sh cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
+./tools/cargo.sh build -p abi-cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
 [ -x "$ABI" ] || { echo "[FAIL] $ABI not produced"; exit 1; }
 
 say "abi auth status"

--- a/.agents/skills/backend-diagnostics/SKILL.md
+++ b/.agents/skills/backend-diagnostics/SKILL.md
@@ -28,5 +28,5 @@ Historical verification: **PASS** on Zig master `0.17.0-dev.1099` — Metal link
 ## Troubleshooting
 | Symptom | Fix |
 |---|---|
-| `build` FAIL | `/zig-build-doctor` or `./build.sh check`. |
+| `build` FAIL | `./tools/check.sh`. |
 | missing `Compute Backends:` | CLI grammar drift — check `src/cli/handlers/backends.zig`. |

--- a/.agents/skills/backend-diagnostics/diag.sh
+++ b/.agents/skills/backend-diagnostics/diag.sh
@@ -8,7 +8,7 @@ set -uo pipefail
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd -- "$SCRIPT_DIR/../../.." && pwd)
 cd "$REPO_ROOT"
-ABI="$REPO_ROOT/zig-out/bin/abi"
+ABI="$REPO_ROOT/target/debug/abi"
 fail=0
 say() { printf '\n=== %s ===\n' "$*"; }
 check() { local label="$1" expect="$2"; shift 2; local out; out=$("$@" 2>&1)
@@ -16,12 +16,12 @@ check() { local label="$1" expect="$2"; shift 2; local out; out=$("$@" 2>&1)
     grep -qF -- "$expect" <<<"$out" && echo "[ok] $label" || { echo "[FAIL] $label (missing: $expect)"; fail=$((fail+1)); }; }
 
 say "build cli"
-./build.sh cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
+./tools/cargo.sh build -p abi-cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
 [ -x "$ABI" ] || { echo "[FAIL] no binary"; exit 1; }
 
 check "backends report"  "Compute Backends:"    "$ABI" backends
 check "compute matrix"   "compute backends"    "$ABI" wdbx compute info
-check "gpu info"         "GPU backend"          "$ABI" wdbx gpu info
+check "gpu info"         "gpu backend="         "$ABI" wdbx gpu info
 
 say "summary"; echo "failed: $fail"
 [ "$fail" -eq 0 ] && echo "RESULT: PASS — backend diagnostics captured." || echo "RESULT: FAIL — $fail check(s)."

--- a/.agents/skills/cluster-demo-guide/SKILL.md
+++ b/.agents/skills/cluster-demo-guide/SKILL.md
@@ -30,5 +30,5 @@ Historical verification: **PASS** on Zig master `0.17.0-dev.1099` — elect → 
 ## Troubleshooting
 | Symptom | Fix |
 |---|---|
-| `build` FAIL | `/zig-build-doctor` or `./build.sh check`. |
+| `build` FAIL | `./tools/check.sh`. |
 | missing `leader_elected=true` | check `src/features/wdbx/cluster.zig`; use the `wdbx-explorer` subagent. |

--- a/.agents/skills/cluster-demo-guide/cluster.sh
+++ b/.agents/skills/cluster-demo-guide/cluster.sh
@@ -8,7 +8,7 @@ set -uo pipefail
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd -- "$SCRIPT_DIR/../../.." && pwd)
 cd "$REPO_ROOT"
-ABI="$REPO_ROOT/zig-out/bin/abi"
+ABI="$REPO_ROOT/target/debug/abi"
 NODES="${1:-3}"
 case "$NODES" in ''|*[!0-9]*) echo "usage: cluster.sh [nodes]" >&2; exit 2;; esac
 fail=0
@@ -18,7 +18,7 @@ check() { local label="$1" expect="$2"; shift 2; local out; out=$("$@" 2>&1)
     grep -qF -- "$expect" <<<"$out" && echo "[ok] $label" || { echo "[FAIL] $label (missing: $expect)"; fail=$((fail+1)); }; }
 
 say "build cli"
-./build.sh cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
+./tools/cargo.sh build -p abi-cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
 [ -x "$ABI" ] || { echo "[FAIL] no binary"; exit 1; }
 
 check "cluster status"      "cluster: nodes="     "$ABI" wdbx cluster status

--- a/.agents/skills/complete-base/SKILL.md
+++ b/.agents/skills/complete-base/SKILL.md
@@ -15,15 +15,12 @@ Evidence is the `RESULT:` line. Fully local, no network.
 .agents/skills/complete-base/complete.sh "summarize backends" fable-5     # custom prompt + model alias
 ```
 - `complete "<prompt>"` (or `complete --model <id> "<prompt>"`) → asserts
-  `model=`, `audit_passed=true`, `persisted=true`, `wdbx kv_entries=`.
+  `model=`, `audit_passed=true`, `wdbx kv_entries=`, and a `persisted=` line
+  (`true` when a durable store path is available, else honest `false`).
 - Model aliases are canonicalized (`fable-5` → `claude-fable-5`); an unrecognized
   id passes through with a one-line stderr warning.
 
 Prints `RESULT: PASS` (exit 0) or a FAIL count.
-
-Historical verification: **PASS** on Zig master `0.17.0-dev.1099` — base completion
-routes to `model=claude-fable-5`, passes the constitution audit, and persists the
-completion (query/response vectors + block) to WDBX.
 
 ## Gotchas
 - ⚠️ **Base path is fully local.** No `--live` means no remote provider is
@@ -31,15 +28,14 @@ completion (query/response vectors + block) to WDBX.
   provider) and on-device `apple-fm` (requires `--confirm`) are out of scope here.
 - `--learn` routes through the SEA self-learning loop — that path is covered by
   the `sea-learn-loop` skill, not this one.
-- `complete` **appends to your default WDBX store** (a completion block + query/
-  response vectors), so `kv_entries`/`vectors`/`blocks` grow each run. This is the
-  designed behavior (same as `run-abi`'s completion step), not a leak.
-- For source-level reasoning about model routing + the catalog, read
-  `src/features/ai/models.zig`; for the SEA path use the `sea-evidence-analyst` subagent.
+- When a durable WDBX path is configured, `complete` may append to that store.
+  Without one, the CLI reports `persisted=false` and `wdbx_status=no persistent
+  WDBX path configured` — both are success cases for this smoke.
+- For routing/catalog source, see `crates/abi-ai`; SEA path is `sea-learn-loop`.
 
 ## Troubleshooting
 | Symptom | Fix |
 |---|---|
 | `build` FAIL | Use `./tools/cargo.sh build -p abi-cli`, then `./tools/check.sh`. |
-| `audit_passed=true` missing | Constitution/audit regression — check `src/features/ai/` (constitution + completion path). |
-| unexpected `model=` | Alias/catalog drift — check `src/features/ai/models.zig`. |
+| `audit_passed=true` missing | Constitution/audit regression — check `crates/abi-ai`. |
+| unexpected `model=` | Alias/catalog drift — check `crates/abi-ai` models. |

--- a/.agents/skills/complete-base/complete.sh
+++ b/.agents/skills/complete-base/complete.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # complete-base driver: build the abi CLI and drive the BASE completion path —
 # `abi complete "<input>"` with no flags. This routes to the local model
-# (claude-fable-5 by default), runs the constitution audit, and records the
-# completion in the default WDBX store. It is fully local: no `--live` (no remote
-# provider) and no `--learn` (that SEA path is covered by sea-learn-loop).
+# (claude-fable-5 by default) and runs the constitution audit. Persistence is
+# optional: when no durable WDBX path is configured the CLI reports
+# `persisted=false` honestly. Fully local: no `--live`, no `--learn`.
 # Asserts exit codes + output markers. Resolves repo root from own path.
 #
 # Usage: .agents/skills/complete-base/complete.sh ["prompt"] [model-id]
@@ -11,7 +11,7 @@ set -uo pipefail
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd -- "$SCRIPT_DIR/../../.." && pwd)
 cd "$REPO_ROOT"
-ABI="$REPO_ROOT/zig-out/bin/abi"
+ABI="$REPO_ROOT/target/debug/abi"
 PROMPT="${1:-complete-base probe: summarize the scheduler status}"
 MODEL="${2:-}"
 fail=0
@@ -21,7 +21,7 @@ markers() { local out="$1"; shift; for m in "$@"; do
         || { echo "[FAIL] missing marker: $m"; fail=$((fail+1)); }; done; }
 
 say "build cli"
-./build.sh cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
+./tools/cargo.sh build -p abi-cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
 [ -x "$ABI" ] || { echo "[FAIL] $ABI not produced"; exit 1; }
 
 if [ -n "$MODEL" ]; then
@@ -33,8 +33,13 @@ else
 fi
 printf '%s\n' "$out"
 [ "$rc" -eq 0 ] || { echo "[FAIL] complete exit $rc"; fail=$((fail+1)); }
-markers "$out" "model=" "audit_passed=true" "persisted=true" "wdbx kv_entries="
+markers "$out" "model=" "audit_passed=true" "wdbx kv_entries="
+if grep -qE 'persisted=(true|false)' <<<"$out"; then
+    echo "[ok] marker: persisted=(true|false)"
+else
+    echo "[FAIL] missing marker: persisted=(true|false)"; fail=$((fail+1))
+fi
 
 say "summary"; echo "failed checks: $fail"
-[ "$fail" -eq 0 ] && echo "RESULT: PASS — base completion ran local + persisted." || echo "RESULT: FAIL — $fail check(s)."
+[ "$fail" -eq 0 ] && echo "RESULT: PASS — base completion ran local (audit + model line)." || echo "RESULT: FAIL — $fail check(s)."
 exit "$fail"

--- a/.agents/skills/connector-localcheck/SKILL.md
+++ b/.agents/skills/connector-localcheck/SKILL.md
@@ -32,5 +32,5 @@ sim responds + reports `escalation: false`; auth status lists all providers.
 ## Troubleshooting
 | Symptom | Fix |
 |---|---|
-| `build` FAIL | `/zig-build-doctor` or `./build.sh check`. |
+| `build` FAIL | `./tools/check.sh`. |
 | missing `Twilio ConversationRelay simulation` | grammar drift — check `src/cli/handlers` twilio path + `src/connectors/twilio.zig`. |

--- a/.agents/skills/connector-localcheck/connectors.sh
+++ b/.agents/skills/connector-localcheck/connectors.sh
@@ -8,7 +8,7 @@ set -uo pipefail
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd -- "$SCRIPT_DIR/../../.." && pwd)
 cd "$REPO_ROOT"
-ABI="$REPO_ROOT/zig-out/bin/abi"
+ABI="$REPO_ROOT/target/debug/abi"
 UTTER="${1:-I need account help}"
 fail=0
 say() { printf '\n=== %s ===\n' "$*"; }
@@ -17,7 +17,7 @@ check() { local label="$1" expect="$2"; shift 2; local out; out=$("$@" 2>&1)
     grep -qF -- "$expect" <<<"$out" && echo "[ok] $label" || { echo "[FAIL] $label (missing: $expect)"; fail=$((fail+1)); }; }
 
 say "build cli"
-./build.sh cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
+./tools/cargo.sh build -p abi-cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
 [ -x "$ABI" ] || { echo "[FAIL] no binary"; exit 1; }
 
 check "twilio simulate (local)" "Twilio ConversationRelay simulation" "$ABI" twilio simulate "$UTTER"

--- a/.agents/skills/dashboard-smoke/SKILL.md
+++ b/.agents/skills/dashboard-smoke/SKILL.md
@@ -19,7 +19,7 @@ Prints `RESULT: PASS` (exit 0) or `RESULT: FAIL` with the missing panel/assertio
 
 One-liner by hand:
 ```bash
-./zig-out/bin/abi dashboard < /dev/null 2>&1 | sed $'s/\033\[[0-9;]*m//g'
+./target/debug/abi dashboard < /dev/null 2>&1 | sed $'s/\033\[[0-9;]*m//g'
 ```
 
 ## Gotchas
@@ -34,7 +34,7 @@ One-liner by hand:
   one-shot fallback; treat `unexpected errno`, `tcgetattr`, or `panic` as a bug.
 - **No `timeout` needed** (and macOS lacks it) — a non-TTY stdin makes it a clean
   one-shot. `timeout`/`gtimeout` only matters if you insist on a TTY guard.
-- **The build is near-silent** — confirm with `ls zig-out/bin/abi`, not stdout.
+- **The build is near-silent** — confirm with `ls target/debug/abi`, not stdout.
 - Healthy render = title `ABI Diagnostics Dashboard`, an operational health row,
   and 5 panels (System / Plugins / WDBX Storage / Scheduler / Memory), exit 0.
   Fresh-process values are mostly zero (empty WDBX, a couple completed scheduler
@@ -45,9 +45,8 @@ One-liner by hand:
 |---|---|
 | hangs / never returns | stdin is a TTY — redirect `< /dev/null` to force the one-shot. |
 | empty output | You captured stdout only — the dashboard prints to stderr; use `2>&1`. |
-| looks like a crash (errno/tcgetattr) | Regression in the non-TTY fallback; inspect `src/features/tui/mod.zig`. |
-| a panel missing | Inspect `src/cli/handlers/dashboard.zig`; use the `tui-navigation-guide` subagent for the render loop. |
+| looks like a crash (errno/tcgetattr) | Regression in the non-TTY fallback; inspect `crates/abi-cli` dashboard/TUI code. |
+| a panel missing | Inspect dashboard render in `crates/abi-cli`; panels must still be System / Plugins / WDBX Storage / Scheduler / Memory. |
 
-Historical verification: **PASS** on the pin in `.zigversion` — one-shot render
-of all 5 panels, exit 0. Do not hardcode a Zig nightly in this skill; read
-`.zigversion` for the live pin.
+Historical verification: **PASS** on nightly Rust via `./tools/cargo.sh` — one-shot
+render of all 5 panels, exit 0.

--- a/.agents/skills/dashboard-smoke/dashboard.sh
+++ b/.agents/skills/dashboard-smoke/dashboard.sh
@@ -15,10 +15,10 @@ cd "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || {
 LOG=$(mktemp /tmp/abi-dashboard-smoke.XXXXXX 2>/dev/null || mktemp -t abi-dashboard-smoke)
 trap 'rm -f "$LOG"' EXIT
 echo "[1/3] building abi CLI ..."
-if ! ./build.sh cli >"$LOG" 2>&1; then
+if ! ./tools/cargo.sh build -p abi-cli >"$LOG" 2>&1; then
   echo "RESULT: FAIL (build) — see $LOG"; exit 1
 fi
-BIN=zig-out/bin/abi
+BIN=target/debug/abi
 [ -x "$BIN" ] || { echo "RESULT: FAIL (no binary at $BIN — build is near-silent, verify with ls)"; exit 1; }
 
 echo "[2/3] rendering dashboard one-shot (stdin=/dev/null forces non-interactive) ..."

--- a/.agents/skills/opencode/plugins/tui/SKILL.md
+++ b/.agents/skills/opencode/plugins/tui/SKILL.md
@@ -42,15 +42,15 @@ paths below (or the `run-tui` / `dashboard-smoke` drivers).
 ### repl
 Launch the agent REPL (slash commands live here):
 ```bash
-./zig-out/bin/abi agent tui
+./target/debug/abi agent tui
 ```
 
 ### dashboard
 Show the diagnostics dashboard (`abi tui` is an alias of `abi dashboard`):
 ```bash
-./zig-out/bin/abi dashboard --pane system
-./zig-out/bin/abi dashboard --pane plugins --once --json
-./zig-out/bin/abi tui --compact --pane scheduler
+./target/debug/abi dashboard --pane system
+./target/debug/abi dashboard --pane plugins --once --json
+./target/debug/abi tui --compact --pane scheduler
 ```
 
 Interactive pty smoke (tmux driver):
@@ -70,8 +70,8 @@ scheduler, memory, or 1–5). In the interactive refresh loop, switch panes with
 hotkeys / Tab — there is no separate `pane --focus` CLI.
 
 ```bash
-./zig-out/bin/abi dashboard --list-panes
-./zig-out/bin/abi dashboard --pane memory
+./target/debug/abi dashboard --list-panes
+./target/debug/abi dashboard --pane memory
 ```
 
 ## Slash Commands (in `abi agent tui` REPL)

--- a/.agents/skills/os-control-dryrun/SKILL.md
+++ b/.agents/skills/os-control-dryrun/SKILL.md
@@ -32,5 +32,5 @@ the plan; execute-without-confirm returns exit 2.
 ## Troubleshooting
 | Symptom | Fix |
 |---|---|
-| `build` FAIL | `/zig-build-doctor` or `./build.sh check`. |
+| `build` FAIL | `./tools/check.sh`. |
 | execute-without-confirm didn't return 2 | the confirm gate regressed — check `src/cli/handlers/agent.zig` agent-os path. |

--- a/.agents/skills/os-control-dryrun/dryrun.sh
+++ b/.agents/skills/os-control-dryrun/dryrun.sh
@@ -9,7 +9,7 @@ set -uo pipefail
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd -- "$SCRIPT_DIR/../../.." && pwd)
 cd "$REPO_ROOT"
-ABI="$REPO_ROOT/zig-out/bin/abi"
+ABI="$REPO_ROOT/target/debug/abi"
 if [ "$#" -eq 0 ]; then
     COMMAND=(pwd)
 else
@@ -19,7 +19,7 @@ fail=0
 say() { printf '\n=== %s ===\n' "$*"; }
 
 say "build cli"
-./build.sh cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
+./tools/cargo.sh build -p abi-cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
 [ -x "$ABI" ] || { echo "[FAIL] no binary"; exit 1; }
 
 say "abi agent os dry-run (planning only — no execution)"

--- a/.agents/skills/plugin-runtime-tester/SKILL.md
+++ b/.agents/skills/plugin-runtime-tester/SKILL.md
@@ -33,5 +33,5 @@ Historical verification: **PASS** — `Installed Plugins (16):`; `ai-plugin even
 ## Troubleshooting
 | Symptom | Fix |
 |---|---|
-| `build` FAIL | `/zig-build-doctor` or `./build.sh check`. |
+| `build` FAIL | `./tools/check.sh`. |
 | a plugin → `PluginNotFound` | missing `loadBundledPlugin` + dispatch branch — see `plugin-system-reviewer`. |

--- a/.agents/skills/plugin-runtime-tester/plugins.sh
+++ b/.agents/skills/plugin-runtime-tester/plugins.sh
@@ -9,12 +9,12 @@ set -uo pipefail
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd -- "$SCRIPT_DIR/../../.." && pwd)
 cd "$REPO_ROOT"
-ABI="$REPO_ROOT/zig-out/bin/abi"
+ABI="$REPO_ROOT/target/debug/abi"
 fail=0
 say() { printf '\n=== %s ===\n' "$*"; }
 
 say "build cli"
-./build.sh cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
+./tools/cargo.sh build -p abi-cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
 [ -x "$ABI" ] || { echo "[FAIL] no binary"; exit 1; }
 
 say "abi plugin list"

--- a/.agents/skills/run-tui/SKILL.md
+++ b/.agents/skills/run-tui/SKILL.md
@@ -27,17 +27,14 @@ and there's **no** `errno 19`/`tcgetattr`/panic. Sends `q` (the quit key —
 To eyeball it yourself: `tmux capture-pane -pt <session>` shows the System pane
 (GPU backend, accelerated, native-linked) and the Plugins pane (16 registered).
 
-Historical verification: **PASS** on the pin in `.zigversion` — dashboard box +
-System + Plugins panes render under the pty; `q` quits; session cleaned up.
-Do not hardcode a Zig nightly in this skill; read `.zigversion` for the live pin.
-
+Historical verification: **PASS** on nightly Rust via `./tools/cargo.sh` —
+dashboard box + System + Plugins panes render under the pty; `q` quits; session
+cleaned up.
 
 ## Gotchas (battle scars)
-- ⚠️ **Do NOT prepend `/opt/homebrew/bin` to PATH.** Homebrew ships a `zig`
-  (`/opt/homebrew/bin/zig -> 0.16.0`) that **cannot compile this tree**. Putting
-  brew's bin first shadows the zvm 0.17 zig and the build fails with std API
-  errors. The driver *appends* brew's bin (for `tmux`) so the zvm zig stays
-  first — keep it that way.
+- ⚠️ **Always build with `./tools/cargo.sh`** (never bare Homebrew `cargo`).
+  The driver needs `tmux` on PATH (`brew install tmux`); do not let brew's
+  stable cargo shadow the nightly toolchain used for the build.
 - **A pty is mandatory for the interactive path.** Piped stdin or `/dev/null`
   intentionally uses the one-shot fallback; use tmux when you need to prove the
   live loop paints and accepts `q`.
@@ -53,6 +50,6 @@ Do not hardcode a Zig nightly in this skill; read `.zigversion` for the live pin
 | Symptom | Fix |
 |---|---|
 | `tmux not installed` | `brew install tmux`. |
-| `build` FAIL right after adding brew to PATH | brew's `zig` 0.16 shadowed zvm — append, don't prepend (see Gotchas). |
+| `build` FAIL | Use `./tools/cargo.sh build -p abi-cli`, then `./tools/check.sh`. |
 | `dashboard did not paint` | Increase the `sleep`, or confirm the pane size (`-x/-y`) is large enough. |
 | `tty error / panic in pane` | Regression in the interactive terminal path; confirm launch went through `tmux new-session`. |

--- a/.agents/skills/run-tui/tui.sh
+++ b/.agents/skills/run-tui/tui.sh
@@ -9,8 +9,8 @@ set -uo pipefail
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd -- "$SCRIPT_DIR/../../.." && pwd)
 cd "$REPO_ROOT"
-export PATH="$PATH:/opt/homebrew/bin"   # append (not prepend!) so brew tmux is found without shadowing the zvm zig with brew's 0.16
-ABI="$REPO_ROOT/zig-out/bin/abi"
+export PATH="$PATH:/opt/homebrew/bin"   # append so brew tmux is found; keep rustup/cargo.sh toolchain first
+ABI="$REPO_ROOT/target/debug/abi"
 CMD="${1:-dashboard}"
 SESSION="abi-tui-skill-$$"
 MARKER="ABI Diagnostics Dashboard"
@@ -22,7 +22,7 @@ trap cleanup EXIT
 command -v tmux >/dev/null || { echo "[FAIL] tmux not installed (brew install tmux)"; exit 1; }
 
 say "build cli"
-./build.sh cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
+./tools/cargo.sh build -p abi-cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
 [ -x "$ABI" ] || { echo "[FAIL] $ABI not produced"; exit 1; }
 
 say "launch 'abi $CMD' under tmux pty"

--- a/.agents/skills/scheduler-status/SKILL.md
+++ b/.agents/skills/scheduler-status/SKILL.md
@@ -27,8 +27,8 @@ Prints `RESULT: PASS` (exit 0) or `RESULT: FAIL` with the missing assertion (exi
   own `Scheduler` + `MemoryTracker`, submits one probe task, runs it, prints, exits 0.
 - **Don't use `timeout`** — macOS doesn't ship it, and the command self-terminates
   so no guard is needed (`gtimeout` from coreutils only if you must).
-- **The build is near-silent** — `./build.sh cli` prints ~2 info lines and exits;
-  confirm with `ls zig-out/bin/abi`, not stdout.
+- **The build is near-silent** — `./tools/cargo.sh build -p abi-cli` prints ~2 info lines and exits;
+  confirm with `ls target/debug/abi`, not stdout.
 - Healthy output = `running=0 pending=0 completed=1 failed=0 total_tasks=1`,
   `memory_tracker=attached` (zeroed usage is normal — the probe allocates nothing),
   and a Prometheus block with `scheduler_tasks_submitted 1` / `scheduler_tasks_completed 1`.
@@ -36,7 +36,7 @@ Prints `RESULT: PASS` (exit 0) or `RESULT: FAIL` with the missing assertion (exi
 ## Troubleshooting
 | Symptom | Fix |
 |---|---|
-| `build` FAIL | Check `zig version` (see `/zig-pin`), then `./build.sh check`. |
+| `build` FAIL | Check `zig version` (see `/zig-pin`), then `./tools/check.sh`. |
 | empty output | You captured stdout only — scheduler prints to stderr; use `2>&1`. |
 | `usage: abi scheduler status` | You used `stats`/`info`/bare `scheduler`; the CLI word is `status`. |
 | `completed=0` / `total_tasks=0` | The probe task didn't run — inspect `src/core/scheduler.zig`; use the `scheduler-memory-auditor` subagent to audit submission/completion accounting. |

--- a/.agents/skills/scheduler-status/status.sh
+++ b/.agents/skills/scheduler-status/status.sh
@@ -14,10 +14,10 @@ cd "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || {
 LOG=$(mktemp /tmp/abi-scheduler-status.XXXXXX 2>/dev/null || mktemp -t abi-scheduler-status)
 trap 'rm -f "$LOG"' EXIT
 echo "[1/3] building abi CLI ..."
-if ! ./build.sh cli >"$LOG" 2>&1; then
+if ! ./tools/cargo.sh build -p abi-cli >"$LOG" 2>&1; then
   echo "RESULT: FAIL (build) — see $LOG"; exit 1
 fi
-BIN=zig-out/bin/abi
+BIN=target/debug/abi
 [ -x "$BIN" ] || { echo "RESULT: FAIL (no binary at $BIN — build is near-silent, verify with ls)"; exit 1; }
 
 echo "[2/3] running 'abi scheduler status' (output is on stderr) ..."

--- a/.agents/skills/sea-learn-loop/SKILL.md
+++ b/.agents/skills/sea-learn-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sea-learn-loop
-description: Build the abi CLI and exercise the SEA (Sparse Evidence Attention) self-learning completion path via `abi complete --learn`. Use when working on ai_learn / complete --learn / evidence recall, or to verify the SEA loop runs and persists. SEA defaults on; --sea only forces -Dfeat-sea=true explicitly.
+description: Build the abi CLI and exercise the SEA (Sparse Evidence Attention) self-learning completion path via `abi complete --learn`. Use when working on ai_learn / complete --learn / evidence recall, or to verify the SEA loop runs and persists. SEA is always linked in the Rust workspace; --sea is a compatibility no-op.
 ---
 
 # sea-learn-loop — exercise the SEA self-learning completion
@@ -8,39 +8,36 @@ description: Build the abi CLI and exercise the SEA (Sparse Evidence Attention) 
 Driver: **`.agents/skills/sea-learn-loop/learn.sh`** (paths relative to repo root).
 CLI check — evidence is the `RESULT:` line + the `learn=…` status line.
 
-`feat-sea` defaults **ON** with the rest of the `-Dfeat-*` flags. The default
-run exercises the real SEA path; `evidence_count=0 adapted=false` can still be
-valid when the scratch store has no matching evidence. Use `--sea` only when you
-want to force `-Dfeat-sea=true` explicitly while debugging feature flags.
+SEA is always available in the Rust workspace. The default run exercises the
+real SEA path; `evidence_count=0 adapted=false` can still be valid when the
+store has no matching evidence. `--sea` is accepted for compatibility and does
+not change the build path.
 
 ## Prerequisites
-- Pinned/master Zig on PATH (see `/zig-newest-skills`). macOS builds via `./build.sh`.
+- Nightly Rust via `./tools/cargo.sh` (never bare Homebrew `cargo`).
 
 ## Run (agent path)
 ```bash
 .agents/skills/sea-learn-loop/learn.sh                       # default SEA-on path
 .agents/skills/sea-learn-loop/learn.sh "my custom prompt"    # custom input
-.agents/skills/sea-learn-loop/learn.sh --sea                 # explicitly pass -Dfeat-sea=true
+.agents/skills/sea-learn-loop/learn.sh --sea                 # accepted; no-op on build path
 ```
-It builds the CLI, runs `abi complete --learn "<input>"`, and asserts the
-markers `learn=true`, `model=`, `evidence_count=` (plus a soft `persisted=true`
-check). Prints `RESULT: PASS — SEA learn loop ran.` (exit 0) or a FAIL count.
-
-Historical verification (old feat-sea-off run): **PASS** — `model=claude-fable-5 …
-learn=true evidence_count=0 adapted=false`, store reported `kv_entries=2
-vectors=4 blocks=2`, on Zig master `0.17.0-dev.1099`.
+It builds the CLI, points `ABI_WDBX_PATH` at a scratch store under
+`target/skill-scratch/` (never the live `~/.abi/`), runs
+`abi complete --learn "<input>"`, and asserts the markers `learn=true`,
+`model=`, `evidence_count=` (plus a soft `persisted=true` check). Prints
+`RESULT: PASS — SEA learn loop ran.` (exit 0) or a FAIL count.
 
 ## Gotchas
 - **`evidence_count=0` is not necessarily a failure** — with SEA on, the scratch
   store may simply have no matching evidence yet.
 - The model line shows the catalog default (`claude-fable-5`); `--learn` is local
   (WDBX metadata), not a live API call — no credentials needed.
-- First build can be a fresh feature-graph compile; later `./build.sh cli` runs
+- First build may compile the workspace; later `./tools/cargo.sh build -p abi-cli` runs
   are incremental.
 
 ## Troubleshooting
 | Symptom | Fix |
 |---|---|
-| `build` FAIL (default) | `/zig-build-doctor` or `./build.sh check`. |
-| `build` FAIL (`--sea`) | explicit feat-sea graph issue — check `src/features/sea/{mod,stub}.zig` parity. |
-| missing `learn=true` | `complete` grammar drifted — check `src/cli/` `complete` handler + `--learn`. |
+| `build` FAIL | `./tools/cargo.sh build -p abi-cli`, then `./tools/check.sh`. |
+| missing `learn=true` | `complete` grammar drifted — check `crates/abi-cli` complete handler + `--learn`. |

--- a/.agents/skills/sea-learn-loop/learn.sh
+++ b/.agents/skills/sea-learn-loop/learn.sh
@@ -3,8 +3,8 @@
 # completion path (`abi complete --learn`). Asserts the loop runs, persists, and
 # reports evidence/adaptation counters. Resolves the repo root from its location.
 #
-# feat-sea defaults ON with the other -Dfeat-* flags. Pass --sea only to force
-# -Dfeat-sea=true explicitly while debugging feature-flag behavior.
+# SEA is always available in the Rust workspace (no feature-off CLI flag).
+# `--sea` is accepted for compatibility and is a no-op build-path alias.
 #
 # Usage:
 #   .agents/skills/sea-learn-loop/learn.sh ["input text"]
@@ -24,22 +24,24 @@ for a in "$@"; do
     esac
 done
 
-ABI="$REPO_ROOT/zig-out/bin/abi"
+ABI="$REPO_ROOT/target/debug/abi"
+# Scratch durable store so --learn does not fall back to non-learn local
+# completion and never touches the user's live ~/.abi/.
+SCRATCH_DIR="$REPO_ROOT/target/skill-scratch"
+STORE="$SCRATCH_DIR/sea-learn-wdbx"
 fail=0
 say() { printf '\n=== %s ===\n' "$*"; }
 
-if [ "$SEA" -eq 1 ]; then
-    say "build cli with -Dfeat-sea=true"
-    build_ok() { zig build cli -Dfeat-sea=true; }
-else
-    say "build cli (default feat-sea=true)"
-    build_ok() { ./build.sh cli; }
-fi
-if build_ok; then echo "[ok] build"; else echo "[FAIL] build"; exit 1; fi
+say "build cli (SEA always linked in Rust workspace)"
+if ./tools/cargo.sh build -p abi-cli; then echo "[ok] build"; else echo "[FAIL] build"; exit 1; fi
 [ -x "$ABI" ] || { echo "[FAIL] $ABI not produced"; exit 1; }
 
-say "abi complete --learn"
-echo "\$ $ABI complete --learn \"$INPUT\""
+mkdir -p "$SCRATCH_DIR"
+rm -rf "$STORE"
+export ABI_WDBX_PATH="$STORE"
+
+say "abi complete --learn (ABI_WDBX_PATH=$STORE)"
+echo "\$ ABI_WDBX_PATH=$STORE $ABI complete --learn \"$INPUT\""
 out=$("$ABI" complete --learn "$INPUT" 2>&1); rc=$?
 printf '%s\n' "$out"
 [ "$rc" -eq 0 ] || { echo "[FAIL] complete --learn exit $rc"; fail=$((fail+1)); }
@@ -54,7 +56,7 @@ grep -qF -- "persisted=true" <<<"$out" && echo "[ok] persisted=true" \
     || echo "[note] not persisted (acceptable depending on store state)"
 
 say "summary"
-echo "feat-sea: $([ "$SEA" -eq 1 ] && echo explicit-on || echo default-on)"
+echo "feat-sea: $([ "$SEA" -eq 1 ] && echo flag-accepted-noop || echo default-on)"
 echo "failed checks: $fail"
 [ "$fail" -eq 0 ] && echo "RESULT: PASS — SEA learn loop ran." || echo "RESULT: FAIL — $fail check(s) failed."
 exit "$fail"

--- a/.agents/skills/secure-demo/SKILL.md
+++ b/.agents/skills/secure-demo/SKILL.md
@@ -31,5 +31,5 @@ Historical verification: **PASS** on Zig master `0.17.0-dev.1099` — int8 ratio
 ## Troubleshooting
 | Symptom | Fix |
 |---|---|
-| `build` FAIL | `/zig-build-doctor` or `./build.sh check`. |
+| `build` FAIL | `./tools/check.sh`. |
 | missing `match=true` | a HE/compression invariant broke — check `src/features/wdbx/{compression,crypto_he,fhe}.zig`. |

--- a/.agents/skills/secure-demo/secure.sh
+++ b/.agents/skills/secure-demo/secure.sh
@@ -8,12 +8,12 @@ set -uo pipefail
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd -- "$SCRIPT_DIR/../../.." && pwd)
 cd "$REPO_ROOT"
-ABI="$REPO_ROOT/zig-out/bin/abi"
+ABI="$REPO_ROOT/target/debug/abi"
 fail=0
 say() { printf '\n=== %s ===\n' "$*"; }
 
 say "build cli"
-./build.sh cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
+./tools/cargo.sh build -p abi-cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
 [ -x "$ABI" ] || { echo "[FAIL] no binary"; exit 1; }
 
 say "abi wdbx secure demo"

--- a/.agents/skills/wdbx-api-serve/SKILL.md
+++ b/.agents/skills/wdbx-api-serve/SKILL.md
@@ -44,6 +44,6 @@ bearer enforcement is exactly 401/401/200.
 ## Troubleshooting
 | Symptom | Fix |
 |---|---|
-| `build` FAIL | Check `zig version` (see `/zig-pin`), then `./build.sh check`. |
+| `build` FAIL | Check `zig version` (see `/zig-pin`), then `./tools/check.sh`. |
 | `server did not come up` | Port in use — pass a free base port; or the build didn't produce the binary. |
 | bearer test all 200 | `ABI_WDBX_REST_TOKEN` not being read — check `src/features/wdbx/rest.zig` (`loadBearerToken`/`hasBearerToken`). |

--- a/.agents/skills/wdbx-api-serve/serve.sh
+++ b/.agents/skills/wdbx-api-serve/serve.sh
@@ -9,7 +9,7 @@ set -uo pipefail
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd -- "$SCRIPT_DIR/../../.." && pwd)
 cd "$REPO_ROOT"
-ABI="$REPO_ROOT/zig-out/bin/abi"
+ABI="$REPO_ROOT/target/debug/abi"
 PORT="${1:-8091}"
 PORT2=$((PORT + 1))
 fail=0
@@ -22,7 +22,7 @@ wait_up() { local port="$1"; for _ in $(seq 1 25); do curl -s -o /dev/null "http
 code() { curl -s -o /dev/null -w '%{http_code}' "$@"; }
 
 say "build cli"
-./build.sh cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
+./tools/cargo.sh build -p abi-cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
 [ -x "$ABI" ] || { echo "[FAIL] $ABI not produced"; exit 1; }
 
 say "launch WDBX REST (no auth) on :$PORT"

--- a/.agents/skills/wdbx-bench/SKILL.md
+++ b/.agents/skills/wdbx-bench/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wdbx-bench
-description: Build the abi CLI and benchmark the WDBX vector store (in-process insert/search timing), optionally running the full `zig build benchmarks` suite. Use when asked to benchmark WDBX, measure insert/search latency, profile the vector store, or check benchmark output after a storage change.
+description: Build the abi CLI and benchmark the WDBX vector store (in-process insert/search timing), optionally running the abi-wdbx unit-test suite. Use when asked to benchmark WDBX, measure insert/search latency, profile the vector store, or check benchmark output after a storage change.
 ---
 
 # wdbx-bench — benchmark the WDBX vector store
@@ -12,30 +12,27 @@ These are **local, in-memory** measurements — not a published throughput claim
 (the CLI says so itself). Numbers vary by machine and are noisy at low counts.
 
 ## Prerequisites
-- Pinned/master Zig on PATH (see `/zig-newest-skills`). macOS builds via `./build.sh`.
+- Nightly Rust via `./tools/cargo.sh` (never bare Homebrew `cargo`).
 
 ## Run (agent path)
 ```bash
 .agents/skills/wdbx-bench/bench.sh 50        # build CLI, run `abi wdbx benchmark 50`
-.agents/skills/wdbx-bench/bench.sh 50 --suite  # also run `zig build benchmarks`
+.agents/skills/wdbx-bench/bench.sh 50 --suite  # also run `./tools/cargo.sh test -p abi-wdbx --lib`
 ```
 It builds the CLI, runs `abi wdbx benchmark <count>`, and asserts the markers
 `benchmark (local, in-memory`, `inserts:`, `searches:`. Prints
 `RESULT: PASS — WDBX benchmark ran.` (exit 0) or `RESULT: FAIL — N check(s) failed.`
-
-Historical verification: **PASS** — e.g. `inserts: 50 …` / `searches: 50 …` with
-p50/p95/p99 lines, on Zig master `0.17.0-dev.1099`.
 
 ## Gotchas
 - **Not a throughput claim.** Per-op time includes acceleration-kernel dispatch;
   the GPU path is the vectorized CPU fallback unless native kernels are linked
   (`abi backends` shows `accelerated=false` on this machine).
 - Low counts are high-variance — use ≥50 for a stable-ish p50; the suite
-  (`--suite`) runs the broader `zig build benchmarks` targets.
+  (`--suite`) runs `./tools/cargo.sh test -p abi-wdbx --lib`.
 - `bench.sh <non-number>` → usage, exit 2.
 
 ## Troubleshooting
 | Symptom | Fix |
 |---|---|
-| `build` FAIL | Run `/zig-build-doctor` or `./build.sh check` to see the real error. |
-| missing `inserts:`/`searches:` marker | CLI grammar drifted — check `src/cli/handlers/wdbx.zig` `benchmark`. |
+| `build` FAIL | Run `./tools/check.sh` to see the real error. |
+| missing `inserts:`/`searches:` marker | CLI grammar drifted — check `crates/abi-cli` WDBX handler + `crates/abi-wdbx`. |

--- a/.agents/skills/wdbx-bench/bench.sh
+++ b/.agents/skills/wdbx-bench/bench.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # wdbx-bench driver: build the abi CLI, run the in-process WDBX benchmark, and
-# (optionally) the full `zig build benchmarks` suite. Asserts exit codes and the
+# (optionally) the abi-wdbx unit-test suite. Asserts exit codes and the
 # expected output markers. Resolves the repo root from its own location.
 #
 # Usage:
 #   .agents/skills/wdbx-bench/bench.sh [count]     # default count=50
-#   .agents/skills/wdbx-bench/bench.sh --suite     # also run `zig build benchmarks`
+#   .agents/skills/wdbx-bench/bench.sh --suite     # also run `cargo test -p abi-wdbx`
 set -uo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
@@ -22,12 +22,12 @@ for a in "$@"; do
     esac
 done
 
-ABI="$REPO_ROOT/zig-out/bin/abi"
+ABI="$REPO_ROOT/target/debug/abi"
 fail=0
 say() { printf '\n=== %s ===\n' "$*"; }
 
 say "build cli"
-if ./build.sh cli; then echo "[ok] build"; else echo "[FAIL] build"; exit 1; fi
+if ./tools/cargo.sh build -p abi-cli; then echo "[ok] build"; else echo "[FAIL] build"; exit 1; fi
 [ -x "$ABI" ] || { echo "[FAIL] $ABI not produced"; exit 1; }
 
 say "abi wdbx benchmark $COUNT"
@@ -40,8 +40,8 @@ for marker in "benchmark (local, in-memory" "inserts:" "searches:"; do
 done
 
 if [ "$SUITE" -eq 1 ]; then
-    say "zig build benchmarks (full suite)"
-    if zig build benchmarks; then echo "[ok] suite"; else echo "[FAIL] suite"; fail=$((fail+1)); fi
+    say "./tools/cargo.sh test -p abi-wdbx --lib"
+    if ./tools/cargo.sh test -p abi-wdbx --lib; then echo "[ok] suite"; else echo "[FAIL] suite"; fail=$((fail+1)); fi
 fi
 
 say "summary"

--- a/.agents/skills/wdbx-cluster-serve/SKILL.md
+++ b/.agents/skills/wdbx-cluster-serve/SKILL.md
@@ -13,7 +13,7 @@ distinct from the **in-process** `abi wdbx cluster demo` that `/cluster-demo-gui
 single-node `cluster status`. Loopback-only by design.
 
 ## Prerequisites
-- Pinned/master Zig on PATH (see `/zig-newest-skills`). macOS builds via `./build.sh`.
+- Nightly Rust via `./tools/cargo.sh` (never bare Homebrew `cargo`).
 - `nc` for the port probe (optional — the readiness marker is the primary gate; the probe is skipped if `nc` is absent).
 
 ## Run (agent path)
@@ -43,7 +43,7 @@ lingering process, on Zig master `0.17.0-dev.1099`.
 ## Troubleshooting
 | Symptom | Fix |
 |---|---|
-| `build` FAIL | Run `/zig-build-doctor` or `./build.sh check` for the real error. |
+| `build` FAIL | Run `./tools/check.sh` for the real error. |
 | no readiness marker / `bind … failed` | Port in use or privileged — pick a higher free port (`8095`). |
 | missing marker string | CLI grammar drifted — check `src/cli/handlers/wdbx_runtime.zig` `clusterServe`. |
 

--- a/.agents/skills/wdbx-cluster-serve/cluster-serve.sh
+++ b/.agents/skills/wdbx-cluster-serve/cluster-serve.sh
@@ -11,7 +11,7 @@ set -uo pipefail
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd -- "$SCRIPT_DIR/../../.." && pwd)
 cd "$REPO_ROOT"
-ABI="$REPO_ROOT/zig-out/bin/abi"
+ABI="$REPO_ROOT/target/debug/abi"
 PORT="${1:-8092}"
 case "$PORT" in
   ''|*[!0-9]*) echo "usage: cluster-serve.sh [port]   (port must be numeric; default 8092)" >&2; exit 2 ;;
@@ -27,7 +27,7 @@ trap cleanup EXIT
 say() { printf '\n=== %s ===\n' "$*"; }
 
 say "build cli"
-./build.sh cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
+./tools/cargo.sh build -p abi-cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
 [ -x "$ABI" ] || { echo "[FAIL] $ABI not produced"; exit 1; }
 
 MARKER="serving consensus RPC on 127.0.0.1:$PORT"

--- a/.agents/skills/wdbx-roundtrip/SKILL.md
+++ b/.agents/skills/wdbx-roundtrip/SKILL.md
@@ -7,7 +7,7 @@ description: Build the abi CLI and drive a full WDBX persistence round-trip on a
 
 Driver: **`.agents/skills/wdbx-roundtrip/roundtrip.sh`** (paths relative to repo root).
 Builds the CLI and runs the four-step store lifecycle against a scratch segment
-under `zig-out/` (created and removed by the driver). Evidence is the `RESULT:`
+under `target/` (created and removed by the driver). Evidence is the `RESULT:`
 line. Fully local, no network.
 
 ## Run (agent path)
@@ -28,7 +28,7 @@ hashed block, query reports `blocks:1`, verify confirms `chain_valid=true` and
 `WAL OK`.
 
 ## Gotchas
-- The scratch store is `zig-out/skill-wdbx-roundtrip.jsonl` — deleted before and
+- The scratch store is `target/skill-wdbx-roundtrip.jsonl` — deleted before and
   after the run, so it never touches your default `.abi/` store.
 - `wdbx query <store>` on a freshly-block-inserted segment reports `kv_entries:0
   vectors:0 blocks:1` — blocks are the append-only content-addressed log; kv and
@@ -41,5 +41,5 @@ hashed block, query reports `blocks:1`, verify confirms `chain_valid=true` and
 ## Troubleshooting
 | Symptom | Fix |
 |---|---|
-| `build` FAIL | Check `zig version` (see `/zig-pin`), then `./build.sh check`. |
+| `build` FAIL | Check `zig version` (see `/zig-pin`), then `./tools/check.sh`. |
 | `chain_valid=true` missing | Checkpoint/WAL regression — inspect `src/features/wdbx/` (checkpoint + WAL merge path). |

--- a/.agents/skills/wdbx-roundtrip/roundtrip.sh
+++ b/.agents/skills/wdbx-roundtrip/roundtrip.sh
@@ -9,10 +9,10 @@ set -uo pipefail
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd -- "$SCRIPT_DIR/../../.." && pwd)
 cd "$REPO_ROOT"
-ABI="$REPO_ROOT/zig-out/bin/abi"
+ABI="$REPO_ROOT/target/debug/abi"
 PROFILE="${1:-abi}"
 META="${2:-{\"note\":\"wdbx-roundtrip\"}}"
-STORE="$REPO_ROOT/zig-out/skill-wdbx-roundtrip.jsonl"
+STORE="$REPO_ROOT/target/skill-wdbx-roundtrip.jsonl"
 fail=0
 say() { printf '\n=== %s ===\n' "$*"; }
 step() { local label="$1"; shift; local -a markers=(); local a
@@ -25,7 +25,7 @@ step() { local label="$1"; shift; local -a markers=(); local a
             || { echo "[FAIL] $label missing: $a"; fail=$((fail+1)); }; done; }
 
 say "build cli"
-./build.sh cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
+./tools/cargo.sh build -p abi-cli >/dev/null 2>&1 && echo "[ok] build" || { echo "[FAIL] build"; exit 1; }
 [ -x "$ABI" ] || { echo "[FAIL] $ABI not produced"; exit 1; }
 rm -f "$STORE"
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -49,6 +49,7 @@ Status legend: `✅ Done` · `🟡 In progress` · `⚪ Not started` · `🔴 Bl
 
 ## Recently landed
 
+- Agent skill drivers ported off `zig-out`/`./build.sh cli` → `./tools/cargo.sh` + `target/debug/abi` (dashboard, backends, plugins, SEA scratch store, WDBX roundtrip, etc.)
 - nn demo JSON checkpoint (`--out` / `--checkpoint`); Rust smoke scripts + goals/run-abi/mcp-smoke skills
 - **Rust rewrite on `main`** via [#756](https://github.com/donaldfilimon/abi/pull/756) (`34c35d5`)
 - FoundationModels Swift `@c` shim + `complete --live --model apple-fm --confirm`


### PR DESCRIPTION
## Summary
- Port remaining `.agents/skills/*/…sh` drivers off `zig-out/bin/abi` and `./build.sh cli` onto `./tools/cargo.sh build -p abi-cli` + `target/debug/abi`.
- Align smoke assertions with the live Rust CLI (`gpu backend=`, honest `persisted=false` when no store, SEA learn via scratch `ABI_WDBX_PATH`).
- Update matching SKILL.md troubleshooting / path docs; note on `tasks/todo.md`.

## Verification
- `./tools/check.sh` green
- `./tools/check_skills.sh` → 77/77
- Smokes PASS: dashboard-smoke, backend-diagnostics, scheduler-status, auth-localcheck, plugin-runtime-tester, secure-demo, complete-base, os-control-dryrun, wdbx-bench, connector-localcheck, sea-learn-loop, cluster-demo-guide, wdbx-roundtrip, run-tui

## Non-goals
- No product residual fake-complete (GPU kernels / live TLS / ggml)
- Historical Zig-only skills (`zig-pin`, `zig-newest-skills`) left as archived Zig tooling