### PR TITLE
chore(tooling): finish the Zig teardown in agent scripts and hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,8 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(./build.sh *)",
-      "Bash(zig build *)",
-      "Bash(zig test *)",
+      "Bash(./tools/check.sh *)",
+      "Bash(./tools/cargo.sh *)",
       "Bash(npx tsc)",
       "Bash(swift build *)",
       "Bash(swift test *)",
@@ -18,13 +18,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; case \"$f\" in *.zig) pin=$(cat \"$CLAUDE_PROJECT_DIR/.zigversion\" 2>/dev/null); zb=\"$HOME/.zvm/$pin/zig\"; if [ -x \"$zb\" ]; then \"$zb\" fmt \"$f\"; else zig fmt \"$f\"; fi;; esac; } 2>/dev/null || true",
-            "statusMessage": "zig fmt (pinned)"
-          },
-          {
-            "type": "command",
-            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; case \"$f\" in *mod.zig|*stub.zig) cd \"$CLAUDE_PROJECT_DIR\" && zig build check-parity 2>&1 | tail -5;; esac; } 2>/dev/null || true",
-            "statusMessage": "check-parity"
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; case \"$f\" in *.rs) tb=\"$(dirname \"$(rustup which --toolchain nightly cargo)\")\"; if [ -x \"$tb/rustfmt\" ]; then \"$tb/rustfmt\" --edition 2024 \"$f\"; fi;; esac; } 2>/dev/null || true",
+            "statusMessage": "rustfmt (nightly)"
           }
         ]
       },
@@ -46,16 +41,6 @@
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-force-push-main.sh\"",
             "statusMessage": "guard force-push to main"
-          }
-        ]
-      },
-      {
-        "matcher": "Write|Edit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "f=$(jq -r '.tool_input.file_path' 2>/dev/null); case \"$f\" in *plugin_registry.zig) echo 'plugin_registry.zig is generated from src/plugins/*/abi-plugin.json; edit the manifest and rebuild (tools/generate_plugin_registry.zig), do not hand-edit.' >&2; exit 2;; esac",
-            "statusMessage": "guard generated files"
           }
         ]
       },

--- a/.claude/skills/run-abi/smoke.sh
+++ b/.claude/skills/run-abi/smoke.sh
@@ -15,14 +15,14 @@ cd "$REPO_ROOT"
 
 ABI="$REPO_ROOT/target/debug/abi"
 ABI_MCP="$REPO_ROOT/target/debug/abi-mcp"
-STORE="$REPO_ROOT/zig-out/smoke-memory.jsonl"
-TRANSCRIPT="$REPO_ROOT/zig-out/run-abi-smoke.txt"
+STORE="$REPO_ROOT/target/abi-smoke/smoke-memory.jsonl"
+TRANSCRIPT="$REPO_ROOT/target/abi-smoke/run-abi-smoke.txt"
 
 fail=0
 pass=0
 
-# zig-out/ may not exist before the first build; ensure the transcript dir is
-# writable up front so every log line lands instead of erroring out per-line.
+# target/abi-smoke/ may not exist before the first run; ensure the transcript
+# dir is writable up front so every log line lands instead of erroring per-line.
 mkdir -p "$(dirname -- "$TRANSCRIPT")"
 
 log() { printf '%s\n' "$*" | tee -a "$TRANSCRIPT"; }

--- a/.claude/skills/run-tui/tui.sh
+++ b/.claude/skills/run-tui/tui.sh
@@ -9,7 +9,7 @@ set -uo pipefail
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd -- "$SCRIPT_DIR/../../.." && pwd)
 cd "$REPO_ROOT"
-export PATH="$PATH:/opt/homebrew/bin"   # append (not prepend!) so brew tmux is found without shadowing the zvm zig with brew's 0.16
+export PATH="$PATH:/opt/homebrew/bin"   # append (not prepend!) so brew tmux is found without shadowing rustup with brew's stable cargo
 ABI="$REPO_ROOT/target/debug/abi"
 CMD="${1:-dashboard}"
 SESSION="abi-tui-skill-$$"

--- a/.claude/skills/sea-learn-loop/learn.sh
+++ b/.claude/skills/sea-learn-loop/learn.sh
@@ -28,13 +28,14 @@ ABI="$REPO_ROOT/target/debug/abi"
 fail=0
 say() { printf '\n=== %s ===\n' "$*"; }
 
+# The Rust port compiles SEA unconditionally: there is no `-Dfeat-sea` build
+# flag to mirror, so --sea only changes the label, not the build.
 if [ "$SEA" -eq 1 ]; then
-    say "build cli with -Dfeat-sea=true"
-    build_ok() { zig build cli -Dfeat-sea=true; }
+    say "build cli (--sea: SEA is always compiled in)"
 else
-    say "build cli (default feat-sea=true)"
-    build_ok() { ./tools/cargo.sh build -p abi-cli; }
+    say "build cli"
 fi
+build_ok() { ./tools/cargo.sh build -p abi-cli; }
 if build_ok; then echo "[ok] build"; else echo "[FAIL] build"; exit 1; fi
 [ -x "$ABI" ] || { echo "[FAIL] $ABI not produced"; exit 1; }
 

--- a/.claude/skills/wdbx-bench/bench.sh
+++ b/.claude/skills/wdbx-bench/bench.sh
@@ -1,23 +1,24 @@
 #!/usr/bin/env bash
-# wdbx-bench driver: build the abi CLI, run the in-process WDBX benchmark, and
-# (optionally) the full `zig build benchmarks` suite. Asserts exit codes and the
-# expected output markers. Resolves the repo root from its own location.
+# wdbx-bench driver: build the abi CLI and run the in-process WDBX benchmark,
+# asserting exit codes and the expected output markers. Resolves the repo root
+# from its own location.
 #
 # Usage:
 #   .claude/skills/wdbx-bench/bench.sh [count]     # default count=50
-#   .claude/skills/wdbx-bench/bench.sh --suite     # also run `zig build benchmarks`
+#
+# There is no full-suite mode: the Zig `zig build benchmarks` step had no Rust
+# successor (the workspace declares no [[bench]] targets), so the flag was
+# removed rather than left pointing at something that cannot run.
 set -uo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd -- "$SCRIPT_DIR/../../.." && pwd)
 cd "$REPO_ROOT"
 
-SUITE=0
 COUNT=50
 for a in "$@"; do
     case "$a" in
-        --suite) SUITE=1 ;;
-        ''|*[!0-9]*) echo "usage: bench.sh [count] [--suite]" >&2; exit 2 ;;
+        ''|*[!0-9]*) echo "usage: bench.sh [count]" >&2; exit 2 ;;
         *) COUNT="$a" ;;
     esac
 done
@@ -38,11 +39,6 @@ for marker in "benchmark (local, in-memory" "inserts:" "searches:"; do
     grep -qF -- "$marker" <<<"$out" && echo "[ok] marker: $marker" \
         || { echo "[FAIL] missing marker: $marker"; fail=$((fail+1)); }
 done
-
-if [ "$SUITE" -eq 1 ]; then
-    say "zig build benchmarks (full suite)"
-    if zig build benchmarks; then echo "[ok] suite"; else echo "[FAIL] suite"; fail=$((fail+1)); fi
-fi
 
 say "summary"
 echo "failed checks: $fail"

--- a/.claude/skills/wdbx-roundtrip/roundtrip.sh
+++ b/.claude/skills/wdbx-roundtrip/roundtrip.sh
@@ -12,7 +12,7 @@ cd "$REPO_ROOT"
 ABI="$REPO_ROOT/target/debug/abi"
 PROFILE="${1:-abi}"
 META="${2:-{\"note\":\"wdbx-roundtrip\"}}"
-STORE="$REPO_ROOT/zig-out/skill-wdbx-roundtrip.jsonl"
+STORE="$REPO_ROOT/target/abi-smoke/skill-wdbx-roundtrip.jsonl"
 fail=0
 say() { printf '\n=== %s ===\n' "$*"; }
 step() { local label="$1"; shift; local -a markers=(); local a

--- a/crates/abi-cli/src/agent.rs
+++ b/crates/abi-cli/src/agent.rs
@@ -428,6 +428,8 @@ const TUI_HELP: &str = "\
 ABI agent line-mode (interactive raw TUI not linked)
 commands:
   /help              this text
+  /model <id>        switch the completion model (alias-resolved)
+  /profile           show profile routing status
   /quit /exit /q     leave the REPL
   /status /stat      session counters and model
   /context           file_context / open-file summary
@@ -438,11 +440,39 @@ commands:
   free text          local persona completion with file_context
 ";
 
+/// Longest model id the line-mode REPL will accept via `/model`.
+///
+/// Ported from Zig's `MODEL_STORAGE_BYTES`. Zig needed this as a fixed-size
+/// backing array for `state.config.model`; here it survives only as the same
+/// length cap on an owned `String`, so a `/model` argument this long is
+/// rejected the same way in both ports.
+const MODEL_STORAGE_BYTES: usize = 128;
+
+/// Whether `id` is acceptable as a `/model` argument.
+///
+/// Ported from Zig's `validModelId`: every byte must be printable ASCII
+/// excluding space (`0x21..=0x7e`), and the id must be non-empty and no longer
+/// than [`MODEL_STORAGE_BYTES`]. Zig additionally checked
+/// `std.ascii.isWhitespace`, which is redundant here (and there): every ASCII
+/// whitespace byte — space, tab, newline, CR, and the rest — is already below
+/// `0x21`, so the range check alone rejects internal whitespace such as a
+/// two-word id. The range's upper bound also rejects DEL (`0x7f`) and every
+/// non-ASCII byte, including each byte of a multi-byte UTF-8 character, so a
+/// model id is ASCII by construction rather than by a separate check.
+fn valid_model_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= MODEL_STORAGE_BYTES
+        && id.bytes().all(|byte| (0x21..0x7f).contains(&byte))
+}
+
 struct LineModeState {
     session_id: i64,
     turn_count: usize,
     history: Vec<String>,
-    model: &'static str,
+    /// Owned rather than `&'static str`: `/model` can set this to a freeform,
+    /// non-catalog id (Zig accepted any `validModelId` string, not only known
+    /// catalog entries), which has no `'static` lifetime to borrow.
+    model: String,
 }
 
 enum SlashAction {
@@ -458,18 +488,65 @@ fn emit_line(responses: &mut String, stdout: &mut std::io::Stdout, line: &str) {
 }
 
 fn slash_status(state: &LineModeState, responses: &mut String, stdout: &mut std::io::Stdout) {
+    // `session_id=`, not `session=`: matches Zig's `formatStatusLine`.
     emit_line(
         responses,
         stdout,
         &format!(
-            "status: session={} turns={} history={} model={} provider={} sea=off live=off store=off mode=line",
+            "status: session_id={} turns={} history={} model={} provider={} sea=off live=off store=off mode=line",
             state.session_id,
             state.turn_count,
             state.history.len(),
             state.model,
-            abi_ai::models::provider_of(state.model).label(),
+            abi_ai::models::provider_of(&state.model).label(),
         ),
     );
+}
+
+/// `/profile`: report the routing mode and current model. Ported from Zig's
+/// `showProfileStatus`.
+fn slash_profile(state: &LineModeState, responses: &mut String, stdout: &mut std::io::Stdout) {
+    emit_line(
+        responses,
+        stdout,
+        &format!(
+            "profile: adaptive router active; model={}; turns={}",
+            state.model, state.turn_count
+        ),
+    );
+}
+
+/// `/model <id>`: switch the completion model. Ported from Zig's `applyModel`.
+///
+/// An empty argument prints usage without touching `state.model`. An argument
+/// that fails [`valid_model_id`] (after alias resolution — so `/model
+/// fable-5` still normalizes to `claude-fable-5` before validation) reports the
+/// same rejection message and, deliberately, leaves `state.model` unchanged:
+/// the whole point of validating first is that a rejected `/model` cannot move
+/// the session into an inconsistent state.
+fn slash_model(
+    state: &mut LineModeState,
+    arg: &str,
+    responses: &mut String,
+    stdout: &mut std::io::Stdout,
+) {
+    if arg.is_empty() {
+        emit_line(responses, stdout, "usage: /model <id>");
+        return;
+    }
+    let canonical = abi_ai::models::canonical(arg);
+    if !valid_model_id(canonical) {
+        emit_line(
+            responses,
+            stdout,
+            &format!(
+                "model id must be printable non-whitespace ASCII and at most {MODEL_STORAGE_BYTES} bytes"
+            ),
+        );
+        return;
+    }
+    state.model = canonical.to_string();
+    emit_line(responses, stdout, &format!("model set to {}", state.model));
 }
 
 fn slash_context(responses: &mut String, stdout: &mut std::io::Stdout) {
@@ -527,10 +604,25 @@ fn handle_slash(
         .next()
         .unwrap_or(trimmed)
         .to_ascii_lowercase();
+    // Everything after the command token, with the single separating
+    // whitespace run removed but internal whitespace preserved — so
+    // `/model two words` yields the argument `"two words"`, not `"two"`, which
+    // is what makes `valid_model_id` see (and reject) the embedded space.
+    let arg = trimmed
+        .split_once(char::is_whitespace)
+        .map_or("", |(_, rest)| rest.trim());
     match cmd.as_str() {
         "/quit" | "/exit" | "/q" => SlashAction::Quit,
         "/help" | "/h" => {
             emit_line(responses, stdout, TUI_HELP.trim_end());
+            SlashAction::Continue
+        }
+        "/model" => {
+            slash_model(state, arg, responses, stdout);
+            SlashAction::Continue
+        }
+        "/profile" => {
+            slash_profile(state, responses, stdout);
             SlashAction::Continue
         }
         "/status" | "/stat" => {
@@ -605,7 +697,7 @@ fn agent_tui_line_mode() -> Outcome {
         session_id: abi_foundation::time::unix_ms(),
         turn_count: 0,
         history: Vec::new(),
-        model: abi_ai::models::DEFAULT_MODEL,
+        model: abi_ai::models::DEFAULT_MODEL.to_string(),
     };
 
     for line in stdin.lock().lines() {
@@ -769,5 +861,103 @@ mod tests {
     fn train_unknown_profile_is_usage() {
         let outcome = train_profile("nobody");
         assert_eq!(outcome.exit_code, 2);
+    }
+
+    fn line_mode_state(model: &str) -> LineModeState {
+        LineModeState {
+            session_id: 42,
+            turn_count: 0,
+            history: Vec::new(),
+            model: model.to_owned(),
+        }
+    }
+
+    /// Dispatch one REPL line and return only what it wrote to `responses`.
+    ///
+    /// `handle_slash` also writes to a live `std::io::Stdout`, so this prints
+    /// during a `cargo test` run without `--nocapture` shows nothing — libtest
+    /// captures it — but running with `--nocapture` will show duplicate lines.
+    /// That is a property of the REPL loop under test, not of the test.
+    fn dispatch(line: &str, state: &mut LineModeState) -> String {
+        let mut responses = String::new();
+        let mut stdout = std::io::stdout();
+        handle_slash(line, state, &mut responses, &mut stdout);
+        responses
+    }
+
+    #[test]
+    fn model_command_sets_a_valid_model_and_reports_it() {
+        let mut state = line_mode_state(abi_ai::models::DEFAULT_MODEL);
+        let responses = dispatch("/model abi-local", &mut state);
+        assert_eq!(state.model, "abi-local");
+        assert!(responses.contains("model set to abi-local"));
+    }
+
+    #[test]
+    fn model_command_rejects_a_whitespace_containing_id() {
+        // The exact case the smoke test exercises: a two-word "id" must be
+        // rejected, and rejection must not perturb the session's model.
+        let mut state = line_mode_state("abi-local");
+        let responses = dispatch("/model two words", &mut state);
+        assert_eq!(
+            state.model, "abi-local",
+            "a rejected /model must leave state unchanged"
+        );
+        assert!(responses.contains("model id must be printable non-whitespace ASCII"));
+        assert!(!responses.contains("model set to two"));
+    }
+
+    #[test]
+    fn model_command_resolves_aliases_before_validating() {
+        // "/model fable-5" should store the canonical id, matching the
+        // alias-resolution `/model <id>` in the help text promises.
+        let mut state = line_mode_state(abi_ai::models::DEFAULT_MODEL);
+        dispatch("/model fable-5", &mut state);
+        assert_eq!(state.model, "claude-fable-5");
+    }
+
+    #[test]
+    fn model_command_with_no_argument_prints_usage_and_changes_nothing() {
+        let mut state = line_mode_state("abi-local");
+        let responses = dispatch("/model", &mut state);
+        assert_eq!(state.model, "abi-local");
+        assert!(responses.contains("usage: /model <id>"));
+    }
+
+    #[test]
+    fn profile_command_reports_the_current_model_and_turn_count() {
+        let mut state = line_mode_state("abi-local");
+        state.turn_count = 3;
+        let responses = dispatch("/profile", &mut state);
+        assert!(responses.contains("profile: adaptive router active; model=abi-local; turns=3"));
+    }
+
+    #[test]
+    fn status_reports_session_id_not_session() {
+        // The Rust port originally printed `session=`; the smoke test (and
+        // Zig's formatStatusLine) expect `session_id=`.
+        let mut state = line_mode_state("abi-local");
+        let responses = dispatch("/status", &mut state);
+        assert!(responses.contains("status: session_id=42"));
+    }
+
+    #[test]
+    fn help_lists_the_model_and_profile_commands() {
+        assert!(TUI_HELP.contains("/model"));
+        assert!(TUI_HELP.contains("/profile"));
+    }
+
+    #[test]
+    fn valid_model_id_matches_the_zig_reference_cases() {
+        // Verbatim from Zig's "validModelId rejects controls whitespace and
+        // overlong ids" test.
+        assert!(valid_model_id("abi-local"));
+        assert!(valid_model_id("ollama/qwen2"));
+        assert!(!valid_model_id(""));
+        assert!(!valid_model_id("two words"));
+        assert!(!valid_model_id("bad\tid"));
+        assert!(!valid_model_id("bad\x1bid"));
+        assert!(valid_model_id(&"a".repeat(MODEL_STORAGE_BYTES)));
+        assert!(!valid_model_id(&"a".repeat(MODEL_STORAGE_BYTES + 1)));
     }
 }

--- a/crates/abi-cli/src/app.rs
+++ b/crates/abi-cli/src/app.rs
@@ -224,7 +224,17 @@ fn edit_distance(left: &str, right: &str) -> usize {
     previous[right.chars().count()]
 }
 
-fn suggestion<'a>(name: &str, candidates: impl Iterator<Item = &'a str>) -> Option<&'a str> {
+/// Closest edit-distance match for `name` among `candidates`, if any is close
+/// enough to be worth suggesting.
+///
+/// `pub(crate)` so per-command handlers with their own small, fixed choice sets
+/// (see `plugin::run`) can offer the same "did you mean" hint this module
+/// already gives for a mistyped top-level command or `--help` subcommand,
+/// without re-deriving edit distance or its threshold.
+pub(crate) fn suggestion<'a>(
+    name: &str,
+    candidates: impl Iterator<Item = &'a str>,
+) -> Option<&'a str> {
     candidates
         .map(|candidate| (edit_distance(name, candidate), candidate))
         .filter(|(distance, candidate)| *distance <= min(3, candidate.len() / 2 + 1))

--- a/crates/abi-cli/src/dashboard.rs
+++ b/crates/abi-cli/src/dashboard.rs
@@ -177,6 +177,35 @@ fn append_border(out: &mut String, left: &str, title: &str, right: &str) {
     out.push('\n');
 }
 
+/// Reverse video plus bold red — how the dashboard marks the focused pane.
+///
+/// Kept as one constant because it is contract: `tools/run_tui_smoke.sh` asserts
+/// this exact byte sequence precedes the selected pane's title.
+const FOCUS_STYLE: &str = "\x1b[7m\x1b[1;31m";
+/// SGR reset, closing [`FOCUS_STYLE`].
+const STYLE_RESET: &str = "\x1b[0m";
+
+/// Render a pane's top border, highlighting it when it is the focused pane.
+///
+/// The reset lands *before* the newline: leaving it after would let reverse video
+/// bleed into the following row, which is the usual way this kind of highlight
+/// goes wrong. With `color` false (`--plain` / `--no-color`) no escapes are
+/// emitted at all, which is what makes those flags meaningful for the text
+/// render rather than metadata that only shows up in `--json`.
+fn append_pane_header(out: &mut String, title: &str, selected: bool, color: bool) {
+    let mut line = String::new();
+    append_border(&mut line, "┌", title, "┐");
+
+    if selected && color {
+        out.push_str(FOCUS_STYLE);
+        out.push_str(line.trim_end_matches('\n'));
+        out.push_str(STYLE_RESET);
+        out.push('\n');
+    } else {
+        out.push_str(&line);
+    }
+}
+
 fn append_row(out: &mut String, label: &str, value: &str) {
     out.push_str("│ ");
     out.push_str(&fit(label, LABEL_WIDTH));
@@ -364,7 +393,7 @@ fn render_text(ds: &DashboardState) -> String {
 
     for idx in visible {
         let (_, title, _) = PANES[idx];
-        append_border(&mut out, "┌", title, "┐");
+        append_pane_header(&mut out, title, idx == ds.selected_pane, ds.color);
         match PANES[idx].0 {
             "system" => {
                 append_row(&mut out, "GPU backend", &ds.gpu_backend);
@@ -658,6 +687,54 @@ mod tests {
         assert_eq!(v["scheduler"]["completed"], 2);
         assert_eq!(v["wdbx"]["blocks"], 0);
         assert_eq!(v["wdbx"]["vectors"], 0);
+    }
+
+    #[test]
+    fn selected_pane_is_highlighted_and_plain_suppresses_it() {
+        // The focused pane must be visually marked. Zig did this and the Rust
+        // port initially dropped it: `color` was stored and reported in `--json`
+        // but never used to emit anything, so `--pane` had no visible effect and
+        // `--plain` was a no-op for the text render.
+        let colored = run(&["--pane".to_owned(), "memory".to_owned()]);
+        assert_eq!(colored.exit_code, 0, "{}", colored.stderr);
+        assert!(
+            colored.stderr.contains(&format!("{FOCUS_STYLE}┌ Memory")),
+            "focused pane must carry the highlight"
+        );
+        assert!(
+            colored.stderr.contains(STYLE_RESET),
+            "the highlight must be reset so it does not bleed"
+        );
+        // Unfocused panes stay unstyled.
+        assert!(colored.stderr.contains("┌ System"));
+        assert!(!colored.stderr.contains(&format!("{FOCUS_STYLE}┌ System")));
+
+        let plain = run(&[
+            "--pane".to_owned(),
+            "memory".to_owned(),
+            "--plain".to_owned(),
+        ]);
+        assert_eq!(plain.exit_code, 0, "{}", plain.stderr);
+        assert!(
+            !plain.stderr.contains(FOCUS_STYLE),
+            "--plain must emit no escapes"
+        );
+        assert!(plain.stderr.contains("┌ Memory"));
+    }
+
+    #[test]
+    fn highlight_reset_precedes_the_newline() {
+        // Resetting after the newline would let reverse video bleed across the
+        // following row, which is the usual way this bug shows up in a terminal
+        // but is invisible to a "contains" assertion.
+        let out = run(&["--pane".to_owned(), "memory".to_owned()]);
+        let line = out
+            .stderr
+            .lines()
+            .find(|l| l.contains("┌ Memory"))
+            .expect("the memory pane header is rendered");
+        assert!(line.starts_with(FOCUS_STYLE), "got {line:?}");
+        assert!(line.ends_with(STYLE_RESET), "got {line:?}");
     }
 
     #[test]

--- a/crates/abi-cli/src/plugin.rs
+++ b/crates/abi-cli/src/plugin.rs
@@ -10,10 +10,19 @@
 //!   `plugin_list` tool renders the manager's load order (declaration order). The
 //!   two orders differ on purpose; see the `abi-plugins` crate docs.
 
+use std::fmt::Write as _;
+
 use abi_core::registry::Registry;
 use abi_plugins::{PluginManager, register_all};
 
-use crate::app::Outcome;
+use crate::app::{Outcome, suggestion};
+
+/// The two tokens `abi plugin` actually dispatches on. Zig derived this same
+/// pair from the registry's declared `choices` for the subcommand's positional
+/// arg (`arg.parse` failing against `choices` is what drove its "did you mean"
+/// suggestion); this crate has no generic choices-validated arg parser yet, so
+/// the pair is spelled out here instead of derived.
+const SUBCOMMANDS: [&str; 2] = ["list", "run"];
 
 const USAGE: &str = "usage: abi plugin list | run <name> [input]";
 const LIST_USAGE: &str = "usage: abi plugin list";
@@ -45,7 +54,17 @@ pub(crate) fn run(args: &[String]) -> Outcome {
             let input = args[2..].join(" ");
             run_plugin(name, &input)
         }
-        _ => Outcome::stderr(format!("error: {USAGE}\n"), 2),
+        other => {
+            // Matches Zig's `usageErrorWithSuggestion`: the usage line, then an
+            // unconditional `hint:` line when a close-enough match exists — no
+            // blank line between them (unlike `unknown_command`'s top-level
+            // format, which does separate the hint from its usage block).
+            let mut error = format!("error: {USAGE}\n");
+            if let Some(candidate) = suggestion(other, SUBCOMMANDS.into_iter()) {
+                let _ = writeln!(error, "hint: did you mean `{candidate}`?");
+            }
+            Outcome::stderr(error, 2)
+        }
     }
 }
 
@@ -141,5 +160,24 @@ mod tests {
         assert_eq!(run(&["run".to_string()]).exit_code, 2);
         // `list` takes no arguments.
         assert_eq!(run(&["list".to_string(), "extra".to_string()]).exit_code, 2);
+    }
+
+    #[test]
+    fn a_close_typo_earns_a_did_you_mean_hint() {
+        // Ported from Zig's live behavior: `arg.parse` failing a `choices`
+        // check on the registry's `plugin` command (["list", "run"]) drove
+        // `suggest.usageErrorWithSuggestion`, which this mirrors for the two
+        // real subcommands rather than re-deriving a generic choices parser.
+        let output = run(&["rn".to_string()]);
+        assert_eq!(output.exit_code, 2);
+        assert!(output.stderr.contains(USAGE));
+        assert!(output.stderr.contains("hint: did you mean `run`?"));
+    }
+
+    #[test]
+    fn a_dissimilar_token_earns_no_hint() {
+        let output = run(&["bogus".to_string()]);
+        assert_eq!(output.exit_code, 2);
+        assert!(!output.stderr.contains("hint:"));
     }
 }

--- a/tools/contract_cli/complete_through_wdbx.sh
+++ b/tools/contract_cli/complete_through_wdbx.sh
@@ -59,7 +59,10 @@ require_substring "$backends_out" "GPU:"
 plugins_out="$("$ABI" plugin list 2>&1)"
 require_substring "$plugins_out" "Installed Plugins ("
 require_substring "$plugins_out" "example-plugin"
-require_substring "$plugins_out" "(mod.zig)"
+# Plugin entry points are `mod.rs` after the Rust rewrite; the Zig tree
+# reported `mod.zig`. This is the one disclosed field change in the
+# plugin listing contract.
+require_substring "$plugins_out" "(mod.rs)"
 
 plugin_help_out="$("$ABI" plugin --help 2>&1)"
 require_substring "$plugin_help_out" "abi plugin list | run <name> [input]"

--- a/tools/contract_cli/help.sh
+++ b/tools/contract_cli/help.sh
@@ -15,8 +15,9 @@ require_substring "$completion_bash_out" 'tui|--tui)'
 require_substring "$completion_bash_out" '--list-panes'
 require_substring "$completion_bash_out" 'words="list run "'
 reject_substring "$completion_bash_out" 'words="list run list run '
-printf '%s' "$completion_bash_out" > zig-out/abi-completion-contract.bash
-bash -n zig-out/abi-completion-contract.bash
+mkdir -p target/abi-smoke
+printf '%s' "$completion_bash_out" > target/abi-smoke/abi-completion-contract.bash
+bash -n target/abi-smoke/abi-completion-contract.bash
 if grep -Fq -- "Usage: abi" <<<"$completion_bash_out"; then
   echo "expected 'abi help --completion bash' to emit completion only, not text help" >&2
   echo "$completion_bash_out" >&2

--- a/tools/run_tui_smoke.sh
+++ b/tools/run_tui_smoke.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-bin="zig-out/bin/abi"
+bin="target/debug/abi"
 if [ ! -x "$bin" ]; then
-  echo "tui smoke: missing executable at $bin" >&2
+  echo "tui smoke: missing executable at $bin (run ./tools/cargo.sh build -p abi-cli)" >&2
   exit 1
 fi
 
@@ -116,9 +116,12 @@ case "$once_out" in
   *"ABI Diagnostics Dashboard"*"[1-5] Panes"*|"ABI Diagnostics Dashboard"*) ;;
   *) echo "tui smoke: --once under pty missing dashboard content" >&2; echo "$once_out" >&2; exit 1 ;;
 esac
+# The Rust dashboard deliberately does not claim a one-shot snapshot refreshes.
+# Zig's footer read "live snapshot every 250ms" even with --once, which was
+# misleading; the Rust wording states the interval is CLI metadata only.
 case "$once_out" in
-  *"live snapshot every 250ms"*) ;;
-  *) echo "tui smoke: --interval did not update footer" >&2; echo "$once_out" >&2; exit 1 ;;
+  *"refresh is CLI metadata only"*) ;;
+  *) echo "tui smoke: --interval footer missing the one-shot disclosure" >&2; echo "$once_out" >&2; exit 1 ;;
 esac
 case "$once_out" in
   *$'\033[?1049h'*|*$'\033[?1049l'*|*$'\033[H'*|*$'\033[0J'*)
@@ -155,8 +158,9 @@ agent_out=$(ABI_WDBX_PATH=:memory: "$bin" agent tui 2>&1 <<'EOF'
 EOF
 )
 
+# The Rust REPL prints a lowercase "commands:" header; Zig used "Commands:".
 case "$agent_out" in
-  *"Commands:"*"/help"*"/quit"*) ;;
+  *"commands:"*"/help"*"/quit"*) ;;
   *) echo "tui smoke: missing agent REPL help output" >&2; exit 1 ;;
 esac
 


### PR DESCRIPTION
## What

The Rust rewrite and residual scrub (#755–#759) removed the Zig source and the Zig-only skills, but left behind the agent tooling that **shells out** to Zig. Seven scripts and four Claude hooks still referenced `zig build`, `zig-out/`, `.zigversion`, or `zig fmt`.

Those are all dead paths now, so the affected scripts failed on their *first* command — they were passing as "not run", not as "working". Reviving them then surfaced two genuine Rust feature gaps that had been invisible until now; both are fixed in this PR's second commit.

## Commit 1 — repoint the scripts and hooks at Rust

| Was | Now |
|---|---|
| `zig-out/` scratch paths | `target/abi-smoke/` (run-abi smoke, wdbx-roundtrip, contract-CLI capture) |
| `zig-out/bin/abi` | `target/debug/abi` (`tools/run_tui_smoke.sh`), error now names the build command |
| `zig build cli -Dfeat-sea=true` | `./tools/cargo.sh build -p abi-cli` |
| `zig build benchmarks` (`--suite`) | **removed** — no Rust successor exists (no `[[bench]]` targets) |

`.claude/settings.json`: `zig fmt` hook → `rustfmt --edition 2024` (resolved through the nightly toolchain bin, not PATH); `zig build check-parity` hook dropped (parity is a compile-time trait check now); the `plugin_registry.zig` edit-guard dropped (the file doesn't exist); `Bash(zig build *)`/`Bash(zig test *)` → `./tools/cargo.sh`/`./tools/check.sh`.

Three assertions updated from stale Zig wording to the intentional Rust behavior (dashboard footer's one-shot disclosure, lowercase `commands:` header, `(mod.rs)` entry points).

**One real regression fixed**: `DashboardState.color` was stored and reported in `--json` but never used to emit anything — `--pane` had no visible effect and `--plain` was a no-op. Restored as reverse-video + bold red with the reset before the newline (two tests, one pinning escape placement so a bleed bug can't hide behind a `contains` check).

## Commit 2 — the two gaps the revived scripts uncovered

**Agent REPL `/model` + `/profile`.** Recovered the exact Zig behavior from `git show 34c35d5^:src/features/tui/repl_commands.zig` (the commit right before the rewrite): `valid_model_id` (printable ASCII, no space, ≤128 bytes), alias resolution before validation, and — critically — a rejected `/model` must leave the session's model **unchanged**. Also fixed `/status`'s `session=` → `session_id=`. 8 new tests.

**Plugin `did-you-mean`.** `abi plugin rn` reported only the bare usage error. Traced Zig's actual suggestion path (it wasn't in `plugin.zig` — checked several pre-rewrite commits) to a generic `dispatch.zig` mechanism driven by `choices`-validated arg parsing. Porting that generic parser for every typed command is real future work; this ports the one behavior under test, reusing the edit-distance `suggestion()` helper already used for top-level typos. 2 new tests (a close typo gets the hint, a dissimilar token doesn't).

## Honest scope: two more gaps surfaced, not fixed here

Getting further into these scripts hit two more, larger, **distinct** features — filed separately rather than chased inline:

- `tools/run_tui_smoke.sh` now reaches its tmux/PTY section, which drives a real raw-mode terminal editor (cursor edit, tab-completion, ambiguous-command discovery, history recall). That's `abi-tui` — RUST-REWRITE-PLAN.md step 7, explicitly still open.
- `tools/run_contract_cli.sh` now reaches `abi agent spawn --workers "name|profile|task" ...`, expected to print `=== CUSTOM MULTI-AGENT RESULTS ===`. The current `spawn` handler only runs one fixed dry-run worker.

## Verification

Run in a **clean worktree at `main`** both times (the shared checkout holds unrelated concurrent WIP that would otherwise contaminate the result):

- `./tools/check.sh` — all green (fmt, clippy `-D warnings`, build, tests, docs)
- 10 new unit tests, all passing
- The live `~/.abi` store was byte-compared before and after both commits — unchanged

## Note for reviewers

Six skill scripts run store-writing CLI commands without setting `ABI_WDBX_PATH`, so they mutate the real `~/.abi` when run directly. Pre-existing, unrelated to this PR, deliberately not bundled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)