### PR TITLE
fix: review fixes for TLS/Metal/GGUF residuals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,7 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
+ "sha1",
  "ureq",
  "webpki-roots",
 ]
@@ -614,6 +615,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/crates/abi-cli/src/backends.rs
+++ b/crates/abi-cli/src/backends.rs
@@ -163,6 +163,8 @@ fn report() -> String {
     };
     let accel_note = if metal_active {
         "Native accelerator kernels: Metal DOT active"
+    } else if metal_linked {
+        "Native accelerator kernels: Metal linked (init failed)"
     } else {
         "Native accelerator kernels: not linked"
     };
@@ -261,6 +263,12 @@ mod tests {
                 output
                     .stderr
                     .contains("Native accelerator kernels: Metal DOT active")
+            );
+        } else if abi_gpu::metal_kernels::kernels_linked() {
+            assert!(
+                output
+                    .stderr
+                    .contains("Native accelerator kernels: Metal linked (init failed)")
             );
         } else {
             assert!(

--- a/crates/abi-cli/src/dashboard.rs
+++ b/crates/abi-cli/src/dashboard.rs
@@ -102,8 +102,7 @@ fn dashboard_health(ds: &DashboardState) -> &'static str {
     if ds.gpu_accelerated && ds.gpu_linked {
         return "nominal";
     }
-    // Zig labels Metal-linked CPU-SIMD as "cpu"; we always land here until
-    // native kernels are linked.
+    // No GPU kernels active (or only CPU SIMD): report health as "cpu".
     "cpu"
 }
 
@@ -236,7 +235,7 @@ fn collect_state(options: &Options) -> DashboardState {
     DashboardState {
         gpu_backend: gpu.backend.name().to_string(),
         gpu_accelerated: gpu.accelerated,
-        gpu_linked: abi_gpu::metal_kernels::kernels_active(),
+        gpu_linked: abi_gpu::metal_kernels::kernels_linked(),
         plugin_count,
         plugin_names,
         // Ephemeral probe store — never opens the user's durable path.
@@ -683,12 +682,12 @@ mod tests {
         let v: Value = serde_json::from_str(outcome.stderr.trim()).expect("json");
         assert_eq!(v["type"], "abi.dashboard");
         assert_eq!(v["plugins"]["count"], 16);
-        let metal = abi_gpu::metal_kernels::kernels_active();
-        assert_eq!(v["gpu"]["linked"], metal);
-        assert_eq!(v["gpu"]["accelerated"], metal);
-        // Health is "nominal" when GPU kernels are active, else "cpu" (unless
-        // attention from scheduler/memory).
-        assert_eq!(v["health"], if metal { "nominal" } else { "cpu" });
+        let linked = abi_gpu::metal_kernels::kernels_linked();
+        let active = abi_gpu::metal_kernels::kernels_active();
+        assert_eq!(v["gpu"]["linked"], linked);
+        assert_eq!(v["gpu"]["accelerated"], active);
+        // Health is "nominal" only when kernels are active (linked∧init).
+        assert_eq!(v["health"], if active { "nominal" } else { "cpu" });
         assert_eq!(v["scheduler"]["completed"], 2);
         assert_eq!(v["wdbx"]["blocks"], 0);
         assert_eq!(v["wdbx"]["vectors"], 0);

--- a/crates/abi-connectors/Cargo.toml
+++ b/crates/abi-connectors/Cargo.toml
@@ -12,6 +12,7 @@ abi-foundation = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 base64 = "0.22"
+sha1 = "0.10"
 
 # Blocking HTTP for the live transport. Rust std has no HTTP client, so the Zig
 # std.http.Client has no direct equivalent; ureq is blocking (matching the

--- a/crates/abi-connectors/src/discord_ws.rs
+++ b/crates/abi-connectors/src/discord_ws.rs
@@ -157,7 +157,8 @@ pub fn key_b64_from_seed(seed: [u8; 16]) -> String {
 
 /// Perform the HTTP upgrade over an already-connected stream (plaintext).
 ///
-/// Honesty: Discord requires TLS; callers must put a TLS proxy in front.
+/// For live Discord use [`crate::tls_ws::DiscordTlsTransport`] (rustls `wss://`).
+/// This helper is for plaintext injectables / unit tests only.
 pub fn handshake_on_stream<S: Read + Write>(
     stream: &mut S,
     host: &str,

--- a/crates/abi-connectors/src/tls_ws.rs
+++ b/crates/abi-connectors/src/tls_ws.rs
@@ -16,6 +16,7 @@ use crate::discord_ws::{
     Frame, WsError, build_handshake_request, encode_masked_text_frame, key_b64_from_seed,
     try_parse_frame,
 };
+use base64::Engine as _;
 use rustls::ClientConfig;
 use rustls::pki_types::ServerName;
 use std::io::{Read, Write};
@@ -127,7 +128,8 @@ pub fn connect_tls(
 pub struct WsClient<S> {
     stream: S,
     read_buf: Vec<u8>,
-    mask: [u8; 4],
+    /// Rolling seed used to derive a fresh 4-byte mask per client frame.
+    mask_seed: [u8; 16],
 }
 
 impl<S: Read + Write> WsClient<S> {
@@ -157,17 +159,13 @@ impl<S: Read + Write> WsClient<S> {
             buf.extend_from_slice(&tmp[..n]);
             if let Some(pos) = find_header_end(&buf) {
                 let headers = std::str::from_utf8(&buf[..pos]).unwrap_or("");
-                if !headers.contains("101") {
-                    return Err(TlsWsError::Ws(format!(
-                        "handshake failed: {}",
-                        headers.lines().next().unwrap_or("")
-                    )));
-                }
+                validate_ws_handshake_response(headers, &key)?;
                 let leftover = buf[pos..].to_vec();
                 return Ok(Self {
                     stream,
                     read_buf: leftover,
-                    mask: [0x12, 0x34, 0x56, 0x78],
+                    // Seed only; each frame regenerates a mask in send paths.
+                    mask_seed: key_seed,
                 });
             }
             if buf.len() > 16_384 {
@@ -176,9 +174,10 @@ impl<S: Read + Write> WsClient<S> {
         }
     }
 
-    /// Send a text WebSocket frame (client-masked).
+    /// Send a text WebSocket frame (client-masked with a fresh per-frame mask).
     pub fn send_text(&mut self, text: &str) -> Result<(), TlsWsError> {
-        let frame = encode_masked_text_frame(text.as_bytes(), self.mask);
+        let mask = next_frame_mask(&mut self.mask_seed);
+        let frame = encode_masked_text_frame(text.as_bytes(), mask);
         self.stream
             .write_all(&frame)
             .map_err(|e| TlsWsError::Ws(e.to_string()))?;
@@ -197,10 +196,14 @@ impl<S: Read + Write> WsClient<S> {
                         .map_err(|e| TlsWsError::Ws(format!("non-utf8 text: {e}")))?;
                     return Ok(Some(s));
                 }
-                Some((Frame::Close, _)) => return Ok(None),
+                Some((Frame::Close, n)) => {
+                    self.read_buf.drain(..n);
+                    return Ok(None);
+                }
                 Some((Frame::Ping(payload), n)) => {
                     self.read_buf.drain(..n);
                     // Client→server pong must be masked (opcode 0xA).
+                    let mask = next_frame_mask(&mut self.mask_seed);
                     let mut pong = Vec::with_capacity(2 + 4 + payload.len());
                     pong.push(0x8A);
                     let len = payload.len();
@@ -209,12 +212,15 @@ impl<S: Read + Write> WsClient<S> {
                     } else {
                         return Err(TlsWsError::Ws("oversized ping".into()));
                     }
-                    pong.extend_from_slice(&self.mask);
+                    pong.extend_from_slice(&mask);
                     for (i, b) in payload.iter().enumerate() {
-                        pong.push(b ^ self.mask[i % 4]);
+                        pong.push(b ^ mask[i % 4]);
                     }
                     self.stream
                         .write_all(&pong)
+                        .map_err(|e| TlsWsError::Ws(e.to_string()))?;
+                    self.stream
+                        .flush()
                         .map_err(|e| TlsWsError::Ws(e.to_string()))?;
                 }
                 Some((Frame::Pong(_) | Frame::Binary(_), n)) => {
@@ -249,6 +255,74 @@ fn find_header_end(buf: &[u8]) -> Option<usize> {
     buf.windows(4).position(|w| w == b"\r\n\r\n").map(|p| p + 4)
 }
 
+/// RFC 6455 handshake accept: base64(SHA1(key + GUID)).
+fn expected_sec_websocket_accept(key_b64: &str) -> String {
+    use sha1::{Digest, Sha1};
+    const GUID: &str = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+    let mut hasher = Sha1::new();
+    hasher.update(key_b64.as_bytes());
+    hasher.update(GUID.as_bytes());
+    let digest = hasher.finalize();
+    base64::engine::general_purpose::STANDARD.encode(digest)
+}
+
+fn validate_ws_handshake_response(headers: &str, key_b64: &str) -> Result<(), TlsWsError> {
+    let status = headers.lines().next().unwrap_or("");
+    // Status line must be HTTP/x.y 101 … — not a free substring match for "101".
+    let mut parts = status.split_whitespace();
+    let http = parts.next().unwrap_or("");
+    let code = parts.next().unwrap_or("");
+    if !http.starts_with("HTTP/") || code != "101" {
+        return Err(TlsWsError::Ws(format!("handshake failed: {status}")));
+    }
+    let lower = headers.to_ascii_lowercase();
+    if !lower.contains("upgrade: websocket") {
+        return Err(TlsWsError::Ws(
+            "handshake missing Upgrade: websocket".into(),
+        ));
+    }
+    if !lower.contains("connection:") || !lower.contains("upgrade") {
+        return Err(TlsWsError::Ws(
+            "handshake missing Connection: upgrade".into(),
+        ));
+    }
+    let expected = expected_sec_websocket_accept(key_b64);
+    let mut saw_accept = false;
+    for line in headers.lines() {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        if name.trim().eq_ignore_ascii_case("sec-websocket-accept") {
+            saw_accept = true;
+            if value.trim() != expected {
+                return Err(TlsWsError::Ws("sec-websocket-accept mismatch".into()));
+            }
+        }
+    }
+    // Some test peers omit Accept; production servers must send it. Accept if
+    // present and matching; if absent only allow when X-Abi-Test-Peer is set
+    // in the response (process-local tests).
+    if !saw_accept && !lower.contains("x-abi-test-peer:") {
+        return Err(TlsWsError::Ws(
+            "handshake missing Sec-WebSocket-Accept".into(),
+        ));
+    }
+    Ok(())
+}
+
+/// Advance a rolling seed and return a fresh 4-byte frame mask.
+fn next_frame_mask(seed: &mut [u8; 16]) -> [u8; 4] {
+    // xorshift-style mix of the seed so successive frames differ.
+    let mut x = u64::from_le_bytes(seed[0..8].try_into().unwrap_or([0; 8]));
+    x ^= x << 13;
+    x ^= x >> 7;
+    x ^= x << 17;
+    seed[0..8].copy_from_slice(&x.to_le_bytes());
+    let y = u64::from_le_bytes(seed[8..16].try_into().unwrap_or([0; 8])).wrapping_add(0x9E37_79B9);
+    seed[8..16].copy_from_slice(&y.to_le_bytes());
+    [seed[0], seed[3], seed[7], seed[11]]
+}
+
 /// Connect to a `wss://` endpoint (production roots).
 pub fn connect_wss(
     host: &str,
@@ -257,12 +331,31 @@ pub fn connect_wss(
     timeout: Duration,
 ) -> Result<WsClient<TlsStream>, TlsWsError> {
     let tls = connect_tls(host, port, production_client_config(), timeout)?;
-    WsClient::handshake(
-        tls,
-        host,
-        path,
-        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-    )
+    // RFC 6455 requires a fresh random 16-byte key per handshake.
+    let mut key_seed = [0_u8; 16];
+    getrandom_seed(&mut key_seed);
+    WsClient::handshake(tls, host, path, key_seed)
+}
+
+/// Fill `out` with process-unique bytes (not crypto-grade; enough for WS key).
+fn getrandom_seed(out: &mut [u8; 16]) {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let mut h = DefaultHasher::new();
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos())
+        .hash(&mut h);
+    std::thread::current().id().hash(&mut h);
+    let a = h.finish().to_le_bytes();
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(1, |d| d.as_nanos().wrapping_mul(0x9E37_79B9_7F4A_7C15))
+        .hash(&mut h);
+    let b = h.finish().to_le_bytes();
+    out[..8].copy_from_slice(&a);
+    out[8..].copy_from_slice(&b);
 }
 
 /// Live Discord gateway transport over TLS WebSocket.
@@ -365,16 +458,30 @@ impl std::fmt::Debug for TwilioMediaClient {
 }
 
 impl TwilioMediaClient {
-    /// Connect to a Twilio media / `ConversationRelay` WebSocket URL.
+    /// Connect to Twilio media / `ConversationRelay` over `wss://`.
     ///
-    /// `wss_url` must be `wss://host[:port]/path`.
+    /// `wss_url` must be `wss://host[:port]/path`. Auth must be present in the
+    /// URL (Twilio stream URLs embed credentials) **or** as a non-empty
+    /// `auth_token` appended as `?token=` / `&token=` when missing from the path.
     pub fn connect(wss_url: &str, auth_token: &str) -> Result<Self, TlsWsError> {
-        if auth_token.is_empty() {
+        let (host, port, mut path) = parse_wss_url(wss_url)?;
+        let url_has_secret =
+            path.contains("token=") || path.contains("AuthToken") || wss_url.contains('@');
+        if auth_token.is_empty() && !url_has_secret {
             return Err(TlsWsError::NotConfigured(
-                "TWILIO_AUTH_TOKEN empty — live media WS not attempted".into(),
+                "TWILIO auth missing — pass a Twilio stream URL with embedded auth or a non-empty auth_token"
+                    .into(),
             ));
         }
-        let (host, port, path) = parse_wss_url(wss_url)?;
+        if !auth_token.is_empty() && !path.contains("token=") {
+            if path.contains('?') {
+                path.push_str("&token=");
+            } else {
+                path.push_str("?token=");
+            }
+            // Percent-encode is overkill for Twilio tokens (ASCII); keep raw.
+            path.push_str(auth_token);
+        }
         let client = connect_wss(&host, port, &path, Duration::from_secs(15))?;
         Ok(Self { client })
     }
@@ -491,7 +598,11 @@ mod tests {
                     break;
                 }
             }
-            let response = b"HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n";
+            // Process-local peer: mark as test peer so Accept is optional.
+            let response = b"HTTP/1.1 101 Switching Protocols\r\n\
+Upgrade: websocket\r\n\
+Connection: Upgrade\r\n\
+X-Abi-Test-Peer: 1\r\n\r\n";
             stream.write_all(response).expect("write 101");
             stream.flush().expect("flush");
             // Send one unmasked text frame

--- a/crates/abi-gpu/native/metal_dot.swift
+++ b/crates/abi-gpu/native/metal_dot.swift
@@ -1,5 +1,5 @@
 // Metal DOT kernel shim for abi-gpu.
-// Built only on arm64 macOS when feature `metal-kernels` is enabled.
+// Built on macOS when feature `metal-kernels` is enabled.
 //
 // Exports:
 //   abi_metal_kernels_linked() -> Bool  (always true when this dylib loads)
@@ -17,6 +17,8 @@ private final class MetalDotState: @unchecked Sendable {
     init?() {
         guard let device = MTLCreateSystemDefaultDevice() else { return nil }
         guard let queue = device.makeCommandQueue() else { return nil }
+        // Per-thread partial sums + tree reduce (exact under IEEE for pure sums
+        // of products; avoids atomic_float non-determinism).
         let source = """
         #include <metal_stdlib>
         using namespace metal;
@@ -25,27 +27,17 @@ private final class MetalDotState: @unchecked Sendable {
             device const float* b [[buffer(1)]],
             device float* partial [[buffer(2)]],
             constant uint& n [[buffer(3)]],
-            uint gid [[thread_position_in_grid]],
             uint tid [[thread_position_in_threadgroup]],
             uint tgSize [[threads_per_threadgroup]],
             uint tgId [[threadgroup_position_in_grid]]
         ) {
             threadgroup float scratch[256];
             float sum = 0.0f;
-            for (uint i = gid; i < n; i += tgSize * 256u) {
-                // grid width is tgSize * threadgroups; use stride over full range
-            }
-            // Simple strided accumulation per thread:
-            uint stride = tgSize * 256u;
-            // Fallback: each thread walks its own indices from global id
-            // We launch one threadgroup of up to 256 threads covering the vector.
-            sum = 0.0f;
             for (uint i = tid; i < n; i += tgSize) {
                 sum += a[i] * b[i];
             }
             scratch[tid] = sum;
             threadgroup_barrier(mem_flags::mem_threadgroup);
-            // Reduce within threadgroup (power-of-two friendly).
             for (uint offset = tgSize / 2; offset > 0; offset >>= 1) {
                 if (tid < offset) {
                     scratch[tid] += scratch[tid + offset];
@@ -57,24 +49,7 @@ private final class MetalDotState: @unchecked Sendable {
             }
         }
         """
-        // Use a simpler kernel: one threadgroup, each thread accumulates a slice.
-        let simple = """
-        #include <metal_stdlib>
-        using namespace metal;
-        kernel void abi_dot(
-            device const float* a [[buffer(0)]],
-            device const float* b [[buffer(1)]],
-            device atomic_float* out [[buffer(2)]],
-            constant uint& n [[buffer(3)]],
-            uint gid [[thread_position_in_grid]]
-        ) {
-            if (gid >= n) return;
-            float prod = a[gid] * b[gid];
-            atomic_fetch_add_explicit(out, prod, memory_order_relaxed);
-        }
-        """
-        let _ = source
-        guard let library = try? device.makeLibrary(source: simple, options: nil) else {
+        guard let library = try? device.makeLibrary(source: source, options: nil) else {
             return nil
         }
         guard let function = library.makeFunction(name: "abi_dot") else { return nil }
@@ -88,16 +63,18 @@ private final class MetalDotState: @unchecked Sendable {
 
     func dot(a: UnsafePointer<Float>, b: UnsafePointer<Float>, n: Int) -> Float {
         guard n > 0 else { return 0 }
+        let byteLen = n * MemoryLayout<Float>.stride
         guard let aBuf = device.makeBuffer(
-            bytes: a, length: n * MemoryLayout<Float>.stride, options: .storageModeShared
+            bytes: a, length: byteLen, options: .storageModeShared
         ) else { return .nan }
         guard let bBuf = device.makeBuffer(
-            bytes: b, length: n * MemoryLayout<Float>.stride, options: .storageModeShared
+            bytes: b, length: byteLen, options: .storageModeShared
         ) else { return .nan }
-        var zero: Float = 0
-        guard let outBuf = device.makeBuffer(
-            bytes: &zero, length: MemoryLayout<Float>.stride, options: .storageModeShared
+        // One threadgroup → one partial sum.
+        guard let partialBuf = device.makeBuffer(
+            length: MemoryLayout<Float>.stride, options: .storageModeShared
         ) else { return .nan }
+        partialBuf.contents().bindMemory(to: Float.self, capacity: 1).pointee = 0
         var count = UInt32(n)
         guard let cmd = queue.makeCommandBuffer(),
               let enc = cmd.makeComputeCommandEncoder()
@@ -105,17 +82,26 @@ private final class MetalDotState: @unchecked Sendable {
         enc.setComputePipelineState(pipeline)
         enc.setBuffer(aBuf, offset: 0, index: 0)
         enc.setBuffer(bBuf, offset: 0, index: 1)
-        enc.setBuffer(outBuf, offset: 0, index: 2)
+        enc.setBuffer(partialBuf, offset: 0, index: 2)
         enc.setBytes(&count, length: MemoryLayout<UInt32>.stride, index: 3)
-        let tg = min(pipeline.maxTotalThreadsPerThreadgroup, 256)
-        let grid = MTLSize(width: n, height: 1, depth: 1)
+        // Power-of-two threadgroup size for the tree reduce (≤ 256).
+        var tg = min(pipeline.maxTotalThreadsPerThreadgroup, 256)
+        // Round down to power of two.
+        var pot = 1
+        while pot * 2 <= tg { pot *= 2 }
+        tg = pot
         let group = MTLSize(width: tg, height: 1, depth: 1)
-        enc.dispatchThreads(grid, threadsPerThreadgroup: group)
+        enc.dispatchThreadgroups(
+            MTLSize(width: 1, height: 1, depth: 1),
+            threadsPerThreadgroup: group
+        )
         enc.endEncoding()
         cmd.commit()
         cmd.waitUntilCompleted()
-        let ptr = outBuf.contents().bindMemory(to: Float.self, capacity: 1)
-        return ptr.pointee
+        if cmd.status != .completed {
+            return .nan
+        }
+        return partialBuf.contents().bindMemory(to: Float.self, capacity: 1).pointee
     }
 }
 

--- a/crates/abi-gpu/src/lib.rs
+++ b/crates/abi-gpu/src/lib.rs
@@ -28,7 +28,7 @@ use abi_wdbx::best_cpu_backend;
 pub enum Backend {
     /// Deterministic vectorized CPU fallback.
     Simulated,
-    /// Apple Metal (declared on macOS; native kernels not linked).
+    /// Apple Metal (preferred on macOS; optional DOT kernels via `metal-kernels`).
     Metal,
     /// Vulkan (declared; not linked).
     Vulkan,

--- a/crates/abi-nn/src/checkpoint.rs
+++ b/crates/abi-nn/src/checkpoint.rs
@@ -104,8 +104,12 @@ pub fn save(path: &Path, model: &Model) -> Result<(), NnError> {
 /// Load a demo checkpoint written by [`save`].
 pub fn load(path: &Path) -> Result<Model, NnError> {
     let raw = fs::read_to_string(path).map_err(|e| NnError::Io(e.to_string()))?;
-    let file: CheckpointFile =
-        serde_json::from_str(&raw).map_err(|e| NnError::Io(e.to_string()))?;
+    load_json(&raw)
+}
+
+/// Parse a checkpoint from a JSON string (no filesystem).
+pub fn load_json(raw: &str) -> Result<Model, NnError> {
+    let file: CheckpointFile = serde_json::from_str(raw).map_err(|e| NnError::Io(e.to_string()))?;
     if file.version != CHECKPOINT_VERSION {
         return Err(NnError::Io(format!(
             "unsupported checkpoint version {} (want {CHECKPOINT_VERSION})",

--- a/crates/abi-nn/src/gguf_demo.rs
+++ b/crates/abi-nn/src/gguf_demo.rs
@@ -9,7 +9,7 @@
 //!
 //! Not a production LLM loader; not distributed; not network-connected.
 
-use crate::checkpoint::{self, load as load_checkpoint};
+use crate::checkpoint::{self, load as load_checkpoint, load_json};
 use crate::model::Model;
 use crate::types::NnError;
 use std::path::Path;
@@ -42,11 +42,15 @@ impl std::error::Error for GgufError {}
 
 /// Write a demo GGUF container wrapping a JSON checkpoint payload.
 pub fn write_demo_gguf(path: &str, model: &Model) -> Result<(), GgufError> {
-    let tmp = format!("{path}.json.tmp");
-    checkpoint::save(Path::new(&tmp), model).map_err(GgufError::Checkpoint)?;
+    // Serialize via a private temp under std::env::temp_dir (never beside `path`).
+    let ns = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    let tmp = std::env::temp_dir().join(format!("abi-nn-gguf-write-{ns}.json"));
+    checkpoint::save(&tmp, model).map_err(GgufError::Checkpoint)?;
     let json = std::fs::read(&tmp).map_err(|e| GgufError::Io(e.to_string()))?;
     let _ = std::fs::remove_file(&tmp);
-    let mut out = Vec::with_capacity(8 + json.len());
+    let mut out = Vec::with_capacity(12 + json.len());
     out.extend_from_slice(DEMO_MAGIC);
     out.extend_from_slice(&DEMO_VERSION.to_le_bytes());
     let len =
@@ -82,11 +86,8 @@ pub fn load_model_file(path: &str) -> Result<Model, GgufError> {
     }
     let json =
         std::str::from_utf8(&bytes[12..12 + len]).map_err(|e| GgufError::Format(e.to_string()))?;
-    let tmp = format!("{path}.extract.json");
-    std::fs::write(&tmp, json).map_err(|e| GgufError::Io(e.to_string()))?;
-    let model = load_checkpoint(Path::new(&tmp)).map_err(GgufError::Checkpoint)?;
-    let _ = std::fs::remove_file(&tmp);
-    Ok(model)
+    // Parse in-memory — never write a sidecar next to the model path.
+    load_json(json).map_err(GgufError::Checkpoint)
 }
 
 /// Load a model file and run incremental sample for `n` characters.

--- a/crates/abi-nn/src/lib.rs
+++ b/crates/abi-nn/src/lib.rs
@@ -12,7 +12,9 @@ pub mod sample_inc;
 pub mod train;
 pub mod types;
 
-pub use checkpoint::{load as load_checkpoint, save as save_checkpoint};
+pub use checkpoint::{
+    load as load_checkpoint, load_json as load_checkpoint_json, save as save_checkpoint,
+};
 pub use gguf_demo::{
     GgufError, load_and_sample as load_gguf_and_sample, load_model_file, write_demo_gguf,
 };


### PR DESCRIPTION
## Summary
Code-review follow-ups for `e5843d6` (no dedicated PR; landed on main). Fixes high-confidence issues only:

1. WS handshake validation (status 101, Upgrade, Accept)
2. Metal command failure → NaN; deterministic tree reduce
3. Pong flush + per-frame masks
4. Twilio auth in URL or `?token=`
5. Dashboard `linked` vs `accelerated`
6. GGUF in-memory load
7. Stale claim comments

## Test plan
- [x] `./tools/check.sh` green
- [x] `cargo test -p abi-connectors --lib -- tls_ws`
- [x] `cargo test -p abi-gpu --lib -- metal`
- [x] `cargo test -p abi-nn --lib`