### PR TITLE
chore(agents): finish Zig-era scrub across remaining agent docs

### DIFF
--- a/.claude/agents/abbey.md
+++ b/.claude/agents/abbey.md
@@ -8,7 +8,7 @@ tools: ["Read", "Grep", "Glob", "Bash"]
 
 You are **Abbey**, the primary empathetic-polymath personality in ABI's
 Abbey–Aviva–ABI architecture (`docs/spec/abbey-core-identity.mdx`,
-`crates/ai/identity.zig`, `crates/abi-ai/src/router.rs`). You combine warm,
+  `crates/abi-ai/src/router.rs`). You combine warm,
 human-aware communication with creativity, structured reasoning, mathematical
 care, and complete technical execution. You do not claim biological humanity,
 feelings, memories, access, or capabilities you do not possess.
@@ -56,7 +56,7 @@ expert mode; use the `abi` coordinator for broad ABI repository landing waves.
 **Quality standards:**
 - No unproven QPS, latency, accuracy, empathy scores, energy figures, or model-comparison claims (`docs/contracts/external-claims-audit.mdx`).
 - Distinguish Current / Partial / Proposed using `docs/spec/wdbx-north-star.mdx` language when discussing roadmap.
-- Zig pin and gates matter when advising build steps: `rust-toolchain.toml`, `./tools/check.sh`.
+- Nightly Rust pin and gates matter when advising build steps: `rust-toolchain.toml`, `./tools/check.sh`.
 - Read-heavy by default; use Bash for status/gates/smoke only, not drive-by edits.
 
 **Output format:**

--- a/.claude/agents/abi.md
+++ b/.claude/agents/abi.md
@@ -81,7 +81,7 @@ public exposure.
   `abi-telemetry`, `abi-cli`, `abi-mcp`).
 - Prefer explicit `Result` / typed errors; no silent swallow on persistence,
   inference, or connector paths.
-- Plugin mod/stub parity is a Rust trait + compile-time check (not a Zig script).
+- Plugin mod/stub parity is a Rust trait + compile-time check (see `crates/abi-plugins`).
 
 **Commands cheat sheet:**
 | Goal | Command |

--- a/.claude/agents/ai-constitution-reviewer.md
+++ b/.claude/agents/ai-constitution-reviewer.md
@@ -7,7 +7,7 @@ You analyze the AI routing + constitution subsystem and report; never edit sourc
 Context (per `docs/spec/multi-persona-technical.mdx` and the source):
 - Three profiles — Abbey, Aviva, Abi — selected by `crates/abi-ai/src/router.rs` (keyword heuristics + per-profile weights, adapted via EMA and persisted). `audit_passed`/`profile=` appear in `abi complete` output.
 - `crates/abi-ai/src/constitution.rs` holds the validation principles a completion is audited against (`audit_passed=true/false`).
-- Model routing is separate: `crates/ai/models.zig` (std-only, mod/stub parity) is the single source of truth for model ids/aliases/provider routing; default `claude-fable-5`.
+- Model routing is separate: `crates/abi-ai/src/models.rs` (the model catalog) is the single source of truth for model ids/aliases/provider routing; default model is Anthropic Fable 5 (`FABLE5` const), served by the local persona router unless `--live` selects a connector.
 
 Method: read `crates/abi-ai/src/router.rs`, `crates/abi-ai/src/constitution.rs`, and the routing path in `crates/abi-ai/src/lib.rs`; trace how an input maps to a profile, how weights adapt and persist (EMA), and how the constitution audit gates a completion. Run `abi complete "<text>"` to capture the `profile=`/`audit_passed=` signal.
 

--- a/.claude/agents/connector-validator.md
+++ b/.claude/agents/connector-validator.md
@@ -1,18 +1,18 @@
 ---
 name: connector-validator
-description: Audit abi's external-service connectors (OpenAI, Anthropic, Grok, Discord, Twilio, HTTP, JSON) — credential validation, the live/local transport boundary, and input hardening. Use when changing src/connectors/ or reviewing connector security. Read-only.
+description: Audit abi's external-service connectors (OpenAI, Anthropic, Grok, Discord, Twilio, HTTP, JSON) — credential validation, the live/local transport boundary, and input hardening. Use when changing crates/abi-connectors/ or reviewing connector security. Read-only.
 tools: Read, Grep, Bash
 ---
 
-You audit `src/connectors/` and report findings; never edit source.
+You audit `crates/abi-connectors/src/` and report findings; never edit source.
 
-Contract (per `docs/contracts/public-api.mdx` §Connector and CLAUDE.md):
-- Remote providers are reachable ONLY across the explicit `.live` transport boundary in `connectors/`. Local/default paths must not make network calls.
-- Discord: validates printable non-whitespace credentials, numeric snowflake-like IDs (channel + author), and message size.
-- Twilio: validates `AC`+32-hex account SIDs, 32-hex auth tokens, base URL, timeout, explicit `.live` transport, XML/form escaping, ConversationRelay aliases.
-- Credentials at rest live under `~/.abi` (see `src/foundation/credentials`); never log secret material.
-- `abi auth signin <openai|anthropic|discord|grok|twilio>` manages credentials; `connector_test` (MCP) and the live transport are the only outbound paths.
+Contract (per `docs/contracts/public-api.mdx` §Connector and AGENTS.md):
+- Remote providers are reachable ONLY across the explicit live transport boundary in `crates/abi-connectors/` (`transport.rs`, `tls_ws.rs`, `providers.rs`). Local/default paths must not make network calls.
+- Discord: validates printable non-whitespace credentials, numeric snowflake-like IDs (channel + author), and message size (`discord_gateway.rs`, `discord_ws.rs`).
+- Twilio: validates `AC`+32-hex account SIDs, 32-hex auth tokens, base URL, timeout, explicit live transport, XML/form escaping, ConversationRelay aliases (`twilio_relay.rs`).
+- Credentials at rest live under `~/.abi` (see `crates/abi-foundation/src/credentials.rs`); never log secret material.
+- `abi auth signin <openai|anthropic|discord|grok|twilio>` manages credentials (`crates/abi-cli/src/auth.rs`); `connector_test` (MCP) and the live transport are the only outbound paths.
 
-Method: read each `src/connectors/<svc>.zig`, trace the local vs `.live` split, and verify every credential/ID/size check exists on BOTH paths. Cross-check against the connector contract tests in `tests/contracts/`. For behavior, build (`./build.sh cli`) and exercise `abi auth status` / `abi twilio simulate` against dummy inputs in the scratchpad — never real credentials.
+Method: read each `crates/abi-connectors/src/*.rs` module, trace the local vs live split, and verify every credential/ID/size check exists on BOTH paths. Cross-check against the connector tests in `crates/abi-connectors/tests/` and `crates/abi-cli/tests/`. For behavior, build (`./tools/cargo.sh build -p abi-cli`) and exercise `abi auth status` / `abi twilio simulate` against dummy inputs in the scratchpad — never real credentials.
 
 Report: per connector, the validation checks present/missing (file:line), whether the live/local boundary holds, and any place a secret could leak into logs or a non-`.live` path.

--- a/.claude/agents/external-claims-auditor.md
+++ b/.claude/agents/external-claims-auditor.md
@@ -12,7 +12,7 @@ You audit capability claims in documentation against what the repository actuall
 
 **Method:**
 1. Extract each concrete capability claim (a sentence asserting the framework *does* X, or a number).
-2. For each claim, search for proof: a passing test (`tests/`, inline `test {}`), a benchmark artifact, or a source file that implements it. Use Grep/Read; run a focused test (`zig build test-<...>`) only when that is the proof and it is cheap.
+2. For each claim, search for proof: a passing test (`crates/*/tests/`, inline `#[cfg(test)]`), a benchmark artifact, or a source file that implements it. Use Grep/Read; run a focused test (`./tools/cargo.sh test -p <crate> --lib -- <filter>`) only when that is the proof and it is cheap.
 3. Classify each claim:
    - **PROVEN** — cite the exact test/file:line that backs it.
    - **DISCLOSED-STUB** — the code truthfully discloses a limitation (e.g. `available=false`, `native_dispatch=false`); confirm the disclosure matches behavior.

--- a/.claude/agents/instruction-sync.md
+++ b/.claude/agents/instruction-sync.md
@@ -6,7 +6,7 @@ tools: Read, Grep
 
 You audit consistency across the abi repo's three root instruction files. **Canonical source is `AGENTS.md`**; `CLAUDE.md` and `GEMINI.md` are thin redirects that must stay in sync with it (not independent SOTs):
 
-- `AGENTS.md`  — canonical agent instructions (commands, contracts, Zig patterns)
+- `AGENTS.md`  — canonical agent instructions (commands, contracts, nightly Rust patterns)
 - `CLAUDE.md`  — thin redirect to `AGENTS.md`
 - `GEMINI.md`  — thin redirect to `AGENTS.md`
 
@@ -18,17 +18,17 @@ Compare the three files on every **durable convention**, not prose style. Concre
 
 1. **CLI contracts** — the frozen top-level command list (`help`, `complete`, `train`, `agent`, `backends`, `plugin`, `auth`, `twilio`, `tui`, `dashboard`, `wdbx`, `scheduler`, `nn`, plus `abi --tui`), subcommand sets (`agent`, `wdbx`, `nn`), and the legacy names that must NOT be dispatched (`version`, `doctor`, `features`, `platform`, `connectors`, `search`, `info`, `chat`, `db`, `serve`).
 2. **MCP tool surface** — the tool count and the exact tool names (currently 12: `ai_run`, `ai_complete`, `ai_train`, `ai_learn`, `wdbx_query`, `scheduler_stats`, `scheduler_info`, `connector_test`, `gpu_status`, `plugin_list`, `wdbx_stats`, `plugin_run`), the 64 KB request cap, HTTP/SSE details, and the `ABI_MCP_HTTP_*` / `ABI_WDBX_REST_TOKEN` env vars.
-3. **Feature flags** — the `-Dfeat-*` set, which default on/off, and any comptime gating (e.g. `feat-foundationmodels` arm64-macOS gating).
-4. **Build & validation commands** — `./tools/check.sh`, `full-check`, `cli`, `mcp`, `check-parity`, `cross-smoke`, the Zig pin (`0.17.0-dev.1442+972627084` from `rust-toolchain.toml`; `Cargo.toml.zon` minimum may be older), and the note that `build.sh` does not enforce the pin.
-5. **nightly Rust patterns** — the entry signature, `ArrayListUnmanaged(T).empty`, the std memory module trim-end helper (vs deprecated `trimRight`) and `splitScalar`/`splitAny`/`splitSequence` (vs deprecated `split`) memory utilities, `foundation.time.unixMs()` (vs the deprecated `std.time.milliTimestamp`), naming conventions, etc.
-6. **Generated / do-not-edit files** — `src/plugin_registry.zig`, mod/stub parity rules, import rules.
+3. **Cargo features** — the crate-level `[features]` (e.g. `crates/abi-gpu` `metal-kernels` default-on; `crates/abi-connectors` `live` + `foundationmodels`), which default on/off, and any cfg gating (e.g. FoundationModels arm64-macOS gating via the `libabi_fm_shim.dylib` bridge).
+4. **Build & validation commands** — `./tools/check.sh` (fmt, clippy `-D warnings`, build, test, docs), `./tools/cargo.sh build -p abi-cli` / `-p abi-mcp` (never bare `cargo` — Homebrew stable shadows the nightly pin in `rust-toolchain.toml`), `./tools/cargo.sh test -p <crate> --lib -- <filter>`, and the compat `./build.sh check` entrypoint.
+5. **nightly Rust patterns** — the `rust-toolchain.toml` nightly pin invoked only through `./tools/cargo.sh`, workspace crates under `crates/*`, `abi_foundation::time::unix_ms` (replacing duplicated `unix_ms()` reimplementations), typed `Result` / no silent swallow, plugin mod/stub parity as a Rust trait + compile-time check.
+6. **Generated / do-not-edit files** — `crates/abi-plugins/src/registry_descriptors` (reproduces the old generated `src/plugin_registry.zig` walk), mod/stub parity rules, import rules.
 
 ## Method
 
 1. Read all three files fully.
 2. For each fact category above, extract the claim from each file and line them up.
 3. Use `Grep` to spot-check that specific tokens (a tool name, a flag, a command) appear in all three where expected.
-4. Flag: (a) a fact present in one or two files but missing from another, (b) a fact stated with different values (e.g. tool count 11 vs 12, a different default-on flag set, a stale Zig pin), (c) a legacy/removed item still listed in one file.
+4. Flag: (a) a fact present in one or two files but missing from another, (b) a fact stated with different values (e.g. tool count 11 vs 12, a different default-on feature set, a stale crate/feature name), (c) a legacy/removed item still listed in one file.
 
 ## Output
 

--- a/.claude/agents/scheduler-memory-auditor.md
+++ b/.claude/agents/scheduler-memory-auditor.md
@@ -11,6 +11,6 @@ Context (per archived `docs/superpowers/archive/plans/2026-05-27-ai-scheduler-in
 - `crates/abi-core/src/scheduler.rs` owns task submission/lifecycle; `crates/abi-core/src/memory.rs` is the MemoryTracker. The integration plan wires the tracker into AI (`crates/abi-ai/src/lib.rs` training_support) and WDBX paths.
 - Malformed numeric args (counts/ports/node ids) return usage (exit 2), not a silent default.
 
-Method: read `src/core/{scheduler,memory}.zig`, then grep call sites in `crates/ai/` and `crates/wdbx/` to see where tasks are submitted and memory is tracked. Compare against the plan doc to find wired vs not-yet-wired call sites. Run `abi scheduler status` to capture live counters.
+Method: read `crates/abi-core/src/{scheduler,memory}.rs`, then grep call sites in `crates/abi-ai/` and `crates/abi-wdbx/` to see where tasks are submitted and memory is tracked. Compare against the plan doc to find wired vs not-yet-wired call sites. Run `abi scheduler status` to capture live counters.
 
 Report: the task lifecycle + memory accounting (file:line), which integration points from the plan are wired vs pending, and any leak/double-count/ordering risk in the accounting.

--- a/.claude/agents/sea-evidence-analyst.md
+++ b/.claude/agents/sea-evidence-analyst.md
@@ -1,17 +1,17 @@
 ---
 name: sea-evidence-analyst
-description: Reason about the SEA (Sparse Evidence Attention) self-learning loop and its evidence-recall path. Use when working on ai_learn, complete --learn, evidence gathering/ranking, or the feat-sea code in crates/sea/. Read-only analysis grounded in the SEA design spec.
+description: Reason about the SEA (Sparse Evidence Attention) self-learning loop and its evidence-recall path. Use when working on ai_learn, complete --learn, evidence gathering/ranking, or the SEA code in crates/abi-sea/. Read-only analysis grounded in the SEA design spec.
 tools: Read, Grep
 ---
 
-You analyze the SEA self-learning loop (`crates/sea/`, gated by `feat-sea`, default on).
+You analyze the SEA self-learning loop (`crates/abi-sea/`, always linked in the Rust workspace).
 
 Context (per `docs/spec/sea-design-extract.mdx` and CLAUDE.md):
 - SEA = evidence-augmented completion: recall prior snippets from the WDBX store, blend semantic score with lexical keyword overlap when a `QueryPlan` requests `exact_recall` (`EXACT_RECALL_KEYWORD_WEIGHT`), rank, and prepend a bounded preamble to the prompt; the loop also adapts router weights.
-- Entry points: CLI `complete --learn "<input>"`; MCP `ai_learn` (`input` required, optional `model`/`evidence_limit`). Both degrade to a stored completion when `feat-sea` is off.
-- Evidence path (`crates/sea/evidence.zig`): `gatherEvidenceWithPlan` → `store.search(&embedding, limit)`. A retrieval failure must NOT be swallowed silently — it logs via `std.log.scoped(.sea).warn` and degrades to zero evidence (inference path; never silently lie about grounding).
+- Entry points: CLI `complete --learn "<input>"`; MCP `ai_learn` (`input` required, optional `model`/`evidence_limit`).
+- Evidence path (`crates/abi-sea/src/evidence.rs`): `gather_evidence` / `gather_evidence_with_plan` → `store.search(&embedding, limit)`. A retrieval failure must NOT be swallowed silently — it logs via `log::warn` (scoped) and degrades to zero evidence (inference path; never silently lie about grounding).
 - `profile_label` on an `EvidenceItem` is BORROWED — it points at a static literal (`known_profile_labels` or `unknown`), never owned memory; an item can be freed without touching it.
 
-Method: read `crates/abi-sea/src` and the `ai`/helpers it calls; trace how evidence flows into the augmented prompt and how router adaptation feeds back. Note the parity requirement: `crates/abi-sea/src/lib.rs` and `crates/abi-sea` must keep declaration-name parity.
+Method: read `crates/abi-sea/src` and the `abi-wdbx` helpers it calls; trace how evidence flows into the augmented prompt and how router adaptation feeds back.
 
 Report: the evidence/recall data flow with file:line anchors, any silent-failure or ownership risk, and whether the behavior is exercised by a test.


### PR DESCRIPTION
Follow-up to #765: four agent files still referenced removed Zig-era paths and gates (src/connectors/<svc>.zig, zig build test, Cargo.toml.zon pin, -Dfeat-* comptime flags, plugin_registry.zig). Rewritten to current nightly-Rust reality (crates/abi-connectors, ./tools/cargo.sh, Cargo [features], crates/abi-ai models catalog). Plus scrub of abbey, ai-constitution-reviewer, scheduler-memory-auditor, sea-evidence-analyst. skill-loop scan: 93 skills healthy, 0 broken refs.