### PR TITLE
refactor(wdbx): extract multiway evolve() frontier loop into a helper

### DIFF
--- a/crates/abi-wdbx/src/multiway.rs
+++ b/crates/abi-wdbx/src/multiway.rs
@@ -527,6 +527,39 @@ impl Engine<'_> {
         None
     }
 
+    /// Drain the current frontier at `child_depth`, one candidate at a time.
+    ///
+    /// Returns `Some(termination)` on cancellation, deadline expiry, a
+    /// corrupt cursor, or whatever [`Engine::expand_one`] reports; `None`
+    /// once every frontier entry at this depth has been expanded.
+    fn process_frontier(&mut self, child_depth: u32) -> Option<Termination> {
+        while usize::try_from(self.result.cursor).unwrap_or(usize::MAX) < self.result.frontier.len()
+        {
+            if self.cancel.is_some_and(|flag| flag.load(Ordering::Acquire)) {
+                return Some(Termination::Cancelled);
+            }
+            if self
+                .deadline
+                .is_some_and(|deadline| Instant::now() >= deadline)
+            {
+                return Some(Termination::Deadline);
+            }
+            let Some(source) = self
+                .result
+                .frontier
+                .get(self.result.cursor as usize)
+                .copied()
+            else {
+                return Some(Termination::InvariantFailure);
+            };
+            if let Some(termination) = self.expand_one(source, child_depth) {
+                return Some(termination);
+            }
+            self.result.cursor += 1;
+        }
+        None
+    }
+
     fn evolve(&mut self) {
         let started = Instant::now();
         loop {
@@ -540,38 +573,10 @@ impl Engine<'_> {
                 break;
             }
             let child_depth = self.result.resume_depth + 1;
-            while usize::try_from(self.result.cursor).unwrap_or(usize::MAX)
-                < self.result.frontier.len()
-            {
-                if self.cancel.is_some_and(|flag| flag.load(Ordering::Acquire)) {
-                    self.result.termination = Termination::Cancelled;
-                    self.result.elapsed += started.elapsed();
-                    return;
-                }
-                if self
-                    .deadline
-                    .is_some_and(|deadline| Instant::now() >= deadline)
-                {
-                    self.result.termination = Termination::Deadline;
-                    self.result.elapsed += started.elapsed();
-                    return;
-                }
-                let Some(source) = self
-                    .result
-                    .frontier
-                    .get(self.result.cursor as usize)
-                    .copied()
-                else {
-                    self.result.termination = Termination::InvariantFailure;
-                    self.result.elapsed += started.elapsed();
-                    return;
-                };
-                if let Some(termination) = self.expand_one(source, child_depth) {
-                    self.result.termination = termination;
-                    self.result.elapsed += started.elapsed();
-                    return;
-                }
-                self.result.cursor += 1;
+            if let Some(termination) = self.process_frontier(child_depth) {
+                self.result.termination = termination;
+                self.result.elapsed += started.elapsed();
+                return;
             }
             self.result.frontier = std::mem::take(&mut self.result.next_frontier);
             self.result.cursor = 0;

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -23,6 +23,21 @@ Status legend: `✅ Done` · `🟡 In progress` · `⚪ Not started` · `🔴 Bl
 
 ---
 
+## Cleanup / refactor backlog (goal: "Cleanup and refactor Rust 2024 nightly abi codebase")
+
+| Item | Status | Notes |
+| ---- | ------ | ----- |
+| `crates/abi-wdbx/src/multiway.rs` decomposition | ✅ | `evolve()`'s frontier-draining loop extracted to `process_frontier()`; elapsed-time bookkeeping now happens once instead of at 4 duplicated early-return sites. 12/12 multiway tests + full gate green. |
+| `crates/abi-cli/src/wdbx.rs` split | ⚪ | ~1476 lines / 41 free fns → `db.rs`, `block.rs`, `query.rs`, `cluster.rs` |
+| `crates/abi-wdbx/src/format.rs` split | ⚪ | ~1248 lines; separate Hash/Record/Segment/Manifest into own modules |
+| `crates/abi-wdbx/src/wal.rs` dedup | ⚪ | ~1102 lines; 7 `append_*` fns each redefine an identical `Mutation` struct — factor to one shared type |
+| `crates/abi-cli/src/agent.rs` decomposition | ⚪ | ~1052 lines |
+| `crates/abi-cli/src/complete.rs` split | ⚪ | ~856 lines; 154-line `run()` mixes arg-parse, validation, dispatch — split into stages |
+
+> Each row: pure refactor, no behavior change. `./tools/check.sh` green + golden fixtures byte-identical before marking ✅.
+
+---
+
 ## Disclosed residuals (do NOT fake-complete)
 
 | Item | Status | Constraint |


### PR DESCRIPTION
## Summary
- `Engine::evolve()` in `crates/abi-wdbx/src/multiway.rs` repeated `self.result.elapsed += started.elapsed()` at four separate early-return sites (cancel, deadline, invariant failure, expand_one termination) plus the loop fall-through.
- Extracted the inner frontier-draining loop into `process_frontier(&mut self, child_depth: u32) -> Option<Termination>`. `evolve()` now checks frontier/depth termination, calls `process_frontier`, and does the elapsed-time bookkeeping exactly once on the single early-return path.
- Pure refactor — no behavior change, no new features, no API change.

First slice of the "cleanup and refactor Rust 2024 nightly codebase" goal tracked in `tasks/todo.md`.

## Test plan
- [x] `./tools/cargo.sh test -p abi-wdbx --lib -- multiway` — 12/12 pass, including the byte-deterministic export-hash and resume-consistency oracles that would catch any behavior drift.
- [x] `./tools/cargo.sh clippy -p abi-wdbx --all-targets -- -D warnings` — clean.
- [x] Full `./tools/check.sh` (fmt, clippy, workspace build+test, docs) — green, both before (baseline) and after this change.

## Reviewer note
The working tree has ~30 unrelated modified/untracked files from a concurrent agent session (`crates/abi-cli/*`, `crates/abi-sea/*`, `crates/abi-wdbx/src/wal.rs`, golden completion fixtures, etc.). None of those are staged in this PR — only `crates/abi-wdbx/src/multiway.rs` and `tasks/todo.md` are touched. `windows credential ACL` is expected to show `UNSTABLE`/fail — that's the known billing-locked hosted-runner issue (job dies in ~2s with zero steps), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)