### PR TITLE
fix(os): harden audit-store scratch paths against CI lock-collision flake

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,9 +41,11 @@ Zig build (`zig build`, `-Dfeat-*`, `src/features/`); ignore it.
 | `./tools/cargo.sh clippy --workspace --all-targets -- -D warnings` | Lint, matching the gate exactly |
 | `./mcp/launcher.sh` | Launch the MCP server; prefers `target/release/abi-mcp` then `target/debug/abi-mcp`; run from repo root (or via the launcher) so `@loader_path` resolves `libabi_fm_shim.dylib` on arm64 macOS; set `ABI_MCP_AUTO_BUILD=1` to build on demand |
 
-There is no separate lint-only or build-only CI — `./tools/check.sh` **is** CI
-(GitHub Actions is billing-locked on this repo, so it's also the only gate that
-actually runs). Treat a red `check.sh` as blocking.
+There is no separate lint-only or build-only CI — `.github/workflows/ci.yml`
+runs `./tools/check.sh` on a self-hosted macOS ARM64 runner for trusted
+same-repo pushes/PRs (fork PRs stay on GitHub-hosted runners only; see
+`.github/self-hosted-runner.md`). Treat a red `check.sh` — locally or in CI —
+as blocking.
 
 ### Local smoke walkthrough
 

--- a/crates/abi-cli/src/os.rs
+++ b/crates/abi-cli/src/os.rs
@@ -519,13 +519,14 @@ mod tests {
     #[test]
     fn execute_and_timeout_audits_reach_the_scratch_store_but_dry_run_does_not() {
         let _guard = abi_foundation::env::lock_for_test();
-        let dir = std::env::temp_dir().join(format!(
-            "abi-os-dispatch-audit-{}-{:?}",
-            std::process::id(),
-            std::thread::current().id()
-        ));
+        // PID+ThreadId alone can collide with a leftover dir from a *panicked*
+        // prior run (the libtest thread pool reuses ThreadIds); the shared
+        // counter-based helper guarantees no collision with anything this
+        // process has made before.
+        let dir = abi_foundation::temp_path::temp_file_path("abi-os-dispatch-audit", "store");
         let policy_path = dir.join("os-policy.toml");
         let store_path = dir.join("store");
+        let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("scratch dir");
         std::fs::write(&policy_path, "allow = [\"true\"]\ntimeout_secs = 1\n")
             .expect("policy file");

--- a/crates/abi-cli/src/os/audit.rs
+++ b/crates/abi-cli/src/os/audit.rs
@@ -96,11 +96,12 @@ mod tests {
 
     fn scratch_store(tag: &str) -> (DurableStore, std::path::PathBuf) {
         // Never `~/.abi/`: a scratch path under the temp dir, unique per test.
-        let dir = std::env::temp_dir().join(format!(
-            "abi-os-audit-{tag}-{}-{:?}",
-            std::process::id(),
-            std::thread::current().id()
-        ));
+        // PID+ThreadId alone can collide with a leftover dir from a *panicked*
+        // prior run (the libtest thread pool reuses ThreadIds, and a panic
+        // skips this test's own cleanup) — the shared counter-based helper
+        // guarantees no collision with anything this process has made before.
+        let dir =
+            abi_foundation::temp_path::temp_file_path(&format!("abi-os-audit-{tag}"), "store");
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("scratch dir");
         let store = DurableStore::open(abi_wdbx::StorePaths::new(dir.display().to_string()))

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -61,6 +61,9 @@ See `docs/superpowers/plans/2026-07-31-rust-647-followups.md`.
 | Configurable timeout | ✅ | `timeout_secs` in the policy file, bounded 1..=3600; default stays 30s |
 | WDBX audit block for executed commands | ✅ | `os/audit.rs` appends vector + `os-cmd:<id>` KV + audit block per **executed** command (never dry-run), including killed timeouts (`timed_out=true`, exit 124). Store injected so tests use a scratch path. Intentional no-store and open/write failures are disclosed distinctly on the `[os-cmd]` line. |
 | `~/.abi/os-policy.toml` | ✅ | `os/policy.rs`, strict TOML subset. **Narrow-only**: `allow` is intersected with the compiled `CEILING`, so the file can never grant a command the binary does not already permit. Unknown, duplicate, and malformed keys fail closed. Path overridable via `ABI_OS_POLICY`. |
+| CI flake: `os::audit`/`os` scratch-store `WriterBusy` | ✅ | 2026-08-01: two tests built their scratch dir from `{pid}-{thread_id:?}`, which a panicked prior run's leftover lock dir can collide with once the libtest thread pool reuses that `ThreadId`. Switched both to `abi_foundation::temp_path::temp_file_path()` (PID + per-process counter). `./tools/check.sh` green. |
+
+**Disclosed, not fixed:** the same ad hoc `temp_dir().join(format!("..{pid}-{thread:?}"))` scratch-path pattern (not `temp_file_path`) also appears in `nn.rs`, `complete.rs`, `wdbx_simulate.rs`, `wdbx/mod.rs`, and `abi-wdbx/src/retrieval.rs`. None have been observed to flake; left untouched per "smallest verified slice" rather than swept into a broad rename.
 
 ---
 


### PR DESCRIPTION
## Summary
- `main`'s CI (#770) went red with `WriterBusy`/"writer already open" panics in two `os`-control tests. Root cause: both built their scratch dir from `{pid}-{thread_id:?}`; the libtest thread pool reuses `ThreadId`s across test functions, so a leftover locked directory from a *panicked* prior run can collide with a later run reusing the same (pid, thread) pair. Confirmed the exact leftover directory from the failing CI run still on disk (owned by a since-dead PID) — this runner is self-hosted on a long-lived machine, so stale scratch dirs persist across runs.
- Switched both tests to `abi_foundation::temp_path::temp_file_path()` (PID + monotonic per-process counter), the same collision-resistant helper `abi-wdbx`'s own `durable.rs` fixture already uses. No product code changed.
- Also corrected a stale `CLAUDE.md` claim ("CI is billing-locked, so `check.sh` is the only real gate") — `ci.yml` actually runs `check.sh` on a self-hosted macOS ARM64 runner.
- Logged the investigation and a disclosed residual (5 other files use the same ad hoc scratch-path pattern, none observed flaking) in `tasks/todo.md`.

## Test plan
- [x] `./tools/cargo.sh test -p abi-cli --lib -- os::` green, single- and multi-threaded, repeated
- [x] Full `./tools/check.sh` green (fmt, clippy `-D warnings`, workspace tests, bench-regression, docs) on top of current `main`
- [ ] Original failure was rare (10+ local repro attempts, 0 failures) — can't prove a negative locally; watch the next real CI run on this branch/PR to confirm the flake is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)