### PR TITLE
fix(wdbx): stop a fork/exec window from reading as writer contention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,8 +61,13 @@ use scratch `DurableStore` paths, `ABI_WDBX_PATH=:memory:`, or
 ## CI & commits
 
 - Conventional Commits. **Never force-push `main`**.
-- CI runs `./tools/check.sh` on nightly Rust (self-hosted macOS ARM64 for
-  same-repo events; hosted runners for fork PRs).
+- CI runs `./tools/check.sh` on nightly Rust on the **self-hosted macOS ARM64
+  runner** for trusted same-repo pushes/PRs. That job is the only one that
+  actually executes: every **GitHub-hosted** job (`windows credential ACL`, and
+  the fork-PR `check-hosted` fallback) is refused at dispatch with *"The job was
+  not started because your account is locked due to a billing issue."* Treat a
+  red self-hosted `check.sh` as blocking; do not read a red hosted job as a
+  code failure, and do not claim hosted coverage the account cannot run.
 
 ## Learned User Preferences
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,9 +41,16 @@ Zig build (`zig build`, `-Dfeat-*`, `src/features/`); ignore it.
 | `./tools/cargo.sh clippy --workspace --all-targets -- -D warnings` | Lint, matching the gate exactly |
 | `./mcp/launcher.sh` | Launch the MCP server; prefers `target/release/abi-mcp` then `target/debug/abi-mcp`; run from repo root (or via the launcher) so `@loader_path` resolves `libabi_fm_shim.dylib` on arm64 macOS; set `ABI_MCP_AUTO_BUILD=1` to build on demand |
 
-There is no separate lint-only or build-only CI — `./tools/check.sh` **is** CI
-(GitHub Actions is billing-locked on this repo, so it's also the only gate that
-actually runs). Treat a red `check.sh` as blocking.
+There is no separate lint-only or build-only CI — `.github/workflows/ci.yml`
+runs `./tools/check.sh` on a **self-hosted macOS ARM64 runner** for trusted
+same-repo pushes/PRs, and that job does execute (see
+`.github/self-hosted-runner.md`). The **GitHub-hosted** jobs in the same
+workflow do not: `windows credential ACL` (`windows-latest`) and the fork-PR
+`check-hosted` fallback (`macos-latest`) are refused at dispatch with *"The job
+was not started because your account is locked due to a billing issue."* — they
+complete in ~3s having run zero steps. So a red hosted job is a billing signal,
+not a code signal, and nothing verified only by a hosted job may be described as
+covered. Treat a red self-hosted `check.sh` — locally or in CI — as blocking.
 
 ### Local smoke walkthrough
 
@@ -57,8 +64,11 @@ $ABI scheduler status
 $ABI dashboard --once --plain
 $ABI complete "summarize ABI scheduler status"
 $ABI agent plan "stage a safe WDBX refactor"
-$ABI wdbx stats
+$ABI wdbx query "$(mktemp -d)/store"   # store stats as JSON; `wdbx stats` is not a command
 ```
+
+The `complete` / `agent` lines above touch the store, so prefix them with
+`ABI_WDBX_PATH=:memory:` unless you actually mean to write to `~/.abi/`.
 
 ## Architecture
 

--- a/crates/abi-connectors/build.rs
+++ b/crates/abi-connectors/build.rs
@@ -6,7 +6,7 @@
 //! when the `foundationmodels` feature is on.
 
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
@@ -68,15 +68,29 @@ fn main() {
 
     println!("cargo:rustc-link-search=native={}", out_dir.display());
     println!("cargo:rustc-link-lib=dylib=abi_fm_shim");
-    // Also search/copy beside target/{debug,release} for `./target/debug/abi`.
-    if env::var("PROFILE").is_ok() {
-        // OUT_DIR is .../target/<profile>/build/<pkg>/out
-        if let Some(dir) = out_dir.ancestors().nth(3).map(PathBuf::from) {
-            let dest = dir.join("libabi_fm_shim.dylib");
-            std::fs::copy(&dylib, &dest).unwrap_or_else(|err| {
-                panic!("copy libabi_fm_shim.dylib to {}: {err}", dest.display());
-            });
-            println!("cargo:rustc-link-search=native={}", dir.display());
-        }
+    // Also search/copy beside target/{debug,release} so the plain
+    // `./target/debug/abi` binary can resolve `@loader_path/...`.
+    if let Some(dir) = profile_dir(&out_dir) {
+        let dest = dir.join("libabi_fm_shim.dylib");
+        std::fs::copy(&dylib, &dest).unwrap_or_else(|err| {
+            panic!("copy libabi_fm_shim.dylib to {}: {err}", dest.display());
+        });
+        println!("cargo:rustc-link-search=native={}", dir.display());
     }
+}
+
+/// `target/<profile>` for an `OUT_DIR`, located by structure rather than depth.
+///
+/// Counting a fixed number of ancestors breaks silently when cargo changes the
+/// layout under `build/`: 1.99.0-nightly nests `build/<pkg>/<hash>/out` where
+/// older releases used `build/<pkg>-<hash>/out`, so a hard-coded `nth(3)`
+/// resolves to `target/<profile>/build` and the dylib lands one directory away
+/// from where `@loader_path` looks. `target/<profile>` is always the parent of
+/// the `build` component, whatever sits beneath it.
+fn profile_dir(out_dir: &Path) -> Option<PathBuf> {
+    out_dir
+        .ancestors()
+        .find(|dir| dir.file_name().is_some_and(|name| name == "build"))
+        .and_then(Path::parent)
+        .map(PathBuf::from)
 }

--- a/crates/abi-gpu/build.rs
+++ b/crates/abi-gpu/build.rs
@@ -1,7 +1,7 @@
 //! Compile the Metal DOT shim on arm64 macOS when `metal-kernels` is enabled.
 
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
@@ -70,9 +70,22 @@ fn main() {
     println!("cargo:rustc-link-lib=framework=Metal");
     println!("cargo:rustc-link-lib=framework=Foundation");
 
-    if let Some(dir) = out_dir.ancestors().nth(3).map(PathBuf::from) {
+    if let Some(dir) = profile_dir(&out_dir) {
         let dest = dir.join("libabi_metal_dot.dylib");
         let _ = std::fs::copy(&dylib, &dest);
         println!("cargo:rustc-link-search=native={}", dir.display());
     }
+}
+
+/// `target/<profile>` for an `OUT_DIR`, located by structure rather than depth.
+///
+/// See the twin helper in `abi-connectors/build.rs`: cargo nests `OUT_DIR`
+/// differently across releases, so a fixed ancestor count silently drops the
+/// dylib one directory away from where `@loader_path` resolves it.
+fn profile_dir(out_dir: &Path) -> Option<PathBuf> {
+    out_dir
+        .ancestors()
+        .find(|dir| dir.file_name().is_some_and(|name| name == "build"))
+        .and_then(Path::parent)
+        .map(PathBuf::from)
 }

--- a/crates/abi-wdbx/src/durable.rs
+++ b/crates/abi-wdbx/src/durable.rs
@@ -372,15 +372,45 @@ fn acquire_writer_lock(paths: &StorePaths) -> Result<File> {
             path: path.clone(),
             message: error.to_string(),
         })?;
-    match file.try_lock() {
-        Ok(()) => Ok(file),
-        Err(TryLockError::WouldBlock) => Err(DurableError::WriterBusy { path }),
-        Err(TryLockError::Error(error)) => Err(DurableError::WriterLock {
-            path,
-            message: error.to_string(),
-        }),
+    // `WouldBlock` does not always mean a real writer owns the store. The lock
+    // lives on the open file description, so a `fork` anywhere in this process
+    // duplicates it into the child; the duplicate only disappears when the
+    // child reaches `exec` and O_CLOEXEC closes it. A store dropped just before
+    // an unrelated `Command::spawn` therefore stays locked for the width of
+    // that fork/exec window — sub-millisecond, but long enough to fail a
+    // reopen. `abi agent os execute` hits this directly: it holds the audit
+    // store open while spawning the command it audits.
+    //
+    // So retry `WouldBlock` for a budget far wider than that window and far
+    // narrower than a human notices. A genuinely held lock outlives the budget
+    // and still reports `WriterBusy`. A real filesystem error is never retried.
+    let deadline = std::time::Instant::now() + WRITER_LOCK_RETRY_BUDGET;
+    loop {
+        match file.try_lock() {
+            Ok(()) => return Ok(file),
+            Err(TryLockError::WouldBlock) => {
+                if std::time::Instant::now() >= deadline {
+                    return Err(DurableError::WriterBusy { path });
+                }
+                std::thread::sleep(WRITER_LOCK_RETRY_STEP);
+            }
+            Err(TryLockError::Error(error)) => {
+                return Err(DurableError::WriterLock {
+                    path,
+                    message: error.to_string(),
+                });
+            }
+        }
     }
 }
+
+/// How long [`acquire_writer_lock`] tolerates a `WouldBlock` before declaring
+/// the store busy. Measured fork/exec windows clear on the first 1 ms retry;
+/// this leaves two orders of magnitude of headroom on a loaded machine.
+const WRITER_LOCK_RETRY_BUDGET: std::time::Duration = std::time::Duration::from_millis(50);
+
+/// Poll interval while waiting out a transient `WouldBlock`.
+const WRITER_LOCK_RETRY_STEP: std::time::Duration = std::time::Duration::from_millis(1);
 
 #[cfg(test)]
 mod tests {
@@ -462,6 +492,41 @@ mod tests {
 
         drop(owner);
         DurableStore::open(fixture.paths.clone()).expect("drop releases writer lock");
+    }
+
+    #[test]
+    fn a_lock_released_moments_later_is_waited_out_rather_than_reported_busy() {
+        // A `fork` in this process duplicates the advisory lock's file
+        // descriptor into the child until it reaches `exec`, so a store that
+        // has already been dropped can still read as locked for a moment.
+        // Standing in for that here: an owner released shortly after the
+        // reopen begins. Without the retry budget this open fails outright.
+        const HELD_FOR: std::time::Duration = std::time::Duration::from_millis(10);
+
+        let fixture = Fixture::new("abi_durable_transient_lock");
+        let owner = DurableStore::open(fixture.paths.clone()).expect("owner takes the lock");
+        let (locked_tx, locked_rx) = std::sync::mpsc::channel();
+        let releaser = std::thread::spawn(move || {
+            locked_tx.send(()).expect("signal that the lock is held");
+            std::thread::sleep(HELD_FOR);
+            drop(owner);
+        });
+        locked_rx.recv().expect("owner reported the lock held");
+
+        let started = std::time::Instant::now();
+        let reopened = DurableStore::open(fixture.paths.clone());
+        let waited = started.elapsed();
+        releaser.join().expect("releaser thread");
+
+        assert!(
+            reopened.is_ok(),
+            "a lock released within the retry budget must not surface as busy: {:?}",
+            reopened.err()
+        );
+        assert!(
+            waited < WRITER_LOCK_RETRY_BUDGET * 2,
+            "waited {waited:?}, which is past the budget rather than inside it"
+        );
     }
 
     #[test]

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -46,7 +46,7 @@ See `docs/superpowers/plans/2026-07-31-rust-647-followups.md`.
 | ---- | ------ | ----- |
 | Lock-across-I/O audit (REST/cluster/MCP) | ✅ | No lock held across TCP I/O; rate-limiter mutex is math-only |
 | MCP malformed/empty bearer contracts | ✅ | `abi-mcp` HTTP tests cover empty/Basic/wrong-case/no-space |
-| DurableStore concurrency regression test | ✅ | `DurableStore` holds a lifetime-scoped advisory writer lock; 50 concurrent opens return `WriterBusy`, drop releases the lock, and 50 real REST query → joined teardown → reopen/search lifecycles stay green. |
+| DurableStore concurrency regression test | ✅ | `DurableStore` holds a lifetime-scoped advisory writer lock; 50 concurrent opens return `WriterBusy`, drop releases the lock, and 50 real REST query → joined teardown → reopen/search lifecycles stay green. `open` also waits out a transient `WouldBlock` (50 ms budget, 1 ms steps) so the fork/exec window that duplicates the lock fd into a child cannot masquerade as contention; a genuinely held lock still reports `WriterBusy`. |
 | Bench regression gate in `check.sh` | ✅ | `tools/bench_regress.sh`: live Rust HNSW insert/search workload, best p50 of 5, 25% local debug threshold; same OS/arch baseline required (other host classes disclose `SKIP`). Deterministic pass/fail hooks prove the comparator. |
 
 ---
@@ -90,7 +90,7 @@ See `docs/superpowers/plans/2026-07-31-rust-647-followups.md`.
 | ---- | ------ | ----- |
 | Live Discord/Twilio TLS clients | ✅ | rustls `wss://` via `abi-connectors::tls_ws`; offline process-local TLS peer tests |
 | Metal DOT kernels | ✅ | `metal-kernels` feature; `accelerated=true` when init succeeds; CPU oracle test |
-| Windows credential ACL CI | ✅ | `cfg(windows)` tests + `windows-acl` job on `windows-latest` |
+| Windows credential ACL CI | ◑ | `cfg(windows)` tests are written and the `windows-acl` job is configured on `windows-latest`, but it has **never executed**: every GitHub-hosted job is refused at dispatch with *"The job was not started because your account is locked due to a billing issue."* (~3s, zero steps). The ACL behavior is therefore unproven at runtime on any host. Re-verify and restore ✅ only after a hosted run actually reports steps. |
 | True incremental NN sampler | ✅ | `SampleState::step` + demo GGUF load/sample |
 
 ---

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -2,8 +2,9 @@
 # The repository gate — successor to `./build.sh check`.
 #
 # Covers the same ground the Zig gate did: format, lint, build, tests, and the
-# frozen-contract checks. GitHub Actions on this repo is billing-locked, so this
-# is the only gate that actually runs; treat a red result as blocking.
+# frozen-contract checks. CI runs this same script on the self-hosted macOS
+# ARM64 runner; the GitHub-hosted jobs beside it are refused at dispatch while
+# the account is billing-locked. Treat a red result as blocking.
 #
 # Always invoked through tools/cargo.sh, never bare `cargo` — see that script for
 # why that distinction matters here.


### PR DESCRIPTION
`main` is currently red. The self-hosted CI run for `35b3a99` failed `./tools/check.sh` on two `abi-cli` os-control tests, and the local gate could not reach its final step at all. These are two independent defects.

## 1. Spurious `WriterBusy` (`crates/abi-wdbx/src/durable.rs`)

The store's advisory writer lock lives on the **open file description**, so any `fork` in the process duplicates it into the child until `exec` closes it via `O_CLOEXEC`. A store dropped just before an unrelated `Command::spawn` therefore stays locked for the width of that window.

This is not test-only. `abi agent os execute` holds the audit store open **while spawning the command it audits**, so a second `abi` invocation could be told the store was busy when no writer owned it.

`acquire_writer_lock` now waits out `WouldBlock` for 50 ms in 1 ms steps. A genuinely held lock outlives the budget and still reports `WriterBusy`; a real filesystem error is never retried.

Diagnosed empirically rather than inferred:
- an `lsof` probe at the moment of failure found **no holder** — the lock had already been released;
- a retry probe recovered on the **first** 1 ms attempt in 6/6 caught failures.

## 2. `./tools/check.sh` could not finish on a fresh checkout

`crates/abi-connectors/build.rs` and `crates/abi-gpu/build.rs` located `target/<profile>` with `OUT_DIR.ancestors().nth(3)`. cargo 1.99.0-nightly nests `build/<pkg>/<hash>/out` where older releases used `build/<pkg>-<hash>/out`, so that resolved to `target/<profile>/build` and both shim dylibs landed one directory away from where `@loader_path` looks. `./target/debug/abi` then refused to launch, aborting the benchmark-regression step.

Both scripts now find the `build` component and take its parent. The primary checkout only masked this with a stale dylib left over from an older cargo layout; CI never saw it because the test step failed first.

## Claim correction

`tasks/todo.md`'s `Windows credential ACL CI ✅` becomes `◑`. The `cfg(windows)` tests are written and the job is configured, but the GitHub API reports *"The job was not started because your account is locked due to a billing issue."* for every hosted job — `windows-acl` has **never executed**, so the ACL behavior is unproven at runtime on any host.

`AGENTS.md`, `CLAUDE.md`, and `tools/check.sh` now state both halves: the self-hosted macOS ARM64 runner does execute the gate; every GitHub-hosted job is refused at dispatch. `CLAUDE.md`'s smoke walkthrough also loses `abi wdbx stats`, which is not a command.

## Verification

| Check | Before | After |
| --- | --- | --- |
| `./tools/check.sh` | aborted at benchmark step (exit 134) | **exit 0, `check: all green`** |
| `os::` @ `--test-threads 8` | 18/40 and 11/20 failures | **0/50 and 0/40** |
| `durable::` unit tests | 8 pass | 9 pass (new regression test) |
| New test with retry budget set to 0 | — | fails deliberately |
| Documented smoke walkthrough | `./target/debug/abi` would not launch | re-run green on the real binary |

Note: the hosted CI checks on this PR will report red for billing reasons, not code reasons — read the self-hosted `check (self-hosted)` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)