### PR TITLE
fix(cli): stop abi-cli tests from opening the live ~/.abi store

### DIFF
--- a/crates/abi-cli/src/app.rs
+++ b/crates/abi-cli/src/app.rs
@@ -572,6 +572,12 @@ mod tests {
 
     #[test]
     fn train_and_complete_are_attached() {
+        // `complete` resolves the durable store, so this is the one dispatch
+        // test that reads `ABI_WDBX_PATH`. Take the shared lock: os::tests
+        // installs a process-global override pointing at its own scratch
+        // store, and opening that store here would steal its writer lock.
+        let _guard = abi_foundation::env::lock_for_test();
+
         let train = run(&args(&["train", "example"]));
         assert_eq!(train.exit_code, 0);
         assert!(train.stdout.contains("training accepted"));

--- a/crates/abi-cli/src/util.rs
+++ b/crates/abi-cli/src/util.rs
@@ -19,10 +19,26 @@ pub(crate) fn open_store_result() -> Result<Option<DurableStore>, abi_wdbx::Dura
     {
         return Ok(None);
     }
-    let Some(home) = abi_foundation::env::get("HOME") else {
+    let Some(home) = default_store_home() else {
         return Ok(None);
     };
     DurableStore::open(StorePaths::new(format!("{home}/.abi/wdbx"))).map(Some)
+}
+
+/// Home directory backing the default `~/.abi/wdbx` store.
+///
+/// `~/.abi/` is the operator's live store, so the lib-test build refuses the
+/// fallback outright rather than creating state and holding a writer lock
+/// inside real user data. A unit test that wants a store points
+/// `ABI_WDBX_PATH` at a scratch directory; one that does not gets `no-store`.
+#[cfg(not(test))]
+pub(crate) fn default_store_home() -> Option<String> {
+    abi_foundation::env::get("HOME")
+}
+
+#[cfg(test)]
+pub(crate) fn default_store_home() -> Option<String> {
+    None
 }
 
 /// Compatibility helper for completion/training paths that already disclose
@@ -30,4 +46,60 @@ pub(crate) fn open_store_result() -> Result<Option<DurableStore>, abi_wdbx::Dura
 /// as OS audit should use [`open_store_result`] and preserve the error detail.
 pub(crate) fn open_store() -> Option<DurableStore> {
     open_store_result().ok().flatten()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the lib-test build's refusal to fall back to `$HOME/.abi/wdbx`.
+    ///
+    /// Scope: this pins the [`default_store_home`] gate, not a suite-wide
+    /// property. "No abi-cli test touches `~/.abi/`" is established by running
+    /// each test binary under a scratch `HOME` and inspecting it; this test is
+    /// what makes removing the gate fail loudly instead of silently.
+    ///
+    /// `HOME` is overridden to a scratch directory so that a regression fails
+    /// safely: if the gate is ever deleted, this test writes into the scratch
+    /// tree it then asserts on, never into the developer's real store.
+    #[test]
+    fn the_home_store_fallback_is_refused_in_the_test_build() {
+        assert!(
+            default_store_home().is_none(),
+            "the test build must never resolve the ~/.abi/wdbx home fallback"
+        );
+
+        // `ABI_WDBX_PATH` overrides are process-global and os::tests sets one,
+        // so take the shared lock rather than racing it.
+        let _guard = abi_foundation::env::lock_for_test();
+        let home = std::env::temp_dir().join(format!(
+            "abi-util-home-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&home).expect("scratch home");
+        // An empty override reads back as unset, which also neutralizes any
+        // value the developer running the suite has exported.
+        abi_foundation::env::set_override(abi_foundation::env::WDBX_PATH, "");
+        abi_foundation::env::set_override(abi_foundation::env::WDBX_PERSIST, "");
+        abi_foundation::env::set_override("HOME", &home.display().to_string());
+
+        let resolved = open_store_result();
+        let created = home.join(".abi");
+        let leaked = created.exists();
+
+        abi_foundation::env::clear_override("HOME");
+        abi_foundation::env::clear_override(abi_foundation::env::WDBX_PATH);
+        abi_foundation::env::clear_override(abi_foundation::env::WDBX_PERSIST);
+        let _ = std::fs::remove_dir_all(&home);
+
+        assert!(
+            matches!(resolved, Ok(None)),
+            "an unconfigured store must report no-store, not open a home store"
+        );
+        assert!(
+            !leaked,
+            "no store state may be created under a home directory"
+        );
+    }
 }

--- a/crates/abi-cli/src/wdbx/api.rs
+++ b/crates/abi-cli/src/wdbx/api.rs
@@ -24,7 +24,9 @@ fn open_default_store() -> Result<DurableStore, String> {
     ) {
         return Err("WDBX persistence disabled (ABI_WDBX_PERSIST=0)".into());
     }
-    let home = std::env::var("HOME").map_err(|_| "HOME is unset".to_string())?;
+    // Shared with `util::open_store_result` so the lib-test build's refusal to
+    // touch the operator's live `~/.abi/` store covers this path too.
+    let home = crate::util::default_store_home().ok_or_else(|| "HOME is unset".to_string())?;
     DurableStore::open(StorePaths::new(format!("{home}/.abi/wdbx"))).map_err(|e| e.to_string())
 }
 

--- a/crates/abi-cli/tests/process.rs
+++ b/crates/abi-cli/tests/process.rs
@@ -2,19 +2,26 @@
 
 use std::process::{Command, Output};
 
-fn run(arguments: &[&str]) -> Output {
+/// The spawned executable is a non-test build, so the `cfg(test)` refusal in
+/// `util::default_store_home` does not apply to it: left alone it would resolve
+/// `$HOME/.abi/wdbx` and write into the operator's live store. Pin every spawn
+/// at `:memory:` instead. It is set before `envs` so a caller can still choose
+/// its own store path.
+fn spawn(arguments: &[&str], environment: &[(&str, &str)]) -> Output {
     Command::new(env!("CARGO_BIN_EXE_abi"))
-        .args(arguments)
-        .output()
-        .expect("Rust abi executable should run")
-}
-
-fn run_with_env(arguments: &[&str], environment: &[(&str, &str)]) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_abi"))
+        .env("ABI_WDBX_PATH", ":memory:")
         .args(arguments)
         .envs(environment.iter().copied())
         .output()
         .expect("Rust abi executable should run")
+}
+
+fn run(arguments: &[&str]) -> Output {
+    spawn(arguments, &[])
+}
+
+fn run_with_env(arguments: &[&str], environment: &[(&str, &str)]) -> Output {
+    spawn(arguments, environment)
 }
 
 #[test]

--- a/crates/abi-cli/tests/process.rs
+++ b/crates/abi-cli/tests/process.rs
@@ -206,3 +206,39 @@ fn auth_status_and_logout_cross_the_real_process_boundary() {
     assert_eq!(logout.stderr, b"Logged out. Credentials cleared.\n");
     assert!(!path.exists());
 }
+
+/// Guards the `ABI_WDBX_PATH` pin in [`spawn`]: `abi complete` resolves the
+/// durable store, and the spawned binary is a non-test build that the
+/// `cfg(test)` refusal in `util::default_store_home` cannot reach. Without the
+/// pin the child writes `.abi/wdbx/{wdbx.wal, wdbx.writer.lock}` under `HOME` —
+/// here a scratch directory, so removing the pin fails this test rather than
+/// touching the operator's live store.
+#[test]
+fn a_spawned_store_command_writes_nothing_under_home() {
+    let home = std::env::temp_dir().join(format!(
+        "abi-home-process-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock after epoch")
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&home).expect("scratch home");
+    let home_text = home.to_str().expect("UTF-8 temporary path");
+
+    // `spawn` sets the pin before `envs`, so `HOME` layers on top of it.
+    let completed = run_with_env(&["complete", "hello"], &[("HOME", home_text)]);
+
+    let leaked = home.join(".abi").exists();
+    let _ = std::fs::remove_dir_all(&home);
+
+    // The success assertions are load-bearing: a child that failed to start
+    // would also create nothing, and pass this test for the wrong reason.
+    assert!(
+        completed.status.success(),
+        "{}",
+        String::from_utf8_lossy(&completed.stderr)
+    );
+    assert!(String::from_utf8_lossy(&completed.stdout).contains("profile="));
+    assert!(!leaked, "a spawned abi created state under HOME");
+}


### PR DESCRIPTION
## Problem

`crates/abi-cli/src/util.rs` `open_store_result()` falls through to `\$HOME/.abi/wdbx` when neither `ABI_WDBX_PATH` nor `ABI_WDBX_PERSIST` is set. Tests reaching it created `~/.abi/wdbx/wdbx.wal` and held `~/.abi/wdbx/wdbx.writer.lock` — inside the operator's live store directory, which `CLAUDE.md` and `AGENTS.md` both forbid ("Tests must never open that path").

Live data was not corrupted (`~/.abi/wdbx/` is a sibling of the real `~/.abi/wdbx.wal` / `~/.abi/wdbx.seg.*.jsonl`), but the suite still created state and took an exclusive writer lock there.

## Which tests actually reached it

Enumerated empirically by temporarily panicking in each branch of `open_store_result()` and running at `--test-threads 1`, then again at `--test-threads 8`:

- `app::tests::train_and_complete_are_attached` — the HOME fallback (the leak).
- `os::tests::execute_and_timeout_audits_reach_the_scratch_store_but_dry_run_does_not` — the `ABI_WDBX_PATH` branch, deliberately, at its own scratch path.

That is fewer tests than the report this branch started from, which also named `complete::tests::apple_fm_with_confirm_is_honest_or_live` and "other `complete::tests::*`". The enumeration is host-independent, not an artifact of this Mac: `complete::run` dispatches `--live` to `run_fm_complete`/`run_live_complete`, and `util::open_store()` has exactly three call sites — `complete.rs:101` (`run_local`), `complete.rs:181` (`run_learn`), and `agent.rs:141`. No `--live`, `--neural`, `--soul`, or local-bridge path can reach the store whether or not Apple Intelligence is ready on the host. There are no `#[ignore]`d or feature-gated abi-cli tests that a probe run would have missed.

## Fix

- `util::default_store_home()` is `None` under `cfg(test)`. A unit test that wants a store points `ABI_WDBX_PATH` at a scratch path; one that does not gets `no-store` instead of silently writing into real user data.
- `wdbx::api::open_default_store` routes its HOME lookup through the same helper, so the refusal covers the crate rather than one call site. Note this is a small production behavior change: it now resolves `HOME` via `abi_foundation::env::get`, which treats empty as unset, so `HOME=""` reports "HOME is unset" instead of opening `/.abi/wdbx`. It also stops using a raw `std::env::var`, per the env-registry convention.
- `app::tests::train_and_complete_are_attached` now takes `env::lock_for_test()`. `set_override` is process-global, so without the lock it could pick up the `ABI_WDBX_PATH` that `os::tests` installs and steal that test's writer lock.
- `tests/process.rs` spawns `CARGO_BIN_EXE_abi`, a **non-test** build, so the `cfg(test)` gate is structurally absent there. Every spawn is now pinned at `ABI_WDBX_PATH=:memory:`. No process test resolves the store today, so this closes a reintroduction path rather than a live leak — but the path is real: `HOME=<scratch> target/debug/abi complete hello` creates `.abi/wdbx/{wdbx.wal, wdbx.writer.lock}`, and creates nothing with the pin.

## Regression test

`util::tests::the_home_store_fallback_is_refused_in_the_test_build` asserts the gate directly, then — under `lock_for_test()`, with `ABI_WDBX_PATH`/`ABI_WDBX_PERSIST` forced unset and `HOME` pointed at a scratch dir — asserts `open_store_result()` is `Ok(None)` and that nothing was created.

Verified it catches reintroduction: deleting the `cfg` gate makes it fail, and it fails on the first assertion, *before* any store is opened, so a regression never writes to the real store.

Its doc comment states its scope honestly: it pins the gate, not the suite-wide invariant.

`tests/process.rs::a_spawned_store_command_writes_nothing_under_home` does the same job for the spawn pin: it runs `abi complete` with `HOME` at a scratch directory and asserts nothing appears under it. Verified it fails with the pin removed. Its success assertions are deliberate — a child that fails to start also creates nothing, and would otherwise pass for the wrong reason.

## Verification

All four abi-cli test binaries run under a scratch `HOME`, then the directory inspected:

| binary | before | after |
|---|---|---|
| `unittests src/lib.rs` | `.abi/wdbx/{wdbx.wal, wdbx.writer.lock}` every run (20/20) | 0 paths |
| `unittests src/main.rs` | clean | clean |
| `tests/golden.rs` | clean | clean |
| `tests/process.rs` | clean | clean |

(The `before` column is the state on `main`; `after` is 20 runs per binary on this branch.)

Nothing under `~/.abi/` is **removed** either: every `auth::tests` case that can reach `auth logout`'s `remove_file` builds a `CredentialEnvironment`, which pins `ABI_CREDENTIALS_PATH` at a scratch temp file and holds `lock_for_test()` for the test's lifetime. `grammar_errors_are_usage_errors` skips that setup but only exercises usage errors.

`./tools/check.sh` — **all green**, and `~/.abi/wdbx` was still absent afterward, so the whole-workspace run creates nothing there either.

## The red `windows credential ACL` check is not from this PR

`windows-acl` runs on `windows-latest` — a GitHub-hosted runner — and this repo's Actions billing is locked, so the job is never assigned a runner. It fails in 2-3s having executed **zero steps** (`steps: []`, `runner_name: ""` from the jobs API), which means no code of mine ran in it.

It fails identically on `main` (35bb4f1), on #769, #770, #772, and on an unrelated Vercel bot branch. Nothing in this diff can fix it; restoring it needs the billing lock cleared, or the job moved off a GitHub-hosted runner. Left alone rather than silenced — that's a CI policy call, not part of this change.

The gate that actually executes, `check (self-hosted)`, **passed on head commit `2c058f6`**, every step green including the benchmark step.

## Pre-existing issues found, deliberately not touched

1. **`os::tests::execute_and_timeout_audits_…` `WriterBusy` flake** — the failure PR #772 is fixing. Interleaved A/B of the two binaries under identical load, pooled over two rounds: **base 22/60 (37%) failed, this branch 24/60 (40%)** — statistically indistinguishable, so this change neither causes nor worsens it. It can still make `check.sh` red on a given run; re-run, or land #772.

2. **`tools/bench_regress.sh` aborts (SIGABRT) on a clean build with current nightly cargo.** `crates/abi-connectors/build.rs` copies `libabi_fm_shim.dylib` to `out_dir.ancestors().nth(3)`, which assumed `target/<profile>/build/<pkg>-<hash>/out`. Cargo 1.99.0-nightly (7c83d4cc0) uses `target/<profile>/build/<pkg>/<hash>/out`, one level deeper, so the copy lands in `target/debug/build/` and `target/debug/abi` cannot resolve `@loader_path/libabi_fm_shim.dylib`. Reproduces on `main` with this branch stashed. The green `check.sh` above was obtained after placing the dylib at `target/debug/` by hand. Worth its own change.

3. **`crates/abi-mcp/src/state.rs:26`** has the identical ungated `.abi/wdbx` default. No abi-mcp test reaches it today, and the user scoped this change to abi-cli, so it is left alone — but a follow-up should give it the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

