### PR TITLE
fix(gpu): fail the build when the Metal DOT dylib copy fails

### DIFF
--- a/crates/abi-gpu/build.rs
+++ b/crates/abi-gpu/build.rs
@@ -71,9 +71,9 @@ fn main() {
     println!("cargo:rustc-link-lib=framework=Foundation");
 
     // Copy beside target/{debug,release} so the plain `./target/debug/abi`
-    // binary can resolve `@loader_path/...`. A failed copy has no build-time
-    // symptom — the first sign is a dyld abort at runtime — so fail loudly here
-    // rather than discarding the error.
+    // binary can resolve `@loader_path/...`. A discarded error here would have
+    // no build-time symptom — the first sign would be a dyld abort at runtime —
+    // so fail loudly instead.
     if let Some(dir) = profile_dir(&out_dir) {
         let dest = dir.join("libabi_metal_dot.dylib");
         std::fs::copy(&dylib, &dest).unwrap_or_else(|err| {

--- a/crates/abi-gpu/build.rs
+++ b/crates/abi-gpu/build.rs
@@ -70,9 +70,15 @@ fn main() {
     println!("cargo:rustc-link-lib=framework=Metal");
     println!("cargo:rustc-link-lib=framework=Foundation");
 
+    // Copy beside target/{debug,release} so the plain `./target/debug/abi`
+    // binary can resolve `@loader_path/...`. A failed copy has no build-time
+    // symptom — the first sign is a dyld abort at runtime — so fail loudly here
+    // rather than discarding the error.
     if let Some(dir) = profile_dir(&out_dir) {
         let dest = dir.join("libabi_metal_dot.dylib");
-        let _ = std::fs::copy(&dylib, &dest);
+        std::fs::copy(&dylib, &dest).unwrap_or_else(|err| {
+            panic!("copy libabi_metal_dot.dylib to {}: {err}", dest.display());
+        });
         println!("cargo:rustc-link-search=native={}", dir.display());
     }
 }


### PR DESCRIPTION
## What

`crates/abi-gpu/build.rs:75` copied `libabi_metal_dot.dylib` into
`target/<profile>` with `let _ = std::fs::copy(&dylib, &dest);` — the error was
silently discarded.

Because `target/debug/abi` is linked with
`-install_name @loader_path/libabi_metal_dot.dylib`, a failed copy produces **no
build-time signal at all**. The first symptom is a dyld abort (SIGABRT / exit
134) at runtime, which is exactly the failure mode that made
`tools/bench_regress.sh` hard to diagnose previously.

This makes the copy match its twin at `crates/abi-connectors/build.rs:75`, which
already panics with a clear message on failure, and aligns with the repo rule in
`CLAUDE.md`: *"No silent error swallowing on persistence, inference, or
connector paths — prefer typed `Result`/domain errors, log or propagate."*

## Change

```rust
std::fs::copy(&dylib, &dest).unwrap_or_else(|err| {
    panic!("copy libabi_metal_dot.dylib to {}: {err}", dest.display());
});
```

Plus a comment recording why a silent failure here is invisible until runtime.

## Verification

`./tools/check.sh` — all green (fmt, clippy `-D warnings`, workspace build +
tests, bench regression gate, doc build). The gate itself exercises the copy
path on this arm64 macOS host, so the non-failing case is covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)