### PR TITLE
chore: audit cleanups — workspace deps, gitignore, doc drift, frozen-field comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,7 +158,7 @@ perf.data*
 !.claude/settings.json
 !.claude/skills/
 !.claude/skills/**
-!# Codex
+# Codex
 .codex/
 !.codex/
 !.codex/agents/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,7 @@ Over 1000 lines; decompose before adding to them:
 | File | Lines | Notes |
 |---|---|---|
 | `crates/abi-wdbx/src/multiway.rs` | ~1743 | Manual JSON serialization throughout; the `evolve()` frontier loop has been extracted to a helper |
-| `crates/abi-wdbx/src/wal.rs` | ~1057 | Seven `append_*` functions each redefine an identical `#[derive(Serialize)] struct Mutation` |
+| `crates/abi-wdbx/src/wal.rs` | ~1057 | Mutation dedup landed (shared `enum Mutation<'a>` + `append_json` helper); remaining size is inherent WAL surface |
 
 Watch list (850–1000 lines — not yet over the line, but the next candidates):
 `crates/abi-wdbx/src/hnsw.rs` (~941), `crates/abi-wdbx/src/store.rs` (~933),

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ abi-ai = { path = "crates/abi-ai" }
 abi-sea = { path = "crates/abi-sea" }
 abi-gpu = { path = "crates/abi-gpu" }
 abi-nn = { path = "crates/abi-nn" }
+abi-connectors = { path = "crates/abi-connectors" }
+abi-wdbx = { path = "crates/abi-wdbx" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }

--- a/crates/abi-cli/Cargo.toml
+++ b/crates/abi-cli/Cargo.toml
@@ -20,8 +20,8 @@ abi-ai = { workspace = true }
 abi-sea = { workspace = true }
 abi-nn = { workspace = true }
 abi-gpu = { workspace = true }
-abi-connectors = { path = "../abi-connectors" }
-abi-wdbx = { path = "../abi-wdbx" }
+abi-connectors = { workspace = true }
+abi-wdbx = { workspace = true }
 ctrlc = { workspace = true }
 serde_json = { workspace = true }
 libc = "0.2"

--- a/crates/abi-mcp/Cargo.toml
+++ b/crates/abi-mcp/Cargo.toml
@@ -18,8 +18,8 @@ abi-plugins = { workspace = true }
 abi-ai = { workspace = true }
 abi-sea = { workspace = true }
 abi-gpu = { workspace = true }
-abi-connectors = { path = "../abi-connectors" }
-abi-wdbx = { path = "../abi-wdbx" }
+abi-connectors = { workspace = true }
+abi-wdbx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/abi-wdbx/src/multiway.rs
+++ b/crates/abi-wdbx/src/multiway.rs
@@ -727,6 +727,9 @@ pub fn export_multiway_json(
     metrics: &MultiwayMetrics,
 ) -> Result<String, MultiwayExportError> {
     let mut output = String::new();
+    // `zig_version` is frozen at the value the retired Zig implementation
+    // emitted: it is part of the canonical export byte stream, so changing it
+    // would break export_hash/golden-fixture compatibility. Do not update.
     output.push_str("{\"format\":\"");
     output.push_str(MULTIWAY_FORMAT_VERSION);
     output.push_str("\",\"zig_version\":\"0.17.0-dev.1442+972627084\",\"config\":");
@@ -1009,6 +1012,8 @@ pub fn persist_multiway(
     store.put(&format!("multiway:experiment:{config_hash}"), export_json)?;
     store.put(MULTIWAY_EXPORT_KEY_LATEST, export_json)?;
 
+    // `zig_version` frozen for canonical-format compatibility — see export
+    // comment above; changing it breaks stored metadata comparisons.
     let metadata = format!(
         "{{\"kind\":\"multiway_experiment\",\"config_hash\":\"{}\",\"export_hash\":\"{}\",\"states\":{},\"events\":{},\"termination\":\"{}\",\"complete\":{},\"zig_version\":\"0.17.0-dev.1442+972627084\"}}",
         config_hash,


### PR DESCRIPTION
## Summary
- promote abi-connectors and abi-wdbx to [workspace.dependencies]; abi-cli/abi-mcp now use `workspace = true` like every other ABI crate
- fix malformed .gitignore line (`!# Codex` negation → comment)
- CLAUDE.md hotspot table: drop stale wal.rs Mutation-dedup claim (shared enum Mutation<'a> + append_json landed)
- multiway.rs: document why zig_version stays frozen in canonical export/metadata JSON (export_hash/golden compatibility)

## Gate
`./tools/check.sh` all green — fmt, clippy -D warnings, workspace tests, docs, benchmark-regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)